### PR TITLE
QVAC-16422 : Add build option EXPORT_ONLY_GGML to qvac-fabric.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ else()
 endif()
 
 option(LLAMA_USE_SYSTEM_GGML "Use system libggml" OFF)
-option(EXPORT_ONLY_GGML "Build, install only ggml package artifacts" OFF)
+option(BUILD_LLAMA "Build, install LLAMA package artifacts as well." ON)
 
 option(LLAMA_WASM_MEM64 "llama: use 64-bit memory in WASM builds" ON)
 
@@ -209,7 +209,7 @@ endif()
 # build the library
 #
 
-if (NOT EXPORT_ONLY_GGML)
+if (BUILD_LLAMA)
     add_subdirectory(src)
 
     #
@@ -258,7 +258,7 @@ endif()
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-if (NOT EXPORT_ONLY_GGML)
+if (BUILD_LLAMA)
     set(LLAMA_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR}/llama CACHE PATH "Location of header  files")
     set(LLAMA_LIB_INSTALL_DIR     ${CMAKE_INSTALL_LIBDIR}     CACHE PATH "Location of library files")
     set(LLAMA_BIN_INSTALL_DIR     ${CMAKE_INSTALL_BINDIR}     CACHE PATH "Location of binary  files")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,24 +272,24 @@ set_target_properties(llama
         PUBLIC_HEADER "${LLAMA_PUBLIC_HEADERS}")
 
 install(
-    TARGETS llama
-    EXPORT llama-targets
-    PUBLIC_HEADER
+  TARGETS llama
+  EXPORT llama-targets
+  PUBLIC_HEADER
     DESTINATION ${LLAMA_INCLUDE_INSTALL_DIR})
 
 if (LLAMA_BUILD_COMMON)
 
-    if (NOT LLAMA_CURL AND LLAMA_HTTPLIB)
+  if (NOT LLAMA_CURL AND LLAMA_HTTPLIB)
     install(
-        TARGETS cpp-httplib
-        EXPORT llama-targets)
-    endif()
+      TARGETS cpp-httplib
+      EXPORT llama-targets)
+  endif()
 
-    install(
+  install(
     TARGETS common build_info
     EXPORT llama-targets
     PUBLIC_HEADER
-        DESTINATION ${LLAMA_INCLUDE_INSTALL_DIR}/common)
+      DESTINATION ${LLAMA_INCLUDE_INSTALL_DIR}/common)
 
 endif()
 
@@ -304,19 +304,19 @@ if (LLAMA_MTMD AND TARGET mtmd)
 endif()
 
 install(
-    EXPORT llama-targets
-    FILE llama-targets.cmake
-    NAMESPACE llama::
-    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
+  EXPORT llama-targets
+  FILE llama-targets.cmake
+  NAMESPACE llama::
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
 
 install(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
-    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
 
 configure_package_config_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/llama-config.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
-    INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/llama-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
 
 write_basic_package_version_file(
         ${CMAKE_CURRENT_BINARY_DIR}/llama-version.cmake
@@ -324,7 +324,7 @@ write_basic_package_version_file(
     COMPATIBILITY SameMajorVersion)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
-                ${CMAKE_CURRENT_BINARY_DIR}/llama-version.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/llama-version.cmake
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,9 @@ endif()
 # build the library
 #
 
-if (BUILD_LLAMA)
+if (NOT BUILD_LLAMA)
+    message(STATUS "BUILD_LLAMA is OFF: skipping LLAMA targets.")
+else()
 add_subdirectory(src)
 
 #
@@ -247,8 +249,7 @@ if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_TOOLS)
 elseif (LLAMA_MTMD)
     add_subdirectory(tools/mtmd)
 endif()
-else()
-    message(STATUS "EXPORT_ONLY_GGML is ON: skipping qvac-fabric targets")
+
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,43 +210,43 @@ endif()
 #
 
 if (BUILD_LLAMA)
-    add_subdirectory(src)
+add_subdirectory(src)
 
-    #
-    # utils, programs, examples and tests
-    #
+#
+# utils, programs, examples and tests
+#
 
-    if (NOT LLAMA_BUILD_COMMON)
-        message(STATUS "LLAMA_BUILD_COMMON is OFF, disabling LLAMA_CURL")
-        set(LLAMA_CURL OFF)
+if (NOT LLAMA_BUILD_COMMON)
+    message(STATUS "LLAMA_BUILD_COMMON is OFF, disabling LLAMA_CURL")
+    set(LLAMA_CURL OFF)
+endif()
+
+if (LLAMA_BUILD_COMMON)
+    add_subdirectory(common)
+    if (LLAMA_HTTPLIB)
+        add_subdirectory(vendor/cpp-httplib)
     endif()
+endif()
 
-    if (LLAMA_BUILD_COMMON)
-        add_subdirectory(common)
-        if (LLAMA_HTTPLIB)
-            add_subdirectory(vendor/cpp-httplib)
-        endif()
-    endif()
+if(LLAMA_BUILD_EXAMPLES OR LLAMA_BUILD_TESTS)
+    add_subdirectory(common_test)
+endif()
 
-    if(LLAMA_BUILD_EXAMPLES OR LLAMA_BUILD_TESTS)
-        add_subdirectory(common_test)
-    endif()
+if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_TESTS AND NOT CMAKE_JS_VERSION)
+    include(CTest)
+    add_subdirectory(tests)
+endif()
 
-    if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_TESTS AND NOT CMAKE_JS_VERSION)
-        include(CTest)
-        add_subdirectory(tests)
-    endif()
+if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+    add_subdirectory(pocs)
+endif()
 
