### PR TITLE
QVAC-3697: Load GGUF File From Buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,10 @@ if (LLAMA_BUILD_COMMON)
     add_subdirectory(common)
 endif()
 
+if(LLAMA_BUILD_EXAMPLES OR LLAMA_BUILD_TESTS)
+    add_subdirectory(common_test)
+endif()
+
 if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_TESTS AND NOT CMAKE_JS_VERSION)
     include(CTest)
     add_subdirectory(tests)

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -899,15 +899,7 @@ std::string fs_get_cache_file(const std::string & filename) {
 // Model utils
 //
 
-struct common_init_result common_init_from_params(common_params & params) {
-    common_init_result iparams;
-    auto mparams = common_model_params_to_llama(params);
-
-    llama_model * model = llama_model_load_from_file(params.model.path.c_str(), mparams);
-    if (model == NULL) {
-        LOG_ERR("%s: failed to load model '%s'\n", __func__, params.model.path.c_str());
-        return iparams;
-    }
+struct common_init_result common_init_from_model_and_params(llama_model* model, common_init_result iparams, common_params & params) {
 
     const llama_vocab * vocab = llama_model_get_vocab(model);
 
@@ -1066,6 +1058,19 @@ struct common_init_result common_init_from_params(common_params & params) {
     iparams.context.reset(lctx);
 
     return iparams;
+}
+
+struct common_init_result common_init_from_params(common_params & params) {
+    common_init_result iparams;
+    auto               mparams = common_model_params_to_llama(params);
+
+    llama_model * model = llama_model_load_from_file(params.model.path.c_str(), mparams);
+    if (model == NULL) {
+        LOG_ERR("%s: failed to load model '%s'\n", __func__, params.model.path.c_str());
+        return iparams;
+    }
+
+    return common_init_from_model_and_params(model, std::move(iparams), params);
 }
 
 std::string get_model_endpoint() {

--- a/common/common.h
+++ b/common/common.h
@@ -551,6 +551,8 @@ struct common_init_result {
 };
 
 struct common_init_result     common_init_from_params(common_params & params);
+struct common_init_result     common_init_from_model_and_params(llama_model * model, common_init_result iparams,
+                                                                common_params & params);
 
 struct llama_model_params     common_model_params_to_llama  (      common_params & params);
 struct llama_context_params   common_context_params_to_llama(const common_params & params);

--- a/common_test/CMakeLists.txt
+++ b/common_test/CMakeLists.txt
@@ -1,0 +1,15 @@
+# common_test library for load_into_memory.h and uint8-buff-stream.h
+
+set(TARGET llama-common-test)
+
+add_library(${TARGET} INTERFACE)
+
+target_include_directories(${TARGET} INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_compile_definitions(${TARGET} INTERFACE LLAMA_COMMON_TEST_HEADERS)
+
+target_compile_features(${TARGET} INTERFACE cxx_std_17)
+
+target_link_libraries(${TARGET} INTERFACE common)

--- a/common_test/load_into_memory.h
+++ b/common_test/load_into_memory.h
@@ -1,0 +1,220 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <streambuf>
+#include <string>
+#include <thread>
+#include <vector>
+
+// header-only utilities to showcase how to directly load a model from memory
+#include "uint8-buff-stream-wrapper.h"
+
+namespace {
+bool is_split_file(const char * const model_path) {
+    if (!model_path) {
+        fprintf(stderr, "No model file provided\n");
+        exit(EXIT_FAILURE);
+    }
+
+    std::string path(model_path);
+    return path.find("-of-") != std::string::npos;
+}
+
+std::vector<uint8_t> load_file_into_buffer(const char * const model_path) {
+    std::ifstream file_stream(model_path, std::ios::binary | std::ios::ate);
+    if (!file_stream) {
+        fprintf(stderr, "Failed to open file %s for reading into streambuf\n", model_path);
+        exit(EXIT_FAILURE);
+    }
+
+    const size_t file_size = file_stream.tellg();
+    file_stream.seekg(0, std::ios::beg);
+
+    static_assert(sizeof(std::uint8_t) == sizeof(char), "uint8_t must be same size as char");
+    std::vector<std::uint8_t> buffer(file_size);
+    if (!file_stream.read((char *) buffer.data(), file_size)) {
+        fprintf(stderr, "Failed to read entire file into buffer\n");
+        exit(EXIT_FAILURE);
+    }
+
+    return buffer;
+}
+
+std::unique_ptr<std::basic_streambuf<uint8_t>> load_file_into_streambuf(const char * const model_path) {
+    return std::make_unique<Uint8BufferStreamBuf>(load_file_into_buffer(model_path));
+}
+
+struct file_entry {
+    std::string                                    path;
+    std::unique_ptr<std::basic_streambuf<uint8_t>> streambuf;
+};
+
+std::vector<file_entry> load_files_into_streambuf(const char * const model_path) {
+    std::vector<file_entry> files;
+
+    // Extract pattern from first file path
+    std::string path(model_path);
+
+    // Split by '-'
+    std::vector<std::string> parts;
+    std::stringstream        ss(path);
+    std::string              item;
+    while (std::getline(ss, item, '-')) {
+        parts.push_back(item);
+    }
+
+    // Split the last part by '.'
+    std::string last_part = parts.back();
+    parts.pop_back();
+    size_t dot_pos = last_part.find('.');
+    if (dot_pos != std::string::npos) {
+        parts.push_back(last_part.substr(0, dot_pos));
+        parts.push_back(last_part.substr(dot_pos + 1));  // extension
+    } else {
+        parts.push_back(last_part);
+    }
+
+    // Check if we have enough parts
+    if (parts.size() < 4) {
+        fprintf(stderr, "Model path does not contain expected pattern\n");
+        exit(EXIT_FAILURE);
+    }
+
+    // Get total files from [-2] position (before the extension)
+    int total_files = std::stoi(parts[parts.size() - 2]);
+
+    // Get base path by joining all parts except -start-of-end.gguf
+    std::string base_path;
+    for (size_t i = 0; i < parts.size() - 4; i++) {
+        if (i > 0) {
+            base_path += "-";
+        }
+        base_path += parts[i];
+    }
+
+    for (int i = 1; i <= total_files; i++) {
+        char numbered_path[1024];
+        snprintf(numbered_path, sizeof(numbered_path), "%s-%05d-of-%05d.gguf", base_path.c_str(), i, total_files);
+
+        files.push_back({ numbered_path, load_file_into_streambuf(numbered_path) });
+    }
+
+    return files;
+}
+
+file_entry load_tensor_list_file(const char * const model_path) {
+    std::string path(model_path);
+
+    // Split by '-'
+    std::vector<std::string> parts;
+    std::stringstream        ss(path);
+    std::string              item;
+    while (std::getline(ss, item, '-')) {
+        parts.push_back(item);
+    }
+
+    // Split the last part by '.'
+    std::string last_part = parts.back();
+    parts.pop_back();
+    size_t dot_pos = last_part.find('.');
+    if (dot_pos != std::string::npos) {
+        parts.push_back(last_part.substr(0, dot_pos));
+        parts.push_back(last_part.substr(dot_pos + 1));  // extension
+    } else {
+        parts.push_back(last_part);
+    }
+
+    // Check if we have enough parts
+    if (parts.size() < 4) {
+        fprintf(stderr, "Model path does not contain expected pattern\n");
+        exit(EXIT_FAILURE);
+    }
+
+    // Get base path by joining all parts except -start-of-end.gguf
+    std::string base_path;
+    for (size_t i = 0; i < parts.size() - 4; i++) {
+        if (i > 0) {
+            base_path += "-";
+        }
+        base_path += parts[i];
+    }
+
+    // Construct tensor list file path
+    std::string tensor_list_path = base_path + ".tensors.txt";
+
+    printf("Loading tensor list file: %s\n", tensor_list_path.c_str());
+    return { tensor_list_path, load_file_into_streambuf(tensor_list_path.c_str()) };
+}
+
+llama_model * load_model_from_memory_configuration(const char * model_path, llama_model_params & model_params) {
+    llama_model *                         model;
+    std::chrono::steady_clock::time_point load_start_time;
+    if (getenv("LLAMA_EXAMPLE_MEMORY_BUFFER")) {
+        std::vector<uint8_t> buffer = load_file_into_buffer(model_path);
+        fprintf(stdout, "%s: loading model from memory buffer\n", __func__);
+        load_start_time = std::chrono::steady_clock::now();
+        model           = llama_model_load_from_buffer(std::move(buffer), model_params);
+    } else if (getenv("LLAMA_EXAMPLE_MEMORY_BUFFER_SPLIT")) {
+        file_entry              tensor_list_file = load_tensor_list_file(model_path);
+        std::vector<file_entry> files            = load_files_into_streambuf(model_path);
+        fprintf(stdout, "%s: loading model from %zu file streambufs\n", __func__, files.size());
+
+        std::vector<const char *> file_paths;
+        for (const auto & file : files) {
+            printf("Found file %s with streambuf\n", file.path.c_str());
+            file_paths.push_back(file.path.c_str());
+        }
+
+        load_start_time                 = std::chrono::steady_clock::now();
+        const char * async_load_context = "test-model-load";
+        std::thread  fulfill_thread([&files, &tensor_list_file, &async_load_context]() {
+            const bool success = llama_model_load_fulfill_split_future(
+                tensor_list_file.path.c_str(), async_load_context, std::move(tensor_list_file.streambuf));
+            printf("Fulfilling tensor list file %s: %s\n", tensor_list_file.path.c_str(),
+                   success ? "success" : "failure");
+            if (!success) {
+                exit(EXIT_FAILURE);
+            }
+
+            for (auto & file : files) {
+                const bool success = llama_model_load_fulfill_split_future(file.path.c_str(), async_load_context,
+                                                                            std::move(file.streambuf));
+                printf("Fulfilling file %s with streambuf: %s\n", file.path.c_str(), success ? "success" : "failure");
+                if (!success) {
+                    exit(EXIT_FAILURE);
+                }
+            }
+        });
+        fprintf(stderr, "Loading model from splits\n");
+        model = llama_model_load_from_split_futures(file_paths.data(), file_paths.size(), async_load_context,
+                                                    tensor_list_file.path.c_str(), model_params);
+        fulfill_thread.join();
+    } else if (getenv("LLAMA_EXAMPLE_FROM_FILE")) {
+        load_start_time = std::chrono::steady_clock::now();
+        model           = llama_model_load_from_file(model_path, model_params);
+    } else {
+        return nullptr;
+    }
+
+    if (model == NULL) {
+        fprintf(stderr, "%s: error: unable to load model\n", __func__);
+        exit(1);
+    }
+    std::chrono::steady_clock::time_point load_end_time = std::chrono::steady_clock::now();
+    std::chrono::duration<double>         load_duration = load_end_time - load_start_time;
+    fprintf(stdout, "%s: loading model took %f seconds\n", __func__, load_duration.count());
+    return model;
+}
+
+bool memory_configuration_env_is_set() {
+    return getenv("LLAMA_EXAMPLE_MEMORY_BUFFER") || getenv("LLAMA_EXAMPLE_MEMORY_BUFFER_SPLIT") ||
+           getenv("LLAMA_EXAMPLE_FROM_FILE");
+}
+}  // namespace

--- a/common_test/uint8-buff-stream-wrapper.h
+++ b/common_test/uint8-buff-stream-wrapper.h
@@ -1,0 +1,5 @@
+#pragma once
+
+// Wrapper to include the specific header from src
+#include "uint8-buff-stream.h"
+

--- a/examples/embedding/CMakeLists.txt
+++ b/examples/embedding/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(TARGET llama-embedding)
 add_executable(${TARGET} embedding.cpp)
 install(TARGETS ${TARGET} RUNTIME)
-target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET} PRIVATE common llama llama-common-test ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_17)

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(TARGET llama-simple)
 add_executable(${TARGET} simple.cpp)
 install(TARGETS ${TARGET} RUNTIME)
-target_link_libraries(${TARGET} PRIVATE llama ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET} PRIVATE llama llama-common-test ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_17)

--- a/examples/simple/simple.cpp
+++ b/examples/simple/simple.cpp
@@ -1,14 +1,19 @@
+#include "llama-cpp.h"
 #include "llama.h"
 #include <cstdio>
 #include <cstring>
 #include <string>
-#include <vector>
 
 static void print_usage(int, char ** argv) {
     printf("\nexample usage:\n");
     printf("\n    %s -m model.gguf [-n n_predict] [-ngl n_gpu_layers] [prompt]\n", argv[0]);
+    printf("\n Optional environment variables: LLAMA_EXAMPLE_MEMORY_BUFFER LLAMA_EXAMPLE_MEMORY_BUFFER_SPLIT");
     printf("\n");
 }
+
+#ifdef LLAMA_COMMON_TEST_HEADERS
+#include "load_into_memory.h"
+#endif
 
 int main(int argc, char ** argv) {
     // path to the model gguf file
@@ -83,12 +88,13 @@ int main(int argc, char ** argv) {
     llama_model_params model_params = llama_model_default_params();
     model_params.n_gpu_layers = ngl;
 
+#ifdef LLAMA_COMMON_TEST_HEADERS
+    llama_model * model = memory_configuration_env_is_set() ?
+                              load_model_from_memory_configuration(model_path.c_str(), model_params) :
+                              llama_model_load_from_file(model_path.c_str(), model_params);
+#else
     llama_model * model = llama_model_load_from_file(model_path.c_str(), model_params);
-
-    if (model == NULL) {
-        fprintf(stderr , "%s: error: unable to load model\n" , __func__);
-        return 1;
-    }
+#endif
 
     const llama_vocab * vocab = llama_model_get_vocab(model);
     // tokenize the prompt

--- a/ggml/include/gguf.h
+++ b/ggml/include/gguf.h
@@ -78,7 +78,6 @@ extern "C" {
 
     GGML_API struct gguf_context * gguf_init_empty(void);
     GGML_API struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_params params);
-    //GGML_API struct gguf_context * gguf_init_from_buffer(..);
 
     GGML_API void gguf_free(struct gguf_context * ctx);
 
@@ -199,4 +198,9 @@ extern "C" {
 
 #ifdef  __cplusplus
 }
+#endif
+
+#ifdef __cplusplus
+#include <ios>
+GGML_API struct gguf_context * gguf_init_from_buffer(std::basic_streambuf<uint8_t>& streambuf, struct gguf_init_params params);
 #endif

--- a/ggml/include/uint8-buff-stream.h
+++ b/ggml/include/uint8-buff-stream.h
@@ -1,0 +1,200 @@
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <streambuf>
+#include <vector>
+
+#ifdef __APPLE__
+#    include <locale>
+
+/// @brief Custom ctype specialization for uint8_t to work around libc++
+/// limitation in macOS
+template <> struct std::ctype<uint8_t> : public std::ctype_base {
+    using char_type = uint8_t;
+    static std::locale::id id;
+
+    ctype() : std::ctype_base() {}
+
+    ctype([[maybe_unused]] const std::locale::facet & other) : std::ctype_base() {}
+
+    ctype & operator=(const ctype & other) {
+        if (this != &other) {
+            std::ctype_base::operator=(other);
+        }
+        return *this;
+    }
+
+    // Required public interface methods
+    bool is(mask m, [[maybe_unused]] char_type c) const {
+        return (m & space) != 0;  // Treat all uint8_t as non-space
+    }
+
+    const char_type * is(const char_type * low, const char_type * high, mask * vec) const {
+        for (; low != high; ++low, ++vec) {
+            *vec = 0;  // No special character properties
+        }
+        return high;
+    }
+
+    const char_type * scan_is(mask m, const char_type * low, const char_type * high) const {
+        for (; low != high; ++low) {
+            if (is(m, *low)) {
+                return low;
+            }
+        }
+        return high;
+    }
+
+    const char_type * scan_not(mask m, const char_type * low, const char_type * high) const {
+        for (; low != high; ++low) {
+            if (!is(m, *low)) {
+                return low;
+            }
+        }
+        return high;
+    }
+
+    char_type toupper(char_type c) const {
+        return c;  // No case conversion for uint8_t
+    }
+
+    const char_type * toupper([[maybe_unused]] char_type * low, const char_type * high) const {
+        return high;  // No case conversion for uint8_t
+    }
+
+    char_type tolower(char_type c) const {
+        return c;  // No case conversion for uint8_t
+    }
+
+    const char_type * tolower([[maybe_unused]] char_type * low, const char_type * high) const {
+        return high;  // No case conversion for uint8_t
+    }
+
+    char_type widen(char c) const { return static_cast<char_type>(c); }
+
+    const char * widen(const char * low, const char * high, char_type * dest) const {
+        for (; low != high; ++low, ++dest) {
+            *dest = static_cast<char_type>(*low);
+        }
+        return high;
+    }
+
+    char narrow(char_type c, [[maybe_unused]] char dfault) const { return static_cast<char>(c); }
+
+    const char_type * narrow(const char_type * low, const char_type * high, [[maybe_unused]] char dfault,
+                             char * dest) const {
+        for (; low != high; ++low, ++dest) {
+            *dest = static_cast<char>(*low);
+        }
+        return high;
+    }
+};
+#endif
+
+/// @brief Custom traits for uint8_t for usage in std template classes that use char_traits (e.g. std::basic_streambuf)
+template <> struct std::char_traits<uint8_t> {
+    using char_type  = uint8_t;
+    using int_type   = int;
+    using off_type   = std::streamoff;
+    using pos_type   = std::streampos;
+    using state_type = std::mbstate_t;
+
+    static void assign(char_type & c1, const char_type & c2) noexcept { c1 = c2; }
+
+    static constexpr bool eq(char_type a, char_type b) noexcept { return a == b; }
+
+    static constexpr bool lt(char_type a, char_type b) noexcept { return a < b; }
+
+    static int compare(const char_type * s1, const char_type * s2, std::size_t n) {
+        for (std::size_t i = 0; i < n; ++i) {
+            if (lt(s1[i], s2[i])) {
+                return -1;
+            }
+            if (lt(s2[i], s1[i])) {
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+    static std::size_t length(const char_type * s) {
+        std::size_t i = 0;
+        while (!eq(s[i], char_type())) {
+            ++i;
+        }
+        return i;
+    }
+
+    static const char_type * find(const char_type * s, std::size_t n, const char_type & c) {
+        for (std::size_t i = 0; i < n; ++i) {
+            if (eq(s[i], c)) {
+                return s + i;
+            }
+        }
+        return nullptr;
+    }
+
+    static char_type * move(char_type * s1, const char_type * s2, std::size_t n) {
+        return static_cast<char_type *>(std::memmove(s1, s2, n));
+    }
+
+    static char_type * copy(char_type * s1, const char_type * s2, std::size_t n) {
+        return static_cast<char_type *>(std::memcpy(s1, s2, n));
+    }
+
+    static char_type * assign(char_type * s, std::size_t n, char_type c) {
+        for (std::size_t i = 0; i < n; ++i) {
+            s[i] = c;
+        }
+        return s;
+    }
+
+    static constexpr int_type not_eof(int_type c) noexcept { return eq_int_type(c, eof()) ? 0 : c; }
+
+    static constexpr char_type to_char_type(int_type c) noexcept {
+        return c >= 0 && c <= 255 ? static_cast<char_type>(c) : char_type();
+    }
+
+    static constexpr int_type to_int_type(char_type c) noexcept { return static_cast<int_type>(c); }
+
+    static constexpr bool eq_int_type(int_type c1, int_type c2) noexcept { return c1 == c2; }
+
+    static constexpr int_type eof() noexcept { return static_cast<int_type>(-1); }
+};
+
+#ifdef GGML_SHARED
+#    if defined(_WIN32) && !defined(__MINGW32__)
+#        ifdef GGML_BUILD
+#            define GGML_CLASS_API __declspec(dllexport)
+#        else
+#            define GGML_CLASS_API __declspec(dllimport)
+#        endif
+#    else
+#        define GGML_CLASS_API __attribute__((visibility("default")))
+#    endif
+#else
+#    define GGML_CLASS_API
+#endif
+
+/// @brief Custom streambuf for uint8_t
+class GGML_CLASS_API Uint8BufferStreamBuf : public std::basic_streambuf<uint8_t> {
+  public:
+    Uint8BufferStreamBuf(std::vector<uint8_t> && _data);
+
+  protected:
+    int_type underflow() override;
+
+    /// @brief Efficient bulk reading. The standard implementation specifies that this function can be overridden
+    /// to provide a more efficient implementation: sgetn will call this function if it is overridden.
+    std::streamsize xsgetn(char_type * s, std::streamsize n) override;
+
+    pos_type seekoff(off_type off, std::ios_base::seekdir dir,
+                     std::ios_base::openmode which = std::ios_base::in) override;
+
+    pos_type seekpos(pos_type pos, std::ios_base::openmode which = std::ios_base::in) override;
+
+  private:
+    std::vector<uint8_t> data;
+};

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -194,6 +194,7 @@ add_library(ggml-base
             ../include/ggml-cpp.h
             ../include/ggml-opt.h
             ../include/gguf.h
+            ../include/uint8-buff-stream.h
             ggml.c
             ggml.cpp
             ggml-alloc.c
@@ -203,7 +204,8 @@ add_library(ggml-base
             ggml-threading.h
             ggml-quants.c
             ggml-quants.h
-            gguf.cpp)
+            gguf.cpp
+            uint8-buff-stream.cpp)
 
 target_include_directories(ggml-base PRIVATE .)
 if (GGML_BACKEND_DL)

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -2,6 +2,7 @@
 #include "ggml-backend.h"
 #include "ggml-impl.h"
 #include "gguf.h"
+#include "uint8-buff-stream.h"
 
 #include <cinttypes>
 #include <cstddef>
@@ -216,14 +217,79 @@ struct gguf_context {
     void * data = nullptr;
 };
 
-struct gguf_reader {
-    FILE * file;
+struct gguf_bytes_reader {
+    /// @brief Reads up to `count` objects into the array `buffer`.
+    /// The position of the underlying stream implementation is advanced
+    /// by the number of characters read.
+    ///
+    /// @note If an error occurs, the resulting value of the underlying stream
+    /// position indicator is indeterminate.
+    virtual size_t read(void * buffer, size_t size, size_t count) = 0;
 
-    gguf_reader(FILE * file) : file(file) {}
+    /// @brief Seeks to a position aligned to the given alignment boundary.
+    /// @return The current position after alignment, or 0 on error.
+    virtual size_t align(size_t alignment) = 0;
+
+    virtual ~gguf_bytes_reader() = 0;
+};
+
+gguf_bytes_reader::~gguf_bytes_reader() {}
+
+struct gguf_bytes_buffer_reader : public gguf_bytes_reader {
+    gguf_bytes_buffer_reader(std::basic_streambuf<uint8_t> & streambuf) : streambuf(streambuf), offset(0) {}
+
+    ~gguf_bytes_buffer_reader() {}
+
+    size_t read(void * buffer, size_t size, size_t count) override {
+        size_t total_size = size * count;
+        auto   bytes_read = streambuf.sgetn(static_cast<uint8_t *>(buffer), total_size);
+        offset += bytes_read;
+        return bytes_read;
+    }
+
+    size_t align(size_t alignment) override {
+        size_t new_offset  = GGML_PAD(offset, alignment);
+        size_t seek_offset = new_offset - offset;
+
+        auto result = streambuf.pubseekoff(seek_offset, std::ios_base::cur);
+        if (result == std::streampos(-1)) {
+            return 0;
+        }
+        offset = new_offset;
+        return offset;
+    }
+
+  private:
+    std::basic_streambuf<uint8_t> & streambuf;
+    size_t                          offset;
+};
+
+struct gguf_bytes_file_reader : public gguf_bytes_reader {
+    gguf_bytes_file_reader(FILE * file) : file(file) {}
+
+    ~gguf_bytes_file_reader() {}
+
+    size_t read(void * buffer, size_t size, size_t count) override { return fread(buffer, 1, size * count, file); }
+
+    size_t align(size_t alignment) override {
+        if (fseek(file, GGML_PAD(ftell(file), alignment), SEEK_SET) != 0) {
+            return 0;
+        }
+        return ftell(file);
+    }
+
+  private:
+    FILE * file;
+};
+
+struct gguf_reader {
+    gguf_bytes_reader& bytes_reader;
+
+    gguf_reader(gguf_bytes_reader& bytes_reader) : bytes_reader(bytes_reader) {}
 
     template <typename T>
     bool read(T & dst) const {
-        return fread(&dst, 1, sizeof(dst), file) == sizeof(dst);
+        return bytes_reader.read(&dst, 1, sizeof(dst)) == sizeof(dst);
     }
 
     template <typename T>
@@ -278,11 +344,11 @@ struct gguf_reader {
             return false;
         }
         dst.resize(size);
-        return fread(dst.data(), 1, dst.length(), file) == dst.length();
+        return bytes_reader.read(dst.data(), 1, dst.length()) == dst.length();
     }
 
     bool read(void * dst, const size_t size) const {
-        return fread(dst, 1, size, file) == size;
+        return bytes_reader.read(dst, 1, size) == size;
     }
 };
 
@@ -316,8 +382,8 @@ bool gguf_read_emplace_helper(const struct gguf_reader & gr, std::vector<struct 
     return true;
 }
 
-struct gguf_context * gguf_init_from_file_impl(FILE * file, struct gguf_init_params params) {
-    const struct gguf_reader gr(file);
+namespace {
+struct gguf_context * gguf_init_from_reader_impl(const struct gguf_reader& gr, struct gguf_init_params params) {
     struct gguf_context * ctx = new gguf_context;
 
     bool ok = true;
@@ -606,14 +672,13 @@ struct gguf_context * gguf_init_from_file_impl(FILE * file, struct gguf_init_par
     GGML_ASSERT(int64_t(ctx->info.size()) == n_tensors);
 
     // we require the data section to be aligned, so take into account any padding
-    if (fseek(file, GGML_PAD(ftell(file), ctx->alignment), SEEK_SET) != 0) {
-        GGML_LOG_ERROR("%s: failed to seek to beginning of data section\n", __func__);
+    // store the current file offset - this is where the data section starts
+    ctx->offset = gr.bytes_reader.align(ctx->alignment);
+    if (ctx->offset == 0) {
+        GGML_LOG_ERROR("%s: failed to align data section\n", __func__);
         gguf_free(ctx);
         return nullptr;
     }
-
-    // store the current file offset - this is where the data section starts
-    ctx->offset = ftell(file);
 
     // compute the total size of the data section, taking into account the alignment
     {
@@ -718,6 +783,13 @@ struct gguf_context * gguf_init_from_file_impl(FILE * file, struct gguf_init_par
 
     return ctx;
 }
+}
+
+struct gguf_context * gguf_init_from_file_impl(FILE * file, struct gguf_init_params params) {
+    gguf_bytes_file_reader bytes_reader(file);
+    gguf_reader            reader(bytes_reader);
+    return gguf_init_from_reader_impl(reader, params);
+}
 
 struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_params params) {
     FILE * file = ggml_fopen(fname, "rb");
@@ -730,6 +802,12 @@ struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_p
     struct gguf_context * result = gguf_init_from_file_impl(file, params);
     fclose(file);
     return result;
+}
+
+struct gguf_context * gguf_init_from_buffer(std::basic_streambuf<uint8_t> & streambuf, struct gguf_init_params params) {
+    gguf_bytes_buffer_reader bytes_reader(streambuf);
+    gguf_reader              reader(bytes_reader);
+    return gguf_init_from_reader_impl(reader, params);
 }
 
 void gguf_free(struct gguf_context * ctx) {

--- a/ggml/src/uint8-buff-stream.cpp
+++ b/ggml/src/uint8-buff-stream.cpp
@@ -1,0 +1,59 @@
+#include "uint8-buff-stream.h"
+
+#ifdef __APPLE__
+std::locale::id std::ctype<uint8_t>::id;
+#endif
+
+Uint8BufferStreamBuf::Uint8BufferStreamBuf(std::vector<uint8_t> && _data) : data(std::move(_data)) {
+    setg(const_cast<uint8_t *>(data.data()), const_cast<uint8_t *>(data.data()),
+         const_cast<uint8_t *>(data.data()) + data.size());
+}
+
+Uint8BufferStreamBuf::int_type Uint8BufferStreamBuf::underflow() {
+    if (gptr() < egptr()) {
+        return traits_type::to_int_type(*gptr());
+    }
+    return traits_type::eof();
+}
+
+std::streamsize Uint8BufferStreamBuf::xsgetn(char_type * s, std::streamsize n) {
+    std::streamsize available = egptr() - gptr();
+    std::streamsize to_read   = std::min(n, available);
+    if (to_read > 0) {
+        std::memcpy(s, gptr(), to_read);
+        setg(eback(), gptr() + to_read, egptr());
+    }
+    return to_read;
+}
+
+Uint8BufferStreamBuf::pos_type Uint8BufferStreamBuf::seekoff(off_type off, std::ios_base::seekdir dir,
+                                                             std::ios_base::openmode which) {
+    if (!(which & std::ios_base::in)) {
+        return pos_type(off_type(-1));
+    }
+    char_type * new_pos = nullptr;
+    if (dir == std::ios_base::beg) {
+        new_pos = eback() + off;
+    } else if (dir == std::ios_base::cur) {
+        new_pos = gptr() + off;
+    } else if (dir == std::ios_base::end) {
+        new_pos = egptr() + off;
+    }
+    if (new_pos >= eback() && new_pos <= egptr()) {
+        setg(eback(), new_pos, egptr());
+        return new_pos - eback();
+    }
+    return pos_type(off_type(-1));
+}
+
+Uint8BufferStreamBuf::pos_type Uint8BufferStreamBuf::seekpos(pos_type pos, std::ios_base::openmode which) {
+    if (!(which & std::ios_base::in)) {
+        return pos_type(off_type(-1));
+    }
+    char_type * new_pos = eback() + pos;
+    if (new_pos >= eback() && new_pos <= egptr()) {
+        setg(eback(), new_pos, egptr());
+        return pos;
+    }
+    return pos_type(off_type(-1));
+}

--- a/include/llama-cpp.h
+++ b/include/llama-cpp.h
@@ -32,3 +32,5 @@ typedef std::unique_ptr<llama_adapter_lora, llama_adapter_lora_deleter> llama_ad
 
 LLAMA_API struct llama_model * llama_model_load_from_buffer(std::vector<uint8_t> &&   data,
                                                             struct llama_model_params params);
+LLAMA_API bool                 llama_model_load_fulfill_split_future(const char * path, const char * context,
+                                                                     std::unique_ptr<std::basic_streambuf<uint8_t>> && streambuf);

--- a/include/llama-cpp.h
+++ b/include/llama-cpp.h
@@ -5,6 +5,7 @@
 #endif
 
 #include <memory>
+#include <vector>
 
 #include "llama.h"
 
@@ -28,3 +29,6 @@ typedef std::unique_ptr<llama_model, llama_model_deleter> llama_model_ptr;
 typedef std::unique_ptr<llama_context, llama_context_deleter> llama_context_ptr;
 typedef std::unique_ptr<llama_sampler, llama_sampler_deleter> llama_sampler_ptr;
 typedef std::unique_ptr<llama_adapter_lora, llama_adapter_lora_deleter> llama_adapter_lora_ptr;
+
+LLAMA_API struct llama_model * llama_model_load_from_buffer(std::vector<uint8_t> &&   data,
+                                                            struct llama_model_params params);

--- a/include/llama.h
+++ b/include/llama.h
@@ -456,6 +456,11 @@ extern "C" {
                                  size_t    n_paths,
               struct llama_model_params    params);
 
+    LLAMA_API struct llama_model * llama_model_load_from_split_futures(const char ** paths, size_t n_paths,
+                                                                       const char *              context,
+                                                                       const char *              tensor_list_file,
+                                                                       struct llama_model_params params);
+
     LLAMA_API void llama_model_save_to_file(
             const struct llama_model * model,
                         const char * path_model);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,8 @@ add_library(llama
             llama-memory-hybrid.cpp
             llama-memory-recurrent.cpp
             llama-mmap.cpp
+            llama-model-load-input.cpp
+            llama-model-load.cpp
             llama-model-loader.cpp
             llama-model-saver.cpp
             llama-model.cpp

--- a/src/llama-adapter.cpp
+++ b/src/llama-adapter.cpp
@@ -347,7 +347,7 @@ static void llama_adapter_lora_init_impl(llama_model & model, const char * path_
 
     // set tensor data
     {
-        llama_file gguf_file(path_lora, "rb");
+        llama_file_disk gguf_file(path_lora, "rb");
         std::vector<uint8_t> read_buf;
         auto set_tensor = [&](ggml_tensor * orig, ggml_tensor * dev) {
             size_t offs = gguf_get_data_offset(ctx_gguf.get()) + gguf_get_tensor_offset(ctx_gguf.get(), gguf_find_tensor(ctx_gguf.get(), orig->name));

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1614,7 +1614,7 @@ size_t llama_context::state_seq_set_data(llama_seq_id seq_id, const uint8_t * sr
 }
 
 bool llama_context::state_load_file(const char * filepath, llama_token * tokens_out, size_t n_token_capacity, size_t * n_token_count_out) {
-    llama_file file(filepath, "rb");
+    llama_file_disk file(filepath, "rb");
 
     // sanity checks
     {
@@ -1657,7 +1657,7 @@ bool llama_context::state_load_file(const char * filepath, llama_token * tokens_
 }
 
 bool llama_context::state_save_file(const char * filepath, const llama_token * tokens, size_t n_token_count) {
-    llama_file file(filepath, "wb");
+    llama_file_disk file(filepath, "wb");
 
     file.write_u32(LLAMA_SESSION_MAGIC);
     file.write_u32(LLAMA_SESSION_VERSION);
@@ -1674,7 +1674,7 @@ bool llama_context::state_save_file(const char * filepath, const llama_token * t
 }
 
 size_t llama_context::state_seq_load_file(llama_seq_id seq_id, const char * filepath, llama_token * tokens_out, size_t n_token_capacity, size_t * n_token_count_out) {
-    llama_file file(filepath, "rb");
+    llama_file_disk file(filepath, "rb");
 
     // version checks
     {
@@ -1717,7 +1717,7 @@ size_t llama_context::state_seq_load_file(llama_seq_id seq_id, const char * file
 }
 
 size_t llama_context::state_seq_save_file(llama_seq_id seq_id, const char * filepath, const llama_token * tokens, size_t n_token_count) {
-    llama_file file(filepath, "wb");
+    llama_file_disk file(filepath, "wb");
 
     file.write_u32(LLAMA_STATE_SEQ_MAGIC);
     file.write_u32(LLAMA_STATE_SEQ_VERSION);

--- a/src/llama-impl.h
+++ b/src/llama-impl.h
@@ -30,6 +30,13 @@ void llama_log_callback_default(ggml_log_level level, const char * text, void * 
 #define LLAMA_LOG_DEBUG(...) llama_log_internal(GGML_LOG_LEVEL_DEBUG, __VA_ARGS__)
 #define LLAMA_LOG_CONT(...)  llama_log_internal(GGML_LOG_LEVEL_CONT , __VA_ARGS__)
 
+// Debug-only logging macro that's only enabled in debug builds at compile time
+#ifndef NDEBUG
+#define LLAMA_LOG_CMAKE_DEBUG(...) LLAMA_LOG_DEBUG(__VA_ARGS__)
+#else
+#define LLAMA_LOG_CMAKE_DEBUG(...)
+#endif
+
 //
 // helpers
 //

--- a/src/llama-mmap.cpp
+++ b/src/llama-mmap.cpp
@@ -54,9 +54,7 @@ static std::string llama_format_win_err(DWORD err) {
 }
 #endif
 
-// llama_file
-
-struct llama_file::impl {
+struct llama_file_disk::impl {
 #if defined(_WIN32)
     HANDLE fp_win32;
     std::string GetErrorMessageWin32(DWORD error_code) const {
@@ -241,13 +239,13 @@ struct llama_file::impl {
     size_t size;
 };
 
-llama_file::llama_file(const char * fname, const char * mode) : pimpl(std::make_unique<impl>(fname, mode)) {}
-llama_file::~llama_file() = default;
+llama_file_disk::llama_file_disk(const char * fname, const char * mode) : pimpl(std::make_unique<impl>(fname, mode)) {}
+llama_file_disk::~llama_file_disk() = default;
 
-size_t llama_file::tell() const { return pimpl->tell(); }
-size_t llama_file::size() const { return pimpl->size; }
+size_t llama_file_disk::tell() const { return pimpl->tell(); }
+size_t llama_file_disk::size() const { return pimpl->size; }
 
-int llama_file::file_id() const {
+int llama_file_disk::file_id() const {
 #ifdef _WIN32
     return _fileno(pimpl->fp);
 #else
@@ -259,13 +257,13 @@ int llama_file::file_id() const {
 #endif
 }
 
-void llama_file::seek(size_t offset, int whence) const { pimpl->seek(offset, whence); }
-void llama_file::read_raw(void * ptr, size_t len) const { pimpl->read_raw(ptr, len); }
+void llama_file_disk::seek(size_t offset, int whence) const { pimpl->seek(offset, whence); }
+void llama_file_disk::read_raw(void * ptr, size_t len) const { pimpl->read_raw(ptr, len); }
 
-uint32_t llama_file::read_u32() const { return pimpl->read_u32(); }
+uint32_t llama_file_disk::read_u32() const { return pimpl->read_u32(); }
 
-void llama_file::write_raw(const void * ptr, size_t len) const { pimpl->write_raw(ptr, len); }
-void llama_file::write_u32(uint32_t val) const { pimpl->write_u32(val); }
+void llama_file_disk::write_raw(const void * ptr, size_t len) const { pimpl->write_raw(ptr, len); }
+void llama_file_disk::write_u32(uint32_t val) const { pimpl->write_u32(val); }
 
 // llama_mmap
 

--- a/src/llama-mmap.h
+++ b/src/llama-mmap.h
@@ -13,21 +13,36 @@ using llama_mmaps  = std::vector<std::unique_ptr<llama_mmap>>;
 using llama_mlocks = std::vector<std::unique_ptr<llama_mlock>>;
 
 struct llama_file {
-    llama_file(const char * fname, const char * mode);
-    ~llama_file();
+    virtual ~llama_file() = default;
 
-    size_t tell() const;
-    size_t size() const;
+    virtual size_t tell() const = 0;
+    virtual size_t size() const = 0;
+    virtual int file_id() const = 0;
 
-    int file_id() const; // fileno overload
+    virtual void seek(size_t offset, int whence) const = 0;
 
-    void seek(size_t offset, int whence) const;
+    virtual void read_raw(void * ptr, size_t len) const = 0;
+    virtual uint32_t read_u32() const = 0;
 
-    void read_raw(void * ptr, size_t len) const;
-    uint32_t read_u32() const;
+    virtual void write_raw(const void * ptr, size_t len) const = 0;
+    virtual void write_u32(uint32_t val) const = 0;
+};
 
-    void write_raw(const void * ptr, size_t len) const;
-    void write_u32(uint32_t val) const;
+struct llama_file_disk : public llama_file {
+    llama_file_disk(const char * fname, const char * mode);
+    ~llama_file_disk() override;
+
+    size_t tell() const override;
+    size_t size() const override;
+    int file_id() const override;
+
+    void seek(size_t offset, int whence) const override;
+
+    void read_raw(void * ptr, size_t len) const override;
+    uint32_t read_u32() const override;
+
+    void write_raw(const void * ptr, size_t len) const override;
+    void write_u32(uint32_t val) const override;
 
 private:
     struct impl;

--- a/src/llama-mmap.h
+++ b/src/llama-mmap.h
@@ -49,6 +49,35 @@ private:
     std::unique_ptr<impl> pimpl;
 };
 
+template <bool Writable> struct llama_file_buffer : public llama_file {
+    llama_file_buffer(std::unique_ptr<std::basic_streambuf<uint8_t>> && streambuf);
+
+    ~llama_file_buffer() override;
+
+    size_t tell() const override;
+    size_t size() const override;
+
+    /// @return -1 to indicate this is not a real file descriptor
+    int file_id() const override;
+
+    void seek(size_t offset, int whence) const override;
+
+    void     read_raw(void * ptr, size_t len) const override;
+    uint32_t read_u32() const override;
+
+    /// @throw std::runtime_error if the buffer is read-only
+    void write_raw(const void * ptr, size_t len) const override;
+
+    /// @throw std::runtime_error if the buffer is read-only
+    void write_u32(uint32_t val) const override;
+
+    std::unique_ptr<std::basic_streambuf<uint8_t>> streambuf;
+};
+
+// Type aliases for convenience
+using llama_file_buffer_ro = llama_file_buffer<false>;
+using llama_file_buffer_rw = llama_file_buffer<true>;
+
 struct llama_mmap {
     llama_mmap(const llama_mmap &) = delete;
     llama_mmap(struct llama_file * file, size_t prefetch = (size_t) -1, bool numa = false);

--- a/src/llama-model-load-input.cpp
+++ b/src/llama-model-load-input.cpp
@@ -1,4 +1,6 @@
 #include "llama-model-load-input.h"
+#include <sstream>
+#include "llama-mmap.h"
 
 namespace load_input_variant {
 
@@ -12,12 +14,51 @@ const char * identifier(load_input_t & load_input) {
 }
 
 fname_load_input split_name_from_variant(load_input_t & load_input) {
+    if (std::holds_alternative<buffer_future_load_input>(load_input)) {
+        auto future_input = std::get<buffer_future_load_input>(load_input);
+        return fname_load_input{ future_input.promise_key, future_input.splits };
+    }
     auto file_input = std::get<fname_load_input>(load_input);
     return file_input;
 }
 
 bool variant_supports_split_load(load_input_t & load_input) {
-    return std::holds_alternative<fname_load_input>(load_input);
+    return std::holds_alternative<fname_load_input>(load_input) ||
+           std::holds_alternative<buffer_future_load_input>(load_input);
+}
+
+bool variant_supports_split_load_from_memory(load_input_t & load_input) {
+    return std::holds_alternative<buffer_future_load_input>(load_input);
+}
+
+std::optional<std::set<std::string>> parse_tensor_list_from_future(load_input_t & load_input) {
+    std::set<std::string> tensor_names;
+
+    if (!std::holds_alternative<buffer_future_load_input>(load_input)) {
+        return std::nullopt;
+    }
+
+    const auto & future_input = std::get<buffer_future_load_input>(load_input);
+
+    // Open and read the tensor list file
+    llama_future_file_buffer_ro           tensor_file(future_input.tensor_list_file, future_input.context);
+    std::unique_ptr<llama_file_buffer_ro> file_buffer = tensor_file.extract();
+
+    // Read the entire buffer as bytes and convert to string
+    std::vector<uint8_t>              buffer;
+    std::basic_istream<uint8_t>       stream(file_buffer->streambuf.get());
+    std::istreambuf_iterator<uint8_t> begin(stream), end;
+    buffer.assign(begin, end);
+
+    // Convert bytes to string and split by newlines
+    std::string        content(reinterpret_cast<const char *>(buffer.data()), buffer.size());
+    std::istringstream line_stream(content);
+    std::string        line;
+    while (std::getline(line_stream, line)) {
+        tensor_names.insert(line);
+    }
+
+    return tensor_names;
 }
 
 }  // namespace load_input_variant

--- a/src/llama-model-load-input.cpp
+++ b/src/llama-model-load-input.cpp
@@ -1,0 +1,23 @@
+#include "llama-model-load-input.h"
+
+namespace load_input_variant {
+
+const char * identifier(load_input_t & load_input) {
+    if (std::holds_alternative<fname_load_input>(load_input)) {
+        const auto & file_input = std::get<fname_load_input>(load_input);
+        return file_input.fname.c_str();
+    }
+    static const char * buffer_id_str = "buffer";
+    return buffer_id_str;
+}
+
+fname_load_input split_name_from_variant(load_input_t & load_input) {
+    auto file_input = std::get<fname_load_input>(load_input);
+    return file_input;
+}
+
+bool variant_supports_split_load(load_input_t & load_input) {
+    return std::holds_alternative<fname_load_input>(load_input);
+}
+
+}  // namespace load_input_variant

--- a/src/llama-model-load-input.h
+++ b/src/llama-model-load-input.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace load_input_variant {
+
+struct fname_load_input {
+    const std::string &        fname;
+    std::vector<std::string> & splits;  // optional, only need if the split does not follow naming scheme
+};
+
+struct buffer_load_input {
+    std::unique_ptr<std::basic_streambuf<uint8_t>> & streambuf;
+};
+
+}  // namespace load_input_variant
+
+using load_input_t = std::variant<load_input_variant::fname_load_input, load_input_variant::buffer_load_input>;
+
+namespace load_input_variant {
+const char * identifier(load_input_t & load_input);
+
+fname_load_input split_name_from_variant(load_input_t & load_input);
+
+bool variant_supports_split_load(load_input_t & load_input);
+}  // namespace load_input_variant

--- a/src/llama-model-load-input.h
+++ b/src/llama-model-load-input.h
@@ -3,6 +3,8 @@
 #include <stdint.h>
 
 #include <memory>
+#include <optional>
+#include <set>
 #include <string>
 #include <variant>
 #include <vector>
@@ -18,9 +20,17 @@ struct buffer_load_input {
     std::unique_ptr<std::basic_streambuf<uint8_t>> & streambuf;
 };
 
+struct buffer_future_load_input {
+    const std::string &        promise_key;
+    const std::string &        context;
+    std::vector<std::string> & splits;
+    const std::string &        tensor_list_file;
+};
+
 }  // namespace load_input_variant
 
-using load_input_t = std::variant<load_input_variant::fname_load_input, load_input_variant::buffer_load_input>;
+using load_input_t = std::variant<load_input_variant::fname_load_input, load_input_variant::buffer_load_input,
+                                  load_input_variant::buffer_future_load_input>;
 
 namespace load_input_variant {
 const char * identifier(load_input_t & load_input);
@@ -28,4 +38,9 @@ const char * identifier(load_input_t & load_input);
 fname_load_input split_name_from_variant(load_input_t & load_input);
 
 bool variant_supports_split_load(load_input_t & load_input);
+
+bool variant_supports_split_load_from_memory(load_input_t & load_input);
+
+/// @brief Parse tensor list from future file or nullopt if not a future file
+std::optional<std::set<std::string>> parse_tensor_list_from_future(load_input_t & load_input);
 }  // namespace load_input_variant

--- a/src/llama-model-load.cpp
+++ b/src/llama-model-load.cpp
@@ -1,0 +1,30 @@
+#include "llama-model-load.h"
+
+#include <memory>
+#include <stdexcept>
+#include <variant>
+
+#include "llama-model-loader.h"
+
+gguf_file_load::gguf_file_load(struct ggml_context ** ctx, load_input_t load_input) :
+    params({
+        /*.no_alloc = */ true,
+        /*.ctx      = */ ctx,
+    }) {
+    using namespace load_input_variant;
+    if (std::holds_alternative<fname_load_input>(load_input)) {
+        const auto & file_input = std::get<fname_load_input>(load_input);
+        meta.reset(gguf_init_from_file(file_input.fname.c_str(), params));
+        if (!meta) {
+            throw std::runtime_error(format("%s: failed to load model from %s", __func__, file_input.fname.c_str()));
+        }
+        file = std::make_unique<llama_file_disk>(file_input.fname.c_str(), "ro");
+    } else {
+        const auto & buffer_input = std::get<buffer_load_input>(load_input);
+        meta.reset(gguf_init_from_buffer(*buffer_input.streambuf, params));
+        if (!meta) {
+            throw std::runtime_error(format("%s: failed to load model from buffer", __func__));
+        }
+        file = std::make_unique<llama_file_buffer_ro>(std::move(buffer_input.streambuf));
+    }
+}

--- a/src/llama-model-load.cpp
+++ b/src/llama-model-load.cpp
@@ -1,5 +1,6 @@
 #include "llama-model-load.h"
 
+#include <cstdint>
 #include <memory>
 #include <stdexcept>
 #include <variant>
@@ -19,6 +20,16 @@ gguf_file_load::gguf_file_load(struct ggml_context ** ctx, load_input_t load_inp
             throw std::runtime_error(format("%s: failed to load model from %s", __func__, file_input.fname.c_str()));
         }
         file = std::make_unique<llama_file_disk>(file_input.fname.c_str(), "ro");
+    } else if (std::holds_alternative<buffer_future_load_input>(load_input)) {
+        const auto & future_input = std::get<buffer_future_load_input>(load_input);
+        auto         future_file =
+            std::make_unique<llama_future_file_buffer_ro>(future_input.promise_key, future_input.context);
+        std::unique_ptr<llama_file_buffer_ro> file_buffer = future_file->extract();
+        meta.reset(gguf_init_from_buffer(*file_buffer->streambuf, params));
+        if (!meta) {
+            throw std::runtime_error(format("%s: failed to load model from buffer", __func__));
+        }
+        file = std::move(file_buffer);
     } else {
         const auto & buffer_input = std::get<buffer_load_input>(load_input);
         meta.reset(gguf_init_from_buffer(*buffer_input.streambuf, params));
@@ -27,4 +38,197 @@ gguf_file_load::gguf_file_load(struct ggml_context ** ctx, load_input_t load_inp
         }
         file = std::make_unique<llama_file_buffer_ro>(std::move(buffer_input.streambuf));
     }
+}
+
+gguf_file_load SplitLoad::load_split_gguf(struct ggml_context ** ctx, const char * fname_split,
+                                          load_input_t & load_input, std::vector<std::string> & splits) {
+    using namespace load_input_variant;
+    if (std::holds_alternative<fname_load_input>(load_input)) {
+        return gguf_file_load(ctx, fname_load_input{ fname_split, splits });
+    }
+    if (std::holds_alternative<buffer_future_load_input>(load_input)) {
+        auto future_input = std::get<buffer_future_load_input>(load_input);
+        return gguf_file_load(
+            ctx, buffer_future_load_input{ fname_split, future_input.context, splits, future_input.tensor_list_file });
+    }
+    return gguf_file_load(ctx, load_input);
+}
+
+SplitLoad::SplitLoad(load_input_t & load_input, load_input_variant::fname_load_input base_split, uint16_t idx,
+                     std::string kv_split_no) :
+    load_input(load_input),
+    base_split(base_split),
+    idx(idx),
+    kv_split_no(std::move(kv_split_no)) {}
+
+IncrementalSplitsTensorLoad::IncrementalSplitsTensorLoad(struct ggml_context * ctx, struct llama_model_loader & ml,
+                                                         gguf_file_load &      base_split,
+                                                         std::set<std::string> tensor_list) :
+    expected_tensors(std::move(tensor_list)) {
+    ml.process_loaded_gguf(ctx, base_split, 0);
+    _process_split(ctx, ml, 0);
+}
+
+struct ggml_context * SplitLoad::load(llama_model_loader & ml) {
+    if (loaded) {
+        return ml.contexts[idx].get();
+    }
+
+    struct ggml_context * ctx = ml.contexts.back().get();
+
+    const char * fname_split = base_split.splits[idx].c_str();
+    LLAMA_LOG_INFO("loading split-file %s\n", fname_split);
+
+    gguf_file_load     split_gguf = gguf_file_load(load_split_gguf(&ctx, fname_split, load_input, base_split.splits));
+    gguf_context_ptr & split_meta = split_gguf.meta;
+
+    if (idx > 0) {
+        const int kid = gguf_find_key(split_meta.get(), kv_split_no.c_str());
+        if (kid < 0) {
+            throw std::runtime_error(format("missing key %s in GGUF split %s", kv_split_no.c_str(), fname_split));
+        }
+        int idx_gguf = gguf_get_val_u16(split_meta.get(), kid);
+        if (idx_gguf != idx) {
+            throw std::runtime_error(
+                format("invalid split file idx: %d (file: %s), expected %d", idx_gguf, fname_split, idx));
+        }
+    }
+
+    // Check that this split's idx matches the expected position in ml.files
+    if (!ml.files.empty() && idx != ml.files.size()) {
+        throw std::runtime_error(
+            format("invalid split file loading order: got idx %d but expected %zu based on ml.files size", idx,
+                   ml.files.size()));
+    }
+
+    ml.process_loaded_gguf(ctx, split_gguf, idx);
+
+    loaded = true;
+    return ctx;
+}
+
+void IncrementalSplitsTensorLoad::add_split(SplitLoad splitLoad) {
+    // +1 because first split is expected to have been already loaded (not delayed)
+    split_info[delayed_files.size() + 1] = SplitInfo();
+    delayed_files.emplace_back(std::move(splitLoad));
+}
+
+void IncrementalSplitsTensorLoad::_load_split(struct llama_model_loader & ml, uint16_t idx) {
+    // -1 because first split is expected to have been already loaded (not delayed and not present in delayed_files)
+    const struct ggml_context * ctx = delayed_files[idx - 1].load(ml);
+    _process_split(ctx, ml, idx);
+}
+
+void IncrementalSplitsTensorLoad::_process_split(const struct ggml_context * ctx, struct llama_model_loader & ml,
+                                                 uint16_t idx) {
+    SplitInfo & split = split_info[idx];
+
+    for (ggml_tensor * cur = ggml_get_first_tensor(ctx); cur; cur = ggml_get_next_tensor(ctx, cur)) {
+        std::string tensor_name = std::string(cur->name);
+        split.total_tensor_count++;
+
+        // Add tensor info with initial loaded state as false
+        tensor_info[tensor_name] = TensorInfo{ idx, false };
+
+        auto it = ml.weights_map.find(tensor_name);
+        if (it == ml.weights_map.end()) {
+            throw std::runtime_error(format("tensor '%s' not found in weights_map", tensor_name.c_str()));
+        }
+        split.data_size += ggml_nbytes(it->second.tensor);
+    }
+}
+
+uint16_t IncrementalSplitsTensorLoad::load_tensor_metadata(struct llama_model_loader & ml, const char * tensor_name,
+                                                           ggml_tensor ** out_tensor_metadata) {
+    LLAMA_LOG_CMAKE_DEBUG("%s: loading tensor %s (tensor_meta=%p, delayed_loaded=%zu, delayed_files.size=%zu)\n",
+                          __func__, tensor_name, (void *) *out_tensor_metadata, delayed_loaded, delayed_files.size());
+    if (expected_tensors.find(tensor_name) == expected_tensors.end()) {
+        throw std::runtime_error(format("unknown tensor not expected in split files: %s", tensor_name));
+    }
+    while (!(*out_tensor_metadata) && delayed_loaded < delayed_files.size()) {
+        // +1 because first split is expected to have been already loaded (not delayed)
+        _load_split(ml, delayed_loaded + 1);
+        *out_tensor_metadata = ml.get_tensor_meta(tensor_name);
+        delayed_loaded++;
+        if (*out_tensor_metadata) {
+            LLAMA_LOG_CMAKE_DEBUG("%s: tensor %s found in file %zu\n", __func__, tensor_name, delayed_loaded);
+        }
+        if (delayed_loaded == delayed_files.size() && ml.weights_map.size() != expected_n_tensors()) {
+            throw std::runtime_error(
+                format("finished incrementally loading all splits but expected %zu tensors, got %zu",
+                       expected_n_tensors(), ml.weights_map.size()));
+        }
+    }
+    uint16_t split_idx = get_split_idx_for_tensor(tensor_name);
+
+    // Mark tensor as loaded and increment split's loaded count
+    auto tensor_it = tensor_info.find(tensor_name);
+    if (!tensor_it->second.is_loaded) {
+        tensor_it->second.is_loaded = true;
+        split_info[split_idx].loaded_tensor_count++;
+    }
+
+    return split_idx;
+}
+
+uint16_t IncrementalSplitsTensorLoad::get_split_idx_for_tensor(const char * tensor_name) const {
+    return _get_tensor_info_iterator(tensor_name)->second.split_idx;
+}
+
+std::size_t IncrementalSplitsTensorLoad::get_split_data_size(uint16_t split_idx) const {
+    return _get_split_info_iterator(split_idx)->second.data_size;
+}
+
+void IncrementalSplitsTensorLoad::print_currently_known_tensors() const {
+    LLAMA_LOG_INFO("Current incremental loaded tensors:\n");
+    for (const auto & it : tensor_info) {
+        LLAMA_LOG_INFO("Tensor '%s' in split %d (loaded: %s)\n", it.first.c_str(), it.second.split_idx,
+                       it.second.is_loaded ? "yes" : "no");
+    }
+}
+
+bool IncrementalSplitsTensorLoad::all_tensors_are_loaded(uint16_t split_idx) const {
+    auto              it    = _get_split_info_iterator(split_idx);
+    const SplitInfo & split = it->second;
+    LLAMA_LOG_CMAKE_DEBUG("Loaded tensor count for split %d: %u/%u\n", split_idx, split.loaded_tensor_count,
+                          split.total_tensor_count);
+    return split.all_tensors_loaded();
+}
+
+std::size_t IncrementalSplitsTensorLoad::expected_n_tensors() {
+    return expected_tensors.size();
+}
+
+void IncrementalSplitsTensorLoad::release_split(struct llama_model_loader & ml, uint16_t split_idx) {
+    // Let destructor of the smart pointer do the release of memory
+    ml.files[split_idx] = nullptr;
+}
+
+std::map<std::string, IncrementalSplitsTensorLoad::TensorInfo>::const_iterator
+IncrementalSplitsTensorLoad::_get_tensor_info_iterator(const char * tensor_name) const {
+    auto it = tensor_info.find(tensor_name);
+    if (it == tensor_info.end()) {
+        throw std::runtime_error(format("tensor '%s' not found in tensor_info map", tensor_name));
+    }
+    return it;
+}
+
+std::map<uint16_t, IncrementalSplitsTensorLoad::SplitInfo>::const_iterator
+IncrementalSplitsTensorLoad::_get_split_info_iterator(uint16_t split_idx) const {
+    auto it = split_info.find(split_idx);
+    if (it == split_info.end()) {
+        throw std::runtime_error(format("split index %d not found in split_info map", split_idx));
+    }
+    return it;
+}
+
+bool IncrementalSplitsTensorLoad::SplitInfo::all_tensors_loaded() const {
+    return loaded_tensor_count >= total_tensor_count;
+}
+
+bool IncrementalSplitsTensorLoad::tensor_ignored(const std::optional<IncrementalSplitsTensorLoad> & splits_tensor_load,
+                                                 const char *                                       tensor_name) {
+    return !splits_tensor_load.has_value() ||
+           (splits_tensor_load.has_value() &&
+            splits_tensor_load->expected_tensors.find(tensor_name) == splits_tensor_load->expected_tensors.end());
 }

--- a/src/llama-model-load.h
+++ b/src/llama-model-load.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+#include <set>
+
+#include "ggml-cpp.h"
+#include "llama-mmap.h"
+#include "llama-model-load-input.h"
+
+struct llama_model_loader;
+
+/// @brief Immediately loads and stores relevant data in the struct fields.
+struct gguf_file_load {
+    struct gguf_init_params     params;
+    gguf_context_ptr            meta;
+    std::unique_ptr<llama_file> file = nullptr;
+
+    gguf_file_load(struct ggml_context ** ctx, load_input_t load_input);
+};

--- a/src/llama-model-load.h
+++ b/src/llama-model-load.h
@@ -17,3 +17,131 @@ struct gguf_file_load {
 
     gguf_file_load(struct ggml_context ** ctx, load_input_t load_input);
 };
+
+/// @brief Stores relevant information to be able to loads a `.gguf` split file when load method is called.
+struct SplitLoad {
+    load_input_t                         load_input;
+    load_input_variant::fname_load_input base_split;
+    uint16_t                             idx;
+    std::string                          kv_split_no;
+    bool                                 loaded = false;
+
+    SplitLoad(load_input_t & load_input, load_input_variant::fname_load_input base_split, uint16_t idx,
+              std::string kv_split_no);
+
+    static gguf_file_load load_split_gguf(struct ggml_context ** ctx, const char * fname_split,
+                                          load_input_t & load_input, std::vector<std::string> & splits);
+
+    struct ggml_context * load(struct llama_model_loader & ml);
+};
+
+/// @brief Handles incremental load of tensor and split-files.
+/// @note First split-file is expected to be already available at construction, the remainder of split-files are
+/// incrementally load on-demand by calling `load_tensor_metadata`
+struct IncrementalSplitsTensorLoad {
+    IncrementalSplitsTensorLoad(struct ggml_context * ctx, struct llama_model_loader & ml, gguf_file_load & base_split,
+                                std::set<std::string> tensor_list);
+
+    void add_split(SplitLoad splitLoad);
+
+    /// @brief Incrementally loads file splits until the tensor metadata is found.
+    /// Also increments loaded tensor count so that `all_tensors_are_loaded` returns true
+    /// when all tensors in a file-split have been requested.
+    /// @returns Split idx where the tensor was found
+    /// @throw runtime_error if tensor was not found
+    uint16_t load_tensor_metadata(struct llama_model_loader & ml, const char * tensor_name,
+                                  ggml_tensor ** out_tensor_metadata);
+
+    /// @returns True if all tensors of a split have been loaded.
+    bool all_tensors_are_loaded(uint16_t split_idx) const;
+
+    /// @returns Max number of tensors as described on the summary tensor-list file.
+    std::size_t expected_n_tensors();
+
+    /// @bried Release file memory for a split.
+    static void release_split(struct llama_model_loader & ml, uint16_t split_idx);
+
+    void print_currently_known_tensors() const;
+
+    uint16_t get_split_idx_for_tensor(const char * tensor_name) const;
+
+    std::size_t get_split_data_size(uint16_t split_idx) const;
+
+    static bool tensor_ignored(const std::optional<IncrementalSplitsTensorLoad> & splits_tensor_load,
+                               const char *                                       tensor_name);
+
+    /// @brief Lalizy get/allocate a context with enough capacity for all tensors of
+    /// same type of an individual split. The context can be used to instantiate the
+    /// final model tensors and and attach to them backend buffers.
+    /// @tparam impl The model implementation type where the context will be stored.
+    template <typename impl>
+    ggml_context * get_model_ctx_for_split_buft(ggml_backend_buffer_type_t buft, uint16_t split, impl * model_impl) {
+        auto key = std::make_pair(buft, split);
+        auto it  = ctx_split_map.find(key);
+        if (it == ctx_split_map.end()) {
+            LLAMA_LOG_CMAKE_DEBUG("%s: creating context for split %d (buft=%s, existing=%zu)\n", __func__, split,
+                                  ggml_backend_buft_name(buft), ctx_split_map.size());
+
+            const size_t max_n_tensors = _get_split_info_iterator(split)->second.total_tensor_count;
+            const size_t ctx_size      = ggml_tensor_overhead() * max_n_tensors;
+
+            ggml_init_params params = {
+                /*.mem_size   =*/ctx_size,
+                /*.mem_buffer =*/NULL,
+                /*.no_alloc   =*/true,
+            };
+
+            ggml_context * ctx = ggml_init(params);
+            if (!ctx) {
+                throw std::runtime_error("failed to create ggml context for split-file");
+            }
+
+            ctx_split_map[key] = ctx;
+            model_impl->ctxs.emplace_back(ctx);
+
+            return ctx;
+        }
+        return it->second;
+    }
+
+    // public so that it can be processed by the backend storage allocator
+    std::map<std::pair<ggml_backend_buffer_type_t, uint16_t>, ggml_context *> ctx_split_map;
+
+  private:
+    struct TensorInfo {
+        uint16_t split_idx = 0;
+        bool     is_loaded = false;
+    };
+
+    struct SplitInfo {
+        uint32_t total_tensor_count = 0, loaded_tensor_count = 0;
+
+        /// @brief Total ggml tensor data size of this split
+        std::size_t data_size = 0;
+
+        bool all_tensors_loaded() const;
+    };
+
+    void _load_split(struct llama_model_loader & ml, uint16_t idx);
+    void _process_split(const struct ggml_context * ctx, struct llama_model_loader & ml, uint16_t idx);
+
+    /// @brief Get tensor info iterator or throw if not found
+    /// @throw runtime_error if tensor not found
+    std::map<std::string, TensorInfo>::const_iterator _get_tensor_info_iterator(const char * tensor_name) const;
+
+    /// @brief Get split info iterator or throw if not found
+    /// @throw runtime_error if split not found
+    std::map<uint16_t, SplitInfo>::const_iterator _get_split_info_iterator(uint16_t split_idx) const;
+
+    std::map<std::string, TensorInfo> tensor_info;
+    std::map<uint16_t, SplitInfo>     split_info;
+
+    /// @brief Number of delayed files that have been loaded
+    std::size_t delayed_loaded = 0;
+
+    /// @brief Vector of split files to be loaded on demand
+    std::vector<SplitLoad> delayed_files;
+
+    /// @brief Set of expected tensor names loaded from tensor list file
+    std::set<std::string> expected_tensors;
+};

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -500,7 +500,7 @@ llama_model_loader::llama_model_loader(
     get_key(llm_kv(LLM_KV_GENERAL_ARCHITECTURE), arch_name, false);
     llm_kv = LLM_KV(llm_arch_from_string(arch_name));
 
-    files.emplace_back(new llama_file(fname.c_str(), "rb"));
+    files.emplace_back(new llama_file_disk(fname.c_str(), "rb"));
     contexts.emplace_back(ctx);
 
     // Save tensors data offset of the main file.
@@ -568,7 +568,7 @@ llama_model_loader::llama_model_loader(
                 }
             }
 
-            files.emplace_back(new llama_file(fname_split, "rb"));
+            files.emplace_back(new llama_file_disk(fname_split, "rb"));
             contexts.emplace_back(ctx);
 
             // Save tensors data offset info of the shard.

--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -79,6 +79,9 @@ struct llama_model_loader {
     llama_mmaps mappings;
 
     std::map<std::string, llama_tensor_weight, weight_name_comparer> weights_map;
+
+    std::optional<IncrementalSplitsTensorLoad> incremental_splits_tensor_load;
+
     std::unordered_map<std::string, llama_model_kv_override> kv_overrides;
     const llama_model_tensor_buft_override * tensor_buft_overrides;
 

--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -158,12 +158,8 @@ struct llama_model_loader {
     void load_data_for(struct ggml_tensor * cur) const;
 
     // Returns false if cancelled by progress_callback
-    bool load_all_data(
-            struct ggml_context * ctx,
-            llama_buf_map & bufs,
-            llama_mlocks * lmlocks,
-            llama_progress_callback progress_callback,
-            void * progress_callback_user_data);
+    bool load_all_data(size_t size_data, struct ggml_context * ctx, llama_buf_map & bufs, llama_mlocks * lmlocks,
+                       llama_progress_callback progress_callback, void * progress_callback_user_data);
 
     std::string ftype_name() const;
 

--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -5,6 +5,7 @@
 #include "llama-impl.h"
 #include "llama-arch.h"
 #include "llama-mmap.h"
+#include "llama-model-load.h"
 
 #include "ggml-cpp.h"
 
@@ -90,6 +91,8 @@ struct llama_model_loader {
     size_t size_done = 0;
     size_t size_data = 0;
     std::vector<std::pair<size_t, size_t>> mmaps_used;
+
+    void process_loaded_gguf(struct ggml_context * ctx, gguf_file_load & gguf_load, uint16_t idx);
 
     llama_model_loader(
         const std::string & fname,

--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -95,8 +95,7 @@ struct llama_model_loader {
     void process_loaded_gguf(struct ggml_context * ctx, gguf_file_load & gguf_load, uint16_t idx);
 
     llama_model_loader(
-        const std::string & fname,
-        std::vector<std::string> & splits, // optional, only need if the split does not follow naming scheme
+        load_input_t load_input,
         bool use_mmap,
         bool check_tensors,
         const llama_model_kv_override * param_overrides_p,

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -4288,6 +4288,13 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
     ml.init_mappings(true, use_mlock ? &pimpl->mlock_mmaps : nullptr);
     pimpl->mappings.reserve(ml.mappings.size());
 
+    return create_backend_buffers(ml.size_data, ctx_map, ml, use_mmap_buffer, use_mlock, n_gpu_layers);
+}
+
+bool llama_model::create_backend_buffers(std::size_t                                                  size_data,
+                                         const std::map<ggml_backend_buffer_type_t, ggml_context *> & ctx_map,
+                                         llama_model_loader & ml, const bool use_mmap_buffer, const bool use_mlock,
+                                         const int32_t n_gpu_layers, bool do_print_backend_buffers_info) {
     // create the backend buffers
     std::vector<std::pair<ggml_context *, llama_buf_map>> ctx_bufs;
     ctx_bufs.reserve(ctx_map.size());
@@ -4296,7 +4303,7 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
     const size_t n_max_backend_buffer = ctx_map.size() * ml.files.size();
     pimpl->bufs.reserve(n_max_backend_buffer);
 
-    for (auto & it : ctx_map) {
+    for (const auto & it : ctx_map) {
         ggml_backend_buffer_type_t buft = it.first;
         ggml_context * ctx              = it.second;
 
@@ -4372,23 +4379,8 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
         ctx_bufs.emplace_back(ctx, buf_map);
     }
 
-    if (llama_supports_gpu_offload()) {
-        const int n_gpu = std::min(n_gpu_layers, int(hparams.n_layer));
-
-        LLAMA_LOG_INFO("%s: offloading %d repeating layers to GPU\n", __func__, n_gpu);
-        if (n_gpu_layers > (int) hparams.n_layer) {
-            LLAMA_LOG_INFO("%s: offloading output layer to GPU\n", __func__);
-        }
-
-        const int max_backend_supported_layers = hparams.n_layer + 1;
-        const int max_offloadable_layers       = hparams.n_layer + 1;
-
-        LLAMA_LOG_INFO("%s: offloaded %d/%d layers to GPU\n", __func__, std::min(n_gpu_layers, max_offloadable_layers), max_backend_supported_layers);
-    }
-
-    // print memory requirements per buffer type
-    for (auto & buf : pimpl->bufs) {
-        LLAMA_LOG_INFO("%s: %12s model buffer size = %8.2f MiB\n", __func__, ggml_backend_buffer_name(buf.get()), ggml_backend_buffer_get_size(buf.get()) / 1024.0 / 1024.0);
+    if(do_print_backend_buffers_info) {
+        print_backend_buffers_info(n_gpu_layers);
     }
 
     // populate tensors_by_name
@@ -4414,6 +4406,29 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
     }
 
     return true;
+}
+
+void llama_model::print_backend_buffers_info(const int32_t n_gpu_layers) {
+    if (llama_supports_gpu_offload()) {
+        const int n_gpu = std::min(n_gpu_layers, int(hparams.n_layer));
+
+        LLAMA_LOG_INFO("%s: offloading %d repeating layers to GPU\n", __func__, n_gpu);
+        if (n_gpu_layers > (int) hparams.n_layer) {
+            LLAMA_LOG_INFO("%s: offloading output layer to GPU\n", __func__);
+        }
+
+        const int max_backend_supported_layers = hparams.n_layer + 1;
+        const int max_offloadable_layers       = hparams.n_layer + 1;
+
+        LLAMA_LOG_INFO("%s: offloaded %d/%d layers to GPU\n", __func__, std::min(n_gpu_layers, max_offloadable_layers),
+                       max_backend_supported_layers);
+    }
+
+    // print memory requirements per buffer type
+    for (auto & buf : pimpl->bufs) {
+        LLAMA_LOG_INFO("%s: %12s model buffer size = %8.2f MiB\n", __func__, ggml_backend_buffer_name(buf.get()),
+                       ggml_backend_buffer_get_size(buf.get()) / 1024.0 / 1024.0);
+    }
 }
 
 std::string llama_model::arch_name() const {

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -17,10 +17,10 @@
 #include <cassert>
 #include <cmath>
 #include <cfloat>
+#include <cstdint>
 #include <cstring>
 #include <cmath>
 #include <functional>
-#include <map>
 #include <regex>
 #include <sstream>
 #include <stdexcept>
@@ -1643,9 +1643,19 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
         ggml_backend_buffer_type_t first_moved_to_buft = nullptr;
 
         auto create_tensor = [&](const LLM_TN_IMPL & tn, const std::initializer_list<int64_t> & ne, int flags) -> ggml_tensor * {
-            ggml_tensor * t_meta = ml.get_tensor_meta(tn.str().c_str());
-
+            const std::string& tensor_name = tn.str();
+            ggml_tensor * t_meta = ml.get_tensor_meta(tensor_name.c_str());
+            std::optional<uint16_t> split_idx;
+            if (!t_meta && (flags & TENSOR_NOT_REQUIRED) &&
+                IncrementalSplitsTensorLoad::tensor_ignored(ml.incremental_splits_tensor_load, tensor_name.c_str())) {
+                return nullptr;
+            }
+            if (ml.incremental_splits_tensor_load.has_value()) {
+                split_idx = ml.incremental_splits_tensor_load->load_tensor_metadata(ml, tn.str().c_str(), &t_meta);
+                LLAMA_LOG_CMAKE_DEBUG("split idx for tensor %s: %d\n", tn.str().c_str(), *split_idx);
+            }
             if (!t_meta) {
+                LLAMA_LOG_ERROR("%s: missing tensor %s\n", __func__ , tn.str().c_str());
                 if (flags & TENSOR_NOT_REQUIRED) {
                     return nullptr;
                 }
@@ -1758,16 +1768,32 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                 }
             }
 
-            ggml_context * ctx = ctx_for_buft(buft);
+            ggml_context * ctx =
+                split_idx.has_value() ?
+                    ml.incremental_splits_tensor_load->get_model_ctx_for_split_buft(buft, *split_idx, pimpl.get()) :
+                    ctx_for_buft(buft);
 
             // if duplicated, check if the original tensor was allocated in the same buffer type context and avoid creating a new one
             if (flags & TENSOR_DUPLICATED) {
-                ggml_tensor * t = ggml_get_tensor(ctx, tn.str().c_str());
+                auto tn_str = tn.str();
+                ggml_tensor * t = ggml_get_tensor(ctx, tn_str.c_str());
                 if (t) {
                     return t;
                 }
+                LLAMA_LOG_WARN("%s: duplicated tensor %s not found on existing context\n", tn_str.c_str(), __func__);
             }
-            return ml.create_tensor(ctx, tn, ne, flags);
+            struct ggml_tensor * tensor = ml.create_tensor(ctx, tn, ne, flags);
+
+            if (split_idx.has_value() && ml.incremental_splits_tensor_load->all_tensors_are_loaded(*split_idx)) {
+                // Upload right now.
+                if (!create_split_backend_buffers(*split_idx, ml.incremental_splits_tensor_load->ctx_split_map, ml,
+                                                  use_mmap_buffer, use_mlock, n_gpu_layers)) {
+                    throw std::runtime_error("Failed to create incremental backend buffers");
+                }
+                IncrementalSplitsTensorLoad::release_split(ml, *split_idx);
+            }
+
+            return tensor;
         };
 
         layers.resize(n_layer);
@@ -4285,10 +4311,37 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
 
     ml.done_getting_tensors();
 
+    if (ml.incremental_splits_tensor_load.has_value()) {
+        // Already did incremental load.
+        print_backend_buffers_info(n_gpu_layers);
+        return true;
+    }
+
     ml.init_mappings(true, use_mlock ? &pimpl->mlock_mmaps : nullptr);
     pimpl->mappings.reserve(ml.mappings.size());
 
     return create_backend_buffers(ml.size_data, ctx_map, ml, use_mmap_buffer, use_mlock, n_gpu_layers);
+}
+
+bool llama_model::create_split_backend_buffers(
+    const uint16_t idx, std::map<std::pair<ggml_backend_buffer_type_t, uint16_t>, ggml_context *> & ctx_split_map,
+    llama_model_loader & ml, const bool use_mmap_buffer, const bool use_mlock, const int32_t n_gpu_layers) {
+    // Extract contexts for the given split index from ctx_split_map into a new map
+    std::map<ggml_backend_buffer_type_t, ggml_context *> ctx_map;
+    for (const auto & [buft_split_idx, ctx] : ctx_split_map) {
+        const auto & [buft, split_idx] = buft_split_idx;
+        if (split_idx == idx) {
+            ctx_map[buft] = ctx;
+        }
+    }
+
+    const std::size_t split_data_size = ml.incremental_splits_tensor_load->get_split_data_size(idx);
+    LLAMA_LOG_CMAKE_DEBUG("%s: creating backend buffers for split %d with size %zu\n", __func__, idx, split_data_size);
+    constexpr bool do_print_backend_buffers_info = false;
+    const bool     creation_success = create_backend_buffers(split_data_size, ctx_map, ml, use_mmap_buffer, use_mlock,
+                                                             n_gpu_layers, do_print_backend_buffers_info);
+
+    return creation_success;
 }
 
 bool llama_model::create_backend_buffers(std::size_t                                                  size_data,

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -4394,7 +4394,7 @@ bool llama_model::create_backend_buffers(std::size_t                            
     for (auto & it : ctx_bufs) {
         ggml_context * ctx = it.first;
         auto & bufs = it.second;
-        if (!ml.load_all_data(ctx, bufs, use_mlock ? &pimpl->mlock_mmaps : NULL, params.progress_callback, params.progress_callback_user_data)) {
+        if (!ml.load_all_data(size_data, ctx, bufs, use_mlock ? &pimpl->mlock_mmaps : NULL, params.progress_callback, params.progress_callback_user_data)) {
             return false;
         }
     }

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -7,10 +7,12 @@
 #include "llama-memory.h"
 #include "llama-vocab.h"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <map>
 
 struct llama_cparams;
 struct llama_ubatch;
@@ -372,6 +374,14 @@ struct llama_model {
 
     explicit llama_model(const struct llama_model_params & params);
     ~llama_model();
+
+    /// @brief Create backend buffers for all tensors
+    bool create_backend_buffers(std::size_t                                                  size_data,
+                                const std::map<ggml_backend_buffer_type_t, ggml_context *> & ctx_map,
+                                llama_model_loader & ml, bool use_mmap_buffer, bool use_mlock, int32_t n_gpu_layers,
+                                bool do_print_backend_buffers_info = true);
+
+    void print_backend_buffers_info(int32_t n_gpu_layers);
 
     void load_stats  (llama_model_loader & ml);
     void load_arch   (llama_model_loader & ml);

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -381,6 +381,11 @@ struct llama_model {
                                 llama_model_loader & ml, bool use_mmap_buffer, bool use_mlock, int32_t n_gpu_layers,
                                 bool do_print_backend_buffers_info = true);
 
+    /// @brief Create backend buffers for tensors on a split file idenfified by `idx`. Removes the split from the map.
+    bool create_split_backend_buffers(
+        uint16_t idx, std::map<std::pair<ggml_backend_buffer_type_t, uint16_t>, ggml_context *> & ctx_split_map,
+        llama_model_loader & ml, bool use_mmap_buffer, bool use_mlock, int32_t n_gpu_layers);
+
     void print_backend_buffers_info(int32_t n_gpu_layers);
 
     void load_stats  (llama_model_loader & ml);

--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -583,7 +583,8 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
     }
 
     std::vector<std::string> splits = {};
-    llama_model_loader ml(fname_inp, splits, use_mmap, /*check_tensors*/ true, kv_overrides, nullptr);
+    load_input_variant::fname_load_input inp{fname_inp, splits};
+    llama_model_loader                   ml(inp, use_mmap, /*check_tensors*/ true, kv_overrides, nullptr);
     ml.init_mappings(false); // no prefetching
 
     llama_model model(llama_model_default_params());

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -248,17 +248,25 @@ struct llama_model * llama_model_load_from_file(
     return llama_model_load_from_file_impl(path_model, splits, params);
 }
 
-struct llama_model * llama_model_load_from_splits(
-        const char ** paths,
-        size_t n_paths,
-        struct llama_model_params params) {
+namespace {
+std::vector<std::string> splits_from_c_paths(const char ** paths, size_t n_paths) {
     std::vector<std::string> splits;
     if (n_paths == 0) {
         LLAMA_LOG_ERROR("%s: list of splits is empty\n", __func__);
-        return nullptr;
+        return splits;
     }
     for (size_t i = 0; i < n_paths; ++i) {
         splits.push_back(paths[i]);
+    }
+    return splits;
+}
+}  // namespace
+
+struct llama_model * llama_model_load_from_splits(const char ** paths, size_t n_paths,
+                                                  struct llama_model_params params) {
+    std::vector<std::string> splits = splits_from_c_paths(paths, n_paths);
+    if (splits.empty()) {
+        return nullptr;
     }
     return llama_model_load_from_file_impl(splits.front(), splits, params);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -197,6 +197,7 @@ llama_build_and_test(test-gguf.cpp)
 llama_build_and_test(test-backend-ops.cpp)
 
 llama_build_and_test(test-model-load-cancel.cpp  LABEL "model")
+llama_build_and_test(test-model-load-disk.cpp    LABEL "model")
 llama_build_and_test(test-autorelease.cpp        LABEL "model")
 
 if (NOT GGML_BACKEND_DL)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ function(llama_build source)
     endif()
 
     add_executable(${TEST_TARGET} ${source})
-    target_link_libraries(${TEST_TARGET} PRIVATE common)
+    target_link_libraries(${TEST_TARGET} PRIVATE common llama-common-test)
     install(TARGETS ${TEST_TARGET} RUNTIME)
 endfunction()
 
@@ -97,7 +97,7 @@ function(llama_build_and_test source)
 
     add_executable(${TEST_TARGET} ${source} get-model.cpp)
     install(TARGETS ${TEST_TARGET} RUNTIME)
-    target_link_libraries(${TEST_TARGET} PRIVATE common)
+    target_link_libraries(${TEST_TARGET} PRIVATE common llama-common-test)
 
     add_test(
         NAME ${TEST_TARGET}
@@ -198,6 +198,8 @@ llama_build_and_test(test-backend-ops.cpp)
 
 llama_build_and_test(test-model-load-cancel.cpp  LABEL "model")
 llama_build_and_test(test-model-load-disk.cpp    LABEL "model")
+llama_build_and_test(test-model-load-memory.cpp  LABEL "model")
+llama_build_and_test(test-model-load-memory-split.cpp LABEL "model")
 llama_build_and_test(test-autorelease.cpp        LABEL "model")
 
 if (NOT GGML_BACKEND_DL)

--- a/tests/test-model-load-disk.cpp
+++ b/tests/test-model-load-disk.cpp
@@ -1,0 +1,41 @@
+#include <cstdlib>
+
+#include "get-model.h"
+#include "llama.h"
+
+int main(int argc, char * argv[]) {
+    auto * model_path = get_model_or_exit(argc, argv);
+    auto * file       = fopen(model_path, "r");
+    if (file == nullptr) {
+        fprintf(stderr, "no model at '%s' found\n", model_path);
+        return EXIT_FAILURE;
+    }
+
+    fprintf(stderr, "using '%s'\n", model_path);
+    fclose(file);
+
+    llama_backend_init();
+    auto params              = llama_model_params{};
+    params.use_mmap          = false;
+    params.progress_callback = [](float progress, void * ctx) {
+        (void) ctx;
+        fprintf(stderr, "%.2f%% ", progress * 100.0f);
+        // true means: Don't cancel the load
+        return true;
+    };
+    auto * model = llama_model_load_from_file(model_path, params);
+
+    // Add newline after progress output
+    fprintf(stderr, "\n");
+
+    if (model == nullptr) {
+        fprintf(stderr, "Failed to load model\n");
+        llama_backend_free();
+        return EXIT_FAILURE;
+    }
+
+    fprintf(stderr, "Model loaded successfully\n");
+    llama_model_free(model);
+    llama_backend_free();
+    return EXIT_SUCCESS;
+}

--- a/tests/test-model-load-memory-split.cpp
+++ b/tests/test-model-load-memory-split.cpp
@@ -1,0 +1,74 @@
+#include <cstdlib>
+#include <thread>
+#include <vector>
+
+#include "get-model.h"
+#include "llama-cpp.h"
+#include "load_into_memory.h"
+
+int main(int argc, char * argv[]) {
+    auto * model_path = get_model_or_exit(argc, argv);
+
+    if (!is_split_file(model_path)) {
+        printf("Skipping not-split model %s\n", model_path);
+        return EXIT_SUCCESS;
+    }
+
+    // Manually load into a memory buffer first
+    file_entry              tensor_list_file = load_tensor_list_file(model_path);
+    std::vector<file_entry> files            = load_files_into_streambuf(model_path);
+
+    llama_backend_init();
+    auto params              = llama_model_params{};
+    params.use_mmap          = false;
+    params.progress_callback = [](float progress, void * ctx) {
+        (void) ctx;
+        fprintf(stderr, "%.2f%% ", progress * 100.0f);
+        // true means: Don't cancel the load
+        return true;
+    };
+
+    printf("Loading model from %zu files\n", files.size());
+
+    std::vector<const char *> file_paths;
+    for (size_t i = 0; i < files.size(); i++) {
+        printf("Found file %s \n", files[i].path.c_str());
+        file_paths.push_back(files[i].path.c_str());
+    }
+
+    const char * async_load_context = "test-model-load";
+    std::thread  fulfill_thread([&files, &tensor_list_file, &async_load_context]() {
+        const bool success = llama_model_load_fulfill_split_future(tensor_list_file.path.c_str(), async_load_context,
+                                                                    std::move(tensor_list_file.streambuf));
+        printf("Fulfilling tensor list file %s: %s\n", tensor_list_file.path.c_str(), success ? "success" : "failure");
+        if (!success) {
+            exit(EXIT_FAILURE);
+        }
+        for (size_t i = 0; i < files.size(); i++) {
+            const bool success = llama_model_load_fulfill_split_future(files[i].path.c_str(), async_load_context,
+                                                                        std::move(files[i].streambuf));
+            printf("Fulfilling file %s: %s\n", files[i].path.c_str(), success ? "success" : "failure");
+            if (!success) {
+                exit(EXIT_FAILURE);
+            }
+        }
+    });
+    fprintf(stderr, "Loading model from splits\n");
+    auto * model = llama_model_load_from_split_futures(file_paths.data(), file_paths.size(), async_load_context,
+                                                       tensor_list_file.path.c_str(), params);
+    fulfill_thread.join();
+
+    fprintf(stderr, "\n");
+
+    if (model == nullptr) {
+        fprintf(stderr, "Failed to load model\n");
+        llama_backend_free();
+        return EXIT_FAILURE;
+    }
+
+    fprintf(stderr, "Model loaded successfully\n");
+    llama_model_free(model);
+    llama_backend_free();
+
+    return EXIT_SUCCESS;
+}

--- a/tests/test-model-load-memory.cpp
+++ b/tests/test-model-load-memory.cpp
@@ -1,0 +1,47 @@
+#include <cstdint>
+#include <cstdlib>
+#include <vector>
+
+#include "get-model.h"
+#include "llama-cpp.h"
+#include "load_into_memory.h"
+
+int main(int argc, char * argv[]) {
+    auto * model_path = get_model_or_exit(argc, argv);
+
+    if (is_split_file(model_path)) {
+        printf("Skipping split model %s\n", model_path);
+        return EXIT_SUCCESS;
+    }
+
+    // Manually load into a memory buffer first
+    std::vector<std::uint8_t> buffer = load_file_into_buffer(model_path);
+
+    llama_backend_init();
+    auto params              = llama_model_params{};
+    params.use_mmap          = false;
+    params.progress_callback = [](float progress, void * ctx) {
+        (void) ctx;
+        fprintf(stderr, "%.2f%% ", progress * 100.0f);
+        // true means: Don't cancel the load
+        return true;
+    };
+
+    // Test that it can load directly from a buffer
+    printf("Loading model from buffer of size %zu bytes\n", buffer.size());
+    auto * model = llama_model_load_from_buffer(std::move(buffer), params);
+
+    // Add newline after progress output
+    fprintf(stderr, "\n");
+
+    if (model == nullptr) {
+        fprintf(stderr, "Failed to load model\n");
+        llama_backend_free();
+        return EXIT_FAILURE;
+    }
+
+    fprintf(stderr, "Model loaded successfully\n");
+    llama_model_free(model);
+    llama_backend_free();
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This pull request makes changes in Llama.cpp in order to be able to load models directly from memory. It is **intended to be reviewable by commit**. Individual commits contain a long text description below the header.

Tested that works properly from a bare Addon (LLM repo). See https://github.com/tetherto/qvac-ext-lib-llama.cpp/pull/1#issuecomment-3188817067

In particular, this PR exposes:
- `llama-cpp.h:llama_model_load_from_buffer(vector<uint8_t>&& data, ...)` to load from a single buffer containing a .gguf file contents.
- `llama.h:llama_model_load_from_split_futures(char** paths, ...)` and `llama-cpp.h:llama_model_load_fulfill_split_future(char* path, ..., unique_ptr<basic_streambuf<uint8_t>>&& streambuf)` which allow to asynchronously/incrementally load a model and upload its tensors to the backend storage while host memory is being released.

### How to run the code?

#### Build and prepare model

Build (e.g. in release mode) LLama.cpp including the examples, tests and tools:
```
cmake -B build -DCMAKE_BUILD_TYPE=Release -DLLAMA_BUILD_TOOLS=ON -DLLAMA_BUILD_TESTS=ON -DLLAMA_BUILD_EXAMPLES=ON -DGGML_VULKAN=ON && cmake --build build
```

Generate a sharded model and its `*.tensor.txt` summary file:
```
./build/bin/llama-gguf-split --split --split-max-size 300M models/qwen3/Qwen3-0.6B-Q8_0.gguf Qwen3-0.6B-Q8_0 &&
 mv Qwen*.* models/qwen3
```

#### Automated tests

Run automated tests for a single `gguf` file:
```
cd build
export LLAMACPP_TEST_MODELFILE=../models/qwen3/Qwen3-0.6B-Q8_0.gguf
ctest -R ^test-model-load-disk$ --verbose
ctest -R ^test-model-load-memory$ --verbose
```

Run automated tests for sharded model:
```
cd build
export LLAMACPP_TEST_MODELFILE=../models/qwen3/Qwen3-0.6B-Q8_0-00001-of-00010.gguf
ctest -R ^test-model-load-disk$ --verbose
ctest -R ^test-model-load-memory-split$ --verbose
```

Or simply run all tests:
```
cd build
export LLAMACPP_TEST_MODELFILE=../models/qwen3/Qwen3-0.6B-Q8_0.gguf
ctest
```

Should output:
```
...
30/41 Test #30: test-backend-ops ..................   Passed  104.24 sec                                                     
      Start 31: test-model-load-cancel                        
31/41 Test #31: test-model-load-cancel ............   Passed    0.34 sec                                                     
      Start 32: test-model-load-disk                          
32/41 Test #32: test-model-load-disk ..............   Passed    0.43 sec                                                     
      Start 33: test-model-load-memory                        
33/41 Test #33: test-model-load-memory ............   Passed    0.00 sec                                                     
      Start 34: test-model-load-memory-split                  
34/41 Test #34: test-model-load-memory-split ......   Passed    0.67 sec 
...
41/41 Test #41: test-eval-callback ................   Passed    0.84 sec

100% tests passed, 0 tests failed out of 41

Label Time Summary:
curl             =   0.84 sec*proc (1 test)
eval-callback    =   0.84 sec*proc (1 test)
main             = 136.15 sec*proc (35 tests)
model            =   1.79 sec*proc (5 tests)
```


#### Examples
Demo video: https://drive.google.com/file/d/1mjqecwJ1LFYUNofr4wIdPFK9IkUxbHZh/view?usp=sharing

Set up the environment:
```
# Do not export any variable to load from disk
# export LLAMA_EXAMPLE_MEMORY_BUFFER=1
export LLAMA_EXAMPLE_MEMORY_BUFFER_SPLIT=1

# Alternatively pass a single .gguf file and set _MEMORY_BUFFER=1
export GGUF_PATH="models/qwen3/Qwen3-0.6B-Q8_0-00001-of-00010.gguf"
```

Run example with Qwen3:
```
/usr/bin/time -v ./build/bin/llama-simple -m "$GGUF_PATH"
```

Outputs:
```
...
print_backend_buffers_info: offloading 28 repeating layers to GPU
print_backend_buffers_info: offloading output layer to GPU
print_backend_buffers_info: offloaded 29/29 layers to GPU
print_backend_buffers_info:      Vulkan0 model buffer size =   199.11 MiB
print_backend_buffers_info:  Vulkan_Host model buffer size =   157.65 MiB
print_backend_buffers_info:      Vulkan0 model buffer size =    44.65 MiB
print_backend_buffers_info:      Vulkan0 model buffer size =    46.78 MiB
print_backend_buffers_info:      Vulkan0 model buffer size =    47.84 MiB
print_backend_buffers_info:      Vulkan0 model buffer size =    45.71 MiB
print_backend_buffers_info:      Vulkan0 model buffer size =    45.71 MiB
print_backend_buffers_info:      Vulkan0 model buffer size =    47.83 MiB
print_backend_buffers_info:      Vulkan0 model buffer size =    47.84 MiB
print_backend_buffers_info:      Vulkan0 model buffer size =    46.78 MiB
print_backend_buffers_info:      Vulkan0 model buffer size =    31.89 MiB
llama_context: constructing llama_context
llama_context: n_batch is less than GGML_KQ_MASK_PAD - increasing to 64
llama_context: n_seq_max     = 1
llama_context: n_ctx         = 35
llama_context: n_ctx_per_seq = 35
llama_context: n_batch       = 64
llama_context: n_ubatch      = 64
llama_context: causal_attn   = 1
llama_context: flash_attn    = 0
llama_context: freq_base     = 1000000.0
llama_context: freq_scale    = 1
llama_context: n_ctx_per_seq (35) < n_ctx_train (40960) -- the full capacity of the model will not be utilized
set_abort_callback: call
llama_context: Vulkan_Host  output buffer size =     0.58 MiB
create_memory: n_ctx = 64 (padded)
llama_kv_cache_unified: layer   0: dev = Vulkan0
llama_kv_cache_unified: layer   1: dev = Vulkan0
llama_kv_cache_unified: layer   2: dev = Vulkan0
llama_kv_cache_unified: layer   3: dev = Vulkan0
llama_kv_cache_unified: layer   4: dev = Vulkan0
llama_kv_cache_unified: layer   5: dev = Vulkan0
llama_kv_cache_unified: layer   6: dev = Vulkan0
llama_kv_cache_unified: layer   7: dev = Vulkan0
llama_kv_cache_unified: layer   8: dev = Vulkan0
llama_kv_cache_unified: layer   9: dev = Vulkan0
llama_kv_cache_unified: layer  10: dev = Vulkan0
llama_kv_cache_unified: layer  11: dev = Vulkan0
llama_kv_cache_unified: layer  12: dev = Vulkan0
llama_kv_cache_unified: layer  13: dev = Vulkan0
llama_kv_cache_unified: layer  14: dev = Vulkan0
llama_kv_cache_unified: layer  15: dev = Vulkan0
llama_kv_cache_unified: layer  16: dev = Vulkan0
llama_kv_cache_unified: layer  17: dev = Vulkan0
llama_kv_cache_unified: layer  18: dev = Vulkan0
llama_kv_cache_unified: layer  19: dev = Vulkan0
llama_kv_cache_unified: layer  20: dev = Vulkan0
llama_kv_cache_unified: layer  21: dev = Vulkan0
llama_kv_cache_unified: layer  22: dev = Vulkan0
llama_kv_cache_unified: layer  23: dev = Vulkan0
llama_kv_cache_unified: layer  24: dev = Vulkan0
llama_kv_cache_unified: layer  25: dev = Vulkan0
llama_kv_cache_unified: layer  26: dev = Vulkan0
llama_kv_cache_unified: layer  27: dev = Vulkan0
llama_kv_cache_unified:    Vulkan0 KV buffer size =     7.00 MiB
llama_kv_cache_unified: size =    7.00 MiB (    64 cells,  28 layers,  1 seqs), K (f16):    3.50 MiB, V (f16):    3.50 MiB
llama_context: enumerating backends
llama_context: backend_ptrs.size() = 2
llama_context: max_nodes = 65536
llama_context: worst-case: n_tokens = 64, n_seqs = 1, n_outputs = 0
graph_reserve: reserving a graph for ubatch with n_tokens =   64, n_seqs =  1, n_outputs =   64
graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
graph_reserve: reserving a graph for ubatch with n_tokens =   64, n_seqs =  1, n_outputs =   64
llama_context:    Vulkan0 compute buffer size =    37.34 MiB
llama_context: Vulkan_Host compute buffer size =     0.27 MiB
llama_context: graph nodes  = 1126
llama_context: graph splits = 2
Hello my name is Emily. I'm a student in the 10th grade. I'm interested in studying in the field of mathematics. I want to kn
ow how to study
main: decoded 32 tokens in 0.18 s, speed: 174.70 t/s

llama_perf_sampler_print:    sampling time =       2.62 ms /    32 runs   (    0.08 ms per token, 12195.12 tokens per second)
llama_perf_context_print:        load time =     402.14 ms
llama_perf_context_print: prompt eval time =      10.13 ms /     4 tokens (    2.53 ms per token,   394.91 tokens per second)
llama_perf_context_print:        eval time =     166.08 ms /    31 runs   (    5.36 ms per token,   186.65 tokens per second)
llama_perf_context_print:       total time =     575.19 ms /    35 tokens

	Command being timed: "./build/bin/llama-simple -m models/qwen3/Qwen3-0.6B-Q8_0-00001-of-00010.gguf"
	User time (seconds): 0.37
	System time (seconds): 0.44
	Percent of CPU this job got: 88%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.93
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 1101056
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 225849
	Voluntary context switches: 796
	Involuntary context switches: 15
	Swaps: 0
	File system inputs: 0
	File system outputs: 32
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```

Run example with GTE:
```
# GGUP_PATH points to gte-large.Q2_K-00001-of-00003.gguf, for example.
/usr/bin/time -v ./build/bin/llama-embedding --model "$GGUF_PATH" --ngl 999
```
---

### Related PRs 
- Memory load in LLM addon repo: https://github.com/tetherto/qvac-lib-infer-llamacpp-llm/pull/195
- Base inference JS class to allow shards loading. https://github.com/tetherto/qvac-lib-infer-base/pull/39
- Fix crash in LLM addon repo https://github.com/tetherto/qvac-lib-infer-llamacpp-llm/pull/194

---

Asana task: https://app.asana.com/1/45238840754660/project/1210873391319186/task/1210877463428607

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210808419738807
  - https://app.asana.com/0/0/1211101393331301
  - https://app.asana.com/0/0/1210877010305812
  - https://app.asana.com/0/0/1210830869333789
  - https://app.asana.com/0/0/1210883423009174
  - https://app.asana.com/0/0/1210703441899425
  - https://app.asana.com/0/0/1210820764621514
  - https://app.asana.com/0/0/1210798482276719
  - https://app.asana.com/0/0/1210808419738803
  - https://app.asana.com/0/0/1210808419738805