### PR TITLE
chore(codeowners): collapse ai-runtime-bk* and ai-runtime-merge -> qvac-internal-{dev,merge}

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tetherto/ai-runtime-bk-models
+* @tetherto/qvac-internal-dev


### PR DESCRIPTION
## Why

Migrating CODEOWNERS to the new internal teams created for the QVAC org structure, and collapsing the deprecated `ai-runtime-bk*` sub-teams.

Mapping applied:

- `@tetherto/ai-runtime-bk` and all `@tetherto/ai-runtime-bk-{apps,core,addons,models}` sub-teams → `@tetherto/qvac-internal-dev`
- `@tetherto/ai-runtime-merge` → `@tetherto/qvac-internal-merge`

Other teams referenced by this repo (e.g. `@tetherto/qvac-health-merge`) are left untouched.

## Diff

Before:

```
* @tetherto/ai-runtime-bk-models
```

After:

```
* @tetherto/qvac-internal-dev
```

## Validation

- Confirmed both target teams exist under `tetherto`.
- Confirmed write access for the target teams on this repo (with the noted exception above, if any).
- All deprecated `ai-runtime-bk*` sub-teams removed.