-    if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_EXAMPLES)
-        add_subdirectory(examples)
-        add_subdirectory(pocs)
-    endif()
-
-    if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_TOOLS)
-        add_subdirectory(tools)
-    elseif (LLAMA_MTMD)
-        add_subdirectory(tools/mtmd)
-    endif()
+if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_TOOLS)
+    add_subdirectory(tools)
+elseif (LLAMA_MTMD)
+    add_subdirectory(tools/mtmd)
+endif()
 else()
     message(STATUS "EXPORT_ONLY_GGML is ON: skipping qvac-fabric targets")
 endif()
@@ -259,94 +259,94 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 if (BUILD_LLAMA)
-    set(LLAMA_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR}/llama CACHE PATH "Location of header  files")
-    set(LLAMA_LIB_INSTALL_DIR     ${CMAKE_INSTALL_LIBDIR}     CACHE PATH "Location of library files")
-    set(LLAMA_BIN_INSTALL_DIR     ${CMAKE_INSTALL_BINDIR}     CACHE PATH "Location of binary  files")
+set(LLAMA_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR}/llama CACHE PATH "Location of header  files")
+set(LLAMA_LIB_INSTALL_DIR     ${CMAKE_INSTALL_LIBDIR}     CACHE PATH "Location of library files")
+set(LLAMA_BIN_INSTALL_DIR     ${CMAKE_INSTALL_BINDIR}     CACHE PATH "Location of binary  files")
 
-    set(LLAMA_PUBLIC_HEADERS
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/llama.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/llama-cpp.h)
+set(LLAMA_PUBLIC_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/llama.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/llama-cpp.h)
 
-    set_target_properties(llama
-        PROPERTIES
-            PUBLIC_HEADER "${LLAMA_PUBLIC_HEADERS}")
+set_target_properties(llama
+    PROPERTIES
+        PUBLIC_HEADER "${LLAMA_PUBLIC_HEADERS}")
 
