### PR TITLE
QVAC-6158: Fix CI MacOS x64 on Tether runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,7 @@ jobs:
             -DCMAKE_BUILD_RPATH="@loader_path" \
             -DLLAMA_FATAL_WARNINGS=ON \
             -DGGML_METAL=OFF \
+            -DGGML_BLAS=OFF \
             -DGGML_RPC=ON
           cmake --build build --config Release -j $(sysctl -n hw.logicalcpu)
 


### PR DESCRIPTION
Our runner  for MacOS failes due to blas only available on 13.3 or newer. Our minor version is incompatible. There are two options, disabling BLAS or trying to upgrade to MacOS 14.
```
Macos latest cmake x64 /Users/runner/work/qvac-ext-lib-llama.cpp/qvac-ext-lib-llama.cpp/ggml/src/ggml-blas/ggml-blas.cpp:143:13: error: 'cblas_sgemm' is only available on macOS 13.3 or newer [-Werror,-Wunguarded-availability-new]
```

- Upgrading to MacOS 14 skip the test since we do not have a MacOS-14 runner for Darwin.
- Final solution: Setting `-DGGML_BLAS=OFF` for Macos-13 x64

See macos-x64 now passing on CI https://github.com/tetherto/qvac-ext-lib-llama.cpp/actions/runs/18159927420/job/51688258752?pr=26#logs
