### PR TITLE
QVAC-6158: Fix CI cmake pkg on Tether fork

### DIFF
--- a/.github/workflows/build-cmake-pkg.yml
+++ b/.github/workflows/build-cmake-pkg.yml
@@ -25,7 +25,7 @@ jobs:
           cmake --build build --config Release
           cmake --install build --prefix "$PREFIX" --config Release
 
-          export LLAMA_CONFIG="$PREFIX"/lib/cmake/llama/llama-config.cmake
+          export LLAMA_CONFIG="$PREFIX"/share/llama/llama-config.cmake
           tclsh <<'EOF'
           set build(commit)  [string trim [exec git rev-parse --short HEAD]]
           set build(number)  [string trim [exec git rev-list  --count HEAD]]
@@ -47,5 +47,5 @@ jobs:
           EOF
 
           cd examples/simple-cmake-pkg
-          cmake -S . -B build -DCMAKE_PREFIX_PATH="$PREFIX"/lib/cmake
+          cmake -S . -B build -DCMAKE_PREFIX_PATH="$PREFIX"/share
           cmake --build build

--- a/examples/simple-cmake-pkg/CMakeLists.txt
+++ b/examples/simple-cmake-pkg/CMakeLists.txt
@@ -7,5 +7,5 @@ find_package(Llama REQUIRED)
 
 add_executable(${TARGET} ${CMAKE_CURRENT_LIST_DIR}/../simple/simple.cpp)
 install(TARGETS ${TARGET} RUNTIME)
-target_link_libraries(${TARGET} PRIVATE llama ggml::all ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET} PRIVATE llama::llama ggml::all ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_17)


### PR DESCRIPTION
Our install path is not based on `/lib` but `/shared`. Update the workflow so that the files are found on the correct folder for our fork. In addition, CMake needs to link against `llama::llama` not `llama` to be able to find the correct include directories.

See CI for cmake-pkg now green: https://github.com/tetherto/qvac-ext-lib-llama.cpp/actions/runs/18161795175/job/51694115100?pr=27#logs

Seems to be related to this changes that we introduced in our fork:
```
install(
  EXPORT llama-targets
  FILE llama-targets.cmake
  NAMESPACE llama::
  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)

install(
  FILES ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
 ```
 
>  CMAKE_INSTALL_DATAROOTDIR is a CMake variable that defines the root directory for read-only architecture-independent data files, with a default value of "share".
>  This variable is part of the GNUInstallDirs module, which provides standard installation directory variables as defined by the GNU Coding Standards.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211520305208299