+install(
+    TARGETS llama
+    EXPORT llama-targets
+    PUBLIC_HEADER
+    DESTINATION ${LLAMA_INCLUDE_INSTALL_DIR})
+
+if (LLAMA_BUILD_COMMON)
+
+    if (NOT LLAMA_CURL AND LLAMA_HTTPLIB)
     install(
-      TARGETS llama
-      EXPORT llama-targets
-      PUBLIC_HEADER
-        DESTINATION ${LLAMA_INCLUDE_INSTALL_DIR})
-
-    if (LLAMA_BUILD_COMMON)
-
-      if (NOT LLAMA_CURL AND LLAMA_HTTPLIB)
-        install(
-          TARGETS cpp-httplib
-          EXPORT llama-targets)
-      endif()
-
-      install(
-        TARGETS common build_info
-        EXPORT llama-targets
-        PUBLIC_HEADER
-          DESTINATION ${LLAMA_INCLUDE_INSTALL_DIR}/common)
-
-    endif()
-
-    if (LLAMA_MTMD AND TARGET mtmd)
-
-      install(
-        TARGETS mtmd
-        EXPORT llama-targets
-        PUBLIC_HEADER
-          DESTINATION ${LLAMA_INCLUDE_INSTALL_DIR}/mtmd)
-
+        TARGETS cpp-httplib
+        EXPORT llama-targets)
     endif()
 
     install(
-      EXPORT llama-targets
-      FILE llama-targets.cmake
-      NAMESPACE llama::
-      DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
+    TARGETS common build_info
+    EXPORT llama-targets
+    PUBLIC_HEADER
+        DESTINATION ${LLAMA_INCLUDE_INSTALL_DIR}/common)
+
+endif()
+
+if (LLAMA_MTMD AND TARGET mtmd)
 
     install(
-      FILES ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
-      DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
+    TARGETS mtmd
+    EXPORT llama-targets
+    PUBLIC_HEADER
+        DESTINATION ${LLAMA_INCLUDE_INSTALL_DIR}/mtmd)
 
-    configure_package_config_file(
-      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/llama-config.cmake.in
-      ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
-      INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
+endif()
 
-    write_basic_package_version_file(
-            ${CMAKE_CURRENT_BINARY_DIR}/llama-version.cmake
-        VERSION ${LLAMA_INSTALL_VERSION}
-        COMPATIBILITY SameMajorVersion)
+install(
+    EXPORT llama-targets
+    FILE llama-targets.cmake
+    NAMESPACE llama::
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
 
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
-                  ${CMAKE_CURRENT_BINARY_DIR}/llama-version.cmake
-            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
 
-    install(
-        FILES convert_hf_to_gguf.py
-        PERMISSIONS
-            OWNER_READ
-            OWNER_WRITE
-            OWNER_EXECUTE
-            GROUP_READ
-            GROUP_EXECUTE
-            WORLD_READ
-            WORLD_EXECUTE
-        DESTINATION ${CMAKE_INSTALL_BINDIR})
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/llama-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
 
-    install(
-        PROGRAMS vulkan_profiling_analyzer.py
-        DESTINATION ${CMAKE_INSTALL_BINDIR})
+write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/llama-version.cmake
+    VERSION ${LLAMA_INSTALL_VERSION}
+    COMPATIBILITY SameMajorVersion)
 
-    configure_file(cmake/llama.pc.in
-            "${CMAKE_CURRENT_BINARY_DIR}/llama.pc"
-            @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
+                ${CMAKE_CURRENT_BINARY_DIR}/llama-version.cmake
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
 
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/llama.pc"
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+install(
+    FILES convert_hf_to_gguf.py
+    PERMISSIONS
+        OWNER_READ
+        OWNER_WRITE
+        OWNER_EXECUTE
+        GROUP_READ
+        GROUP_EXECUTE
+        WORLD_READ
+        WORLD_EXECUTE
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+install(
+    PROGRAMS vulkan_profiling_analyzer.py
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+configure_file(cmake/llama.pc.in
+        "${CMAKE_CURRENT_BINARY_DIR}/llama.pc"
+        @ONLY)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/llama.pc"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,11 +295,11 @@ endif()
 
 if (LLAMA_MTMD AND TARGET mtmd)
 
-    install(
+  install(
     TARGETS mtmd
     EXPORT llama-targets
     PUBLIC_HEADER
-        DESTINATION ${LLAMA_INCLUDE_INSTALL_DIR}/mtmd)
+      DESTINATION ${LLAMA_INCLUDE_INSTALL_DIR}/mtmd)
 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ else()
 endif()
 
 option(LLAMA_USE_SYSTEM_GGML "Use system libggml" OFF)
+option(EXPORT_ONLY_GGML "Build, install only ggml package artifacts" OFF)
 
 option(LLAMA_WASM_MEM64 "llama: use 64-bit memory in WASM builds" ON)
 
@@ -208,42 +209,46 @@ endif()
 # build the library
 #
 
-add_subdirectory(src)
+if (NOT EXPORT_ONLY_GGML)
+    add_subdirectory(src)
 
-#
-# utils, programs, examples and tests
-#
+    #
+    # utils, programs, examples and tests
+    #
 
-if (NOT LLAMA_BUILD_COMMON)
-    message(STATUS "LLAMA_BUILD_COMMON is OFF, disabling LLAMA_CURL")
-    set(LLAMA_CURL OFF)
-endif()
-
-if (LLAMA_BUILD_COMMON)
-    add_subdirectory(common)
-    if (LLAMA_HTTPLIB)
-        add_subdirectory(vendor/cpp-httplib)
+    if (NOT LLAMA_BUILD_COMMON)
+        message(STATUS "LLAMA_BUILD_COMMON is OFF, disabling LLAMA_CURL")
+        set(LLAMA_CURL OFF)
     endif()
-endif()
 
-if(LLAMA_BUILD_EXAMPLES OR LLAMA_BUILD_TESTS)
-    add_subdirectory(common_test)
-endif()
+    if (LLAMA_BUILD_COMMON)
+        add_subdirectory(common)
+        if (LLAMA_HTTPLIB)
+            add_subdirectory(vendor/cpp-httplib)
+        endif()
+    endif()
 
-if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_TESTS AND NOT CMAKE_JS_VERSION)
-    include(CTest)
-    add_subdirectory(tests)
-endif()
+    if(LLAMA_BUILD_EXAMPLES OR LLAMA_BUILD_TESTS)
+        add_subdirectory(common_test)
+    endif()
 
-if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_EXAMPLES)
-    add_subdirectory(examples)
-    add_subdirectory(pocs)
-endif()
+    if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_TESTS AND NOT CMAKE_JS_VERSION)
+        include(CTest)
+        add_subdirectory(tests)
+    endif()
 
-if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_TOOLS)
-    add_subdirectory(tools)
-elseif (LLAMA_MTMD)
-    add_subdirectory(tools/mtmd)
+    if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_EXAMPLES)
+        add_subdirectory(examples)
+        add_subdirectory(pocs)
+    endif()
+
+    if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_TOOLS)
+        add_subdirectory(tools)
+    elseif (LLAMA_MTMD)
+        add_subdirectory(tools/mtmd)
+    endif()
+else()
+    message(STATUS "EXPORT_ONLY_GGML is ON: skipping qvac-fabric targets")
 endif()
 
 #
