### PR TITLE
QVAC-6093: Stream shards. Fixup for MSVC.

### DIFF
--- a/ggml/include/gguf.h
+++ b/ggml/include/gguf.h
@@ -200,7 +200,7 @@ extern "C" {
 }
 #endif
 
-#if defined(__cplusplus) && __cplusplus >= 201703L
+#if defined(__cplusplus)
 #include <streambuf>
 GGML_API struct gguf_context * gguf_init_from_buffer(std::basic_streambuf<char>& streambuf, struct gguf_init_params params);
 #endif


### PR DESCRIPTION
Quickfix: Remove the additional guard, rely only on CMake standard already set. This change fixes as well windows-2022 CI CUDA of Llama.cpp https://github.com/tetherto/qvac-ext-lib-llama.cpp/actions/runs/18130671401/job/51596331956

MSVC does not seem to set `__cplusplus` properly or some options are missing when building with bare even though the project is clearly compiling with C++17. The original intent was to protect `char` guarantees from C++17 but the guard is causing compilation issues at https://github.com/tetherto/qvac-lib-infer-llamacpp-llm/actions/runs/18129284678/job/51592799058?pr=250 (when `cl.exe` is triggered instead of `clang-cl.exe` see log below).

```
  -- The C compiler identification is MSVC 19.44.35217.0
  -- The CXX compiler identification is MSVC 19.44.35217.0

...

  FAILED: src/CMakeFiles/llama.dir/llama-model-load.cpp.obj 
  C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x64\cl.exe   /TP -DGGML_USE_CPU -DGGML_USE_VULKAN -D_CRT_SECURE_NO_WARNINGS -IC:\vcpkg\buildtrees\llama-cpp\src\b6435.1.0-b040a7e18f.clean\src\. -IC:\vcpkg\buildtrees\llama-cpp\src\b6435.1.0-b040a7e18f.clean\include -IC:\vcpkg\buildtrees\llama-cpp\src\b6435.1.0-b040a7e18f.clean\ggml\src\..\include /nologo /DWIN32 /D_WINDOWS /utf-8 /GR /EHsc /MP  /MTd /Z7 /Ob0 /Od /RTC1  -std:c++17 /utf-8 /bigobj /showIncludes /Fosrc\CMakeFiles\llama.dir\llama-model-load.cpp.obj /Fdsrc\CMakeFiles\llama.dir\llama.pdb /FS -c C:\vcpkg\buildtrees\llama-cpp\src\b6435.1.0-b040a7e18f.clean\src\llama-model-load.cpp
  C:\vcpkg\buildtrees\llama-cpp\src\b6435.1.0-b040a7e18f.clean\src\llama-model-load.cpp(28): error C3861: 'gguf_init_from_buffer': identifier not found
  C:\vcpkg\buildtrees\llama-cpp\src\b6435.1.0-b040a7e18f.clean\src\llama-model-load.cpp(35): error C3861: 'gguf_init_from_buffer': identifier not found
  ```
  https://learn.microsoft.com/en-us/cpp/build/reference/compiler-options?view=msvc-170
> cl.exe is a tool that controls the Microsoft C++ (MSVC) C and C++ compilers and linker. cl.exe can be run only on operating systems that support Microsoft Visual Studio for Windows.

Tried `/Zc:__cplusplus` on our Addon but does still does not seem to solve it since it does not apply to the Llama.cpp libraries https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170 (note that bare still forces clang compiler) however due to the toolchain still seem to behave differently regarding `__cplusplus`).

This issue pass over Llama.cpp CI which seems not to rely on MSVC tools (cl.exe is used instead of clang-cl.exe). This might be silently compiling code for older C++ versions in our builds with MSVC toolchain in the rest of the codebase where `__cplusplus` is relied upon (Not solved with this PR).

Related support task: "Prebuilds for Windows use MSVC (cl.exe) instead of Clang (clang-cl.exe) "  https://app.asana.com/1/45238840754660/project/1209995579906894/task/1211510077111151