### PR TITLE
QVAC-6093: Stream shards. Fixup for gradle.

### DIFF
--- a/ggml/include/gguf.h
+++ b/ggml/include/gguf.h
@@ -201,6 +201,6 @@ extern "C" {
 #endif
 
 #if defined(__cplusplus) && __cplusplus >= 201703L
-#include <ios>
+#include <streambuf>
 GGML_API struct gguf_context * gguf_init_from_buffer(std::basic_streambuf<char>& streambuf, struct gguf_init_params params);
 #endif


### PR DESCRIPTION
Fixup gradle build for Llama.cpp. Found out the issue when locally running their gradle example, even though it works with  bare when compiling for Android we should fix it here as well. Missed on Llama.cpp CI because Android was currently misconfigured not running properly the compilation test.

Discovered when doing a deeper analysis of CI in this task: https://app.asana.com/1/45238840754660/task/1211510077111155/comment/1211510580236851?focus=true