@@ -253,93 +258,95 @@ endif()
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-set(LLAMA_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR}/llama CACHE PATH "Location of header  files")
-set(LLAMA_LIB_INSTALL_DIR     ${CMAKE_INSTALL_LIBDIR}     CACHE PATH "Location of library files")
-set(LLAMA_BIN_INSTALL_DIR     ${CMAKE_INSTALL_BINDIR}     CACHE PATH "Location of binary  files")
+if (NOT EXPORT_ONLY_GGML)
+    set(LLAMA_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR}/llama CACHE PATH "Location of header  files")
+    set(LLAMA_LIB_INSTALL_DIR     ${CMAKE_INSTALL_LIBDIR}     CACHE PATH "Location of library files")
+    set(LLAMA_BIN_INSTALL_DIR     ${CMAKE_INSTALL_BINDIR}     CACHE PATH "Location of binary  files")
 
-set(LLAMA_PUBLIC_HEADERS
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/llama.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/llama-cpp.h)
+    set(LLAMA_PUBLIC_HEADERS
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/llama.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/llama-cpp.h)
 
-set_target_properties(llama
-    PROPERTIES
-        PUBLIC_HEADER "${LLAMA_PUBLIC_HEADERS}")
+    set_target_properties(llama
+        PROPERTIES
+            PUBLIC_HEADER "${LLAMA_PUBLIC_HEADERS}")
 
-install(
-  TARGETS llama
-  EXPORT llama-targets
-  PUBLIC_HEADER
-    DESTINATION ${LLAMA_INCLUDE_INSTALL_DIR})
-
-if (LLAMA_BUILD_COMMON)
-
-  if (NOT LLAMA_CURL AND LLAMA_HTTPLIB)
     install(
-      TARGETS cpp-httplib
-      EXPORT llama-targets)
-  endif()
+      TARGETS llama
+      EXPORT llama-targets
+      PUBLIC_HEADER
+        DESTINATION ${LLAMA_INCLUDE_INSTALL_DIR})
 
