### PR TITLE
Inject enable_thinking into the Jinja template context

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -815,6 +815,7 @@ static std::string apply(
         {"messages", messages_override.has_value() ? *messages_override : inputs.messages},
         {"bos_token", tmpl.bos_token()},
         {"eos_token", tmpl.eos_token()},
+        {"enable_thinking", inputs.enable_thinking},
     };
     if (tools_override.has_value() || !inputs.tools.empty()) {
         inp["tools"] = tools_override.has_value() ? *tools_override : inputs.tools;


### PR DESCRIPTION
Inject enable_thinking into the Jinja template context so models like Qwen 3.5 and Gemma 4 actually emit reasoning content.