### PR TITLE
Revert to C style construciton for termux portability

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -5098,12 +5098,18 @@ static vk_device ggml_vk_get_device(size_t idx) {
 #endif
         device->name = GGML_VK_NAME + std::to_string(idx);
 
-        device_create_info = {
+        // Counts + pointers: the ArrayProxy constructor is unavailable when
+        // Vulkan-Hpp is built with VULKAN_HPP_DISABLE_ENHANCED_MODE (e.g. Termux).
+        device_create_info = vk::DeviceCreateInfo(
             vk::DeviceCreateFlags(),
-            device_queue_create_infos,
-            {},
-            device_extensions
-        };
+            static_cast<uint32_t>(device_queue_create_infos.size()),
+            device_queue_create_infos.data(),
+            0u,
+            nullptr,
+            static_cast<uint32_t>(device_extensions.size()),
+            device_extensions.data(),
+            nullptr,
+            nullptr);
         device_create_info.setPNext(&device_features2);
         device->device = device->physical_device.createDevice(device_create_info);
 


### PR DESCRIPTION
Needed pkg in termux: 
```
git git-lfs cmake vulkan-tools vulkan-headers shaderc vulkan-loader-android libandroid-spawn
```

In termux when compiling with `-DGGML_VULKAN=ON` there seems to be a hard crash. This has to due with how the contructor for a vulkan device is setup. Reverting back to an older C style seems to solve this for Termux on Android. 

See error:
```
In file included from /data/data/com.termux/files/home/qvac-fabric-llm.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp:30:
/data/data/com.termux/files/home/qvac-fabric-llm.cpp/ggml/src/ggml-vulkan/../../../vendor/vma/VmaUsage.h:106:36: warning: 
      unknown warning group '-Wsuggest-attribute=noreturn', ignored [-Wunknown-warning-option]
  106 |     #pragma GCC diagnostic ignored "-Wsuggest-attribute=noreturn"
      |                                    ^
/data/data/com.termux/files/home/qvac-fabric-llm.cpp/ggml/src/ggml-vulkan/ggml-vulkan.cpp:5101:28: error: 
      no viable overloaded '='
 5101 |         device_create_info = {
      |         ~~~~~~~~~~~~~~~~~~ ^ ~
 5102 |             vk::DeviceCreateFlags(),
      |             ~~~~~~~~~~~~~~~~~~~~~~~~
 5103 |             device_queue_create_infos,
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~
 5104 |             {},
      |             ~~~
 5105 |             device_extensions
      |             ~~~~~~~~~~~~~~~~~
 5106 |         };
      |         ~
/data/data/com.termux/files/usr/bin/../../usr/include/vulkan/vulkan_structs.hpp:50280:24: note: 
      candidate function not viable: cannot convert initializer list argument to 'const DeviceCreateInfo'
 50280 |     DeviceCreateInfo & operator=( DeviceCreateInfo const & rhs ) VULKAN_HPP_NOEXCEPT = default;
       |                        ^          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/data/com.termux/files/usr/bin/../../usr/include/vulkan/vulkan_structs.hpp:50294:24: note: 
      candidate function not viable: cannot convert initializer list argument to 'const VkDeviceCreateInfo'
 50294 |     DeviceCreateInfo & operator=( VkDeviceCreateInfo const & rhs ) VULKAN_HPP_NOEXCEPT
       |                        ^          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning and 1 error generated.
make[2]: *** [ggml/src/ggml-vulkan/CMakeFiles/ggml-vulkan.dir/build.make:1016: ggml/src/ggml-vulkan/CMakeFiles/ggml-vulkan.dir/ggml-vulkan.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2317: ggml/src/ggml-vulkan/CMakeFiles/ggml-vulkan.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```