-  install(
-    TARGETS common build_info
-    EXPORT llama-targets
-    PUBLIC_HEADER
-      DESTINATION ${LLAMA_INCLUDE_INSTALL_DIR}/common)
+    if (LLAMA_BUILD_COMMON)
 
+      if (NOT LLAMA_CURL AND LLAMA_HTTPLIB)
+        install(
+          TARGETS cpp-httplib
+          EXPORT llama-targets)
+      endif()
+
+      install(
+        TARGETS common build_info
+        EXPORT llama-targets
+        PUBLIC_HEADER
+          DESTINATION ${LLAMA_INCLUDE_INSTALL_DIR}/common)
+
+    endif()
+
+    if (LLAMA_MTMD AND TARGET mtmd)
+
+      install(
+        TARGETS mtmd
+        EXPORT llama-targets
+        PUBLIC_HEADER
+          DESTINATION ${LLAMA_INCLUDE_INSTALL_DIR}/mtmd)
+
+    endif()
+
+    install(
+      EXPORT llama-targets
+      FILE llama-targets.cmake
+      NAMESPACE llama::
+      DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
+
+    install(
+      FILES ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
+      DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
+
+    configure_package_config_file(
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/llama-config.cmake.in
+      ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
+      INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
+
+    write_basic_package_version_file(
+            ${CMAKE_CURRENT_BINARY_DIR}/llama-version.cmake
+        VERSION ${LLAMA_INSTALL_VERSION}
+        COMPATIBILITY SameMajorVersion)
+
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
+                  ${CMAKE_CURRENT_BINARY_DIR}/llama-version.cmake
+            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
+
+    install(
+        FILES convert_hf_to_gguf.py
+        PERMISSIONS
+            OWNER_READ
+            OWNER_WRITE
+            OWNER_EXECUTE
+            GROUP_READ
+            GROUP_EXECUTE
+            WORLD_READ
+            WORLD_EXECUTE
+        DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+    install(
+        PROGRAMS vulkan_profiling_analyzer.py
+        DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+    configure_file(cmake/llama.pc.in
+            "${CMAKE_CURRENT_BINARY_DIR}/llama.pc"
+            @ONLY)
+
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/llama.pc"
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()
-
-if (LLAMA_MTMD AND TARGET mtmd)
-
-  install(
-    TARGETS mtmd
-    EXPORT llama-targets
-    PUBLIC_HEADER
-      DESTINATION ${LLAMA_INCLUDE_INSTALL_DIR}/mtmd)
-
-endif()
-
-install(
-  EXPORT llama-targets
-  FILE llama-targets.cmake
-  NAMESPACE llama::
-  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
-
-install(
-  FILES ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
-  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
-
-configure_package_config_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/llama-config.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
-  INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
-
-write_basic_package_version_file(
-        ${CMAKE_CURRENT_BINARY_DIR}/llama-version.cmake
-    VERSION ${LLAMA_INSTALL_VERSION}
-    COMPATIBILITY SameMajorVersion)
-
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/llama-config.cmake
-              ${CMAKE_CURRENT_BINARY_DIR}/llama-version.cmake
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/llama)
-
-install(
-    FILES convert_hf_to_gguf.py
-    PERMISSIONS
-        OWNER_READ
-        OWNER_WRITE
-        OWNER_EXECUTE
-        GROUP_READ
-        GROUP_EXECUTE
-        WORLD_READ
-        WORLD_EXECUTE
-    DESTINATION ${CMAKE_INSTALL_BINDIR})
-
-install(
-    PROGRAMS vulkan_profiling_analyzer.py
-    DESTINATION ${CMAKE_INSTALL_BINDIR})
-
-configure_file(cmake/llama.pc.in
-        "${CMAKE_CURRENT_BINARY_DIR}/llama.pc"
-        @ONLY)
-
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/llama.pc"
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)


### PR DESCRIPTION
Add build option BUILD_LLAMA to qvac-fabric defaulted to yes. LLAMA builds and install are only done if this option is set to yes.
Main usage to be from the translation addon.