### PR TITLE
Add GGML_OP_DELTA_NET_AR compute shader and dispatch path so Vulkan

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -850,6 +850,7 @@ struct vk_device_struct {
     vk_pipeline pipeline_ssm_scan_f32_d128;
     vk_pipeline pipeline_ssm_scan_f32_d256;
     vk_pipeline pipeline_ssm_conv_f32;
+    vk_pipeline pipeline_dnet_ar_f32_s128;
     vk_pipeline pipeline_opt_step_adamw_f32;
     vk_pipeline pipeline_opt_step_sgd_f32;
     std::map<vk_conv2d_pipeline_state, vk_pipeline> pipeline_conv2d_f32[CONV_SHAPE_COUNT];
@@ -1488,6 +1489,19 @@ struct vk_op_ssm_conv_push_constants {
     uint32_t nb11;
     uint32_t dst_nb0, dst_nb1, dst_nb2;
     uint32_t nc, ncs, nr, n_t, n_s;
+};
+struct vk_op_dnet_ar_push_constants {
+    uint32_t H;
+    uint32_t N;
+    uint32_t g_ne0;
+    uint32_t off_s_in;
+    uint32_t off_q;
+    uint32_t off_k;
+    uint32_t off_v;
+    uint32_t off_g;
+    uint32_t off_b;
+    uint32_t off_o;
+    uint32_t off_s_out;
 };
 
 struct vk_op_conv2d_push_constants {
@@ -4761,6 +4775,10 @@ static void ggml_vk_load_shaders(vk_device& device) {
 
     ggml_vk_create_pipeline(device, device->pipeline_ssm_conv_f32, "ssm_conv_f32", ssm_conv_f32_len, ssm_conv_f32_data, "main", 3, sizeof(vk_op_ssm_conv_push_constants), {32, 16, 1}, {32, 16}, 1);
 
+    ggml_vk_create_pipeline(device, device->pipeline_dnet_ar_f32_s128, "dnet_ar_f32_s128",
+        dnet_ar_f32_len, dnet_ar_f32_data, "main", 7,
+        sizeof(vk_op_dnet_ar_push_constants), {128, 1, 1}, {128}, 1);
+
     ggml_vk_create_pipeline(device, device->pipeline_opt_step_adamw_f32, "opt_step_adamw_f32", opt_step_adamw_f32_len, opt_step_adamw_f32_data, "main", 5, sizeof(vk_op_push_constants), {512, 1, 1}, {}, 1);
 
     ggml_vk_create_pipeline(device, device->pipeline_opt_step_sgd_f32, "opt_step_sgd_f32", opt_step_sgd_f32_len, opt_step_sgd_f32_data, "main", 3, sizeof(vk_op_push_constants), {512, 1, 1}, {}, 1);
@@ -6447,7 +6465,7 @@ static vk_matmul_pipeline ggml_vk_get_mul_mat_mat_id_pipeline(ggml_backend_vk_co
     vk_matmul_pipeline2& mmp = ctx->device->pipeline_dequant_mul_mat_mat_id[src0_type];
     // XXX TODO 'prec' is not actually allowed in mul_mat_id.
     bool prefer_fp16acc = ctx->device->fp16 /*&& prec == GGML_PREC_DEFAULT*/;
-    
+
     if (src0_type == GGML_TYPE_TQ1_0 || src0_type == GGML_TYPE_TQ2_0) {
         prefer_fp16acc = false;
     }
@@ -11055,6 +11073,64 @@ static void ggml_vk_ssm_conv(ggml_backend_vk_context * ctx, vk_context& subctx, 
     });
 }
 
+static void ggml_vk_dnet_ar(ggml_backend_vk_context * ctx, vk_context& subctx, ggml_tensor * dst) {
+    const ggml_tensor * s_in = dst->src[0];
+    const ggml_tensor * q    = dst->src[1];
+    const ggml_tensor * k    = dst->src[2];
+    const ggml_tensor * v    = dst->src[3];
+    const ggml_tensor * g    = dst->src[4];
+    const ggml_tensor * b    = dst->src[5];
+
+    GGML_ASSERT(s_in && q && k && v && g && b);
+
+    const uint32_t S = (uint32_t) s_in->ne[0];
+    const uint32_t H = (uint32_t) s_in->ne[2];
+    const uint32_t N = (uint32_t) s_in->ne[3];
+    const uint32_t g_ne0 = (uint32_t) g->ne[0];
+    GGML_ASSERT(S == 128 && "ggml_vk_dnet_ar: shader specialised for S=128");
+    GGML_ASSERT(g_ne0 == 1 || g_ne0 == S);
+
+    vk_pipeline pipeline = ctx->device->pipeline_dnet_ar_f32_s128;
+    GGML_ASSERT(pipeline != nullptr);
+    ggml_pipeline_request_descriptor_sets(ctx, pipeline, 1);
+
+    vk_subbuffer s_in_buf = ggml_vk_tensor_subbuffer(ctx, s_in);
+    vk_subbuffer q_buf    = ggml_vk_tensor_subbuffer(ctx, q);
+    vk_subbuffer k_buf    = ggml_vk_tensor_subbuffer(ctx, k);
+    vk_subbuffer v_buf    = ggml_vk_tensor_subbuffer(ctx, v);
+    vk_subbuffer g_buf    = ggml_vk_tensor_subbuffer(ctx, g);
+    vk_subbuffer b_buf    = ggml_vk_tensor_subbuffer(ctx, b);
+    vk_subbuffer dst_buf  = ggml_vk_tensor_subbuffer(ctx, dst);
+
+    const uint32_t off_o     = 0;
+    const uint32_t off_s_out = S * H * N;
+
+    const vk_op_dnet_ar_push_constants pc = {
+        H, N, g_ne0,
+        (uint32_t)(s_in_buf.offset / sizeof(float)),
+        (uint32_t)(q_buf.offset    / sizeof(float)),
+        (uint32_t)(k_buf.offset    / sizeof(float)),
+        (uint32_t)(v_buf.offset    / sizeof(float)),
+        (uint32_t)(g_buf.offset    / sizeof(float)),
+        (uint32_t)(b_buf.offset    / sizeof(float)),
+        (uint32_t)(dst_buf.offset / sizeof(float)) + off_o,
+        (uint32_t)(dst_buf.offset / sizeof(float)) + off_s_out,
+    };
+
+    s_in_buf.offset = 0; s_in_buf.size = VK_WHOLE_SIZE;
+    q_buf.offset    = 0; q_buf.size    = VK_WHOLE_SIZE;
+    k_buf.offset    = 0; k_buf.size    = VK_WHOLE_SIZE;
+    v_buf.offset    = 0; v_buf.size    = VK_WHOLE_SIZE;
+    g_buf.offset    = 0; g_buf.size    = VK_WHOLE_SIZE;
+    b_buf.offset    = 0; b_buf.size    = VK_WHOLE_SIZE;
+    dst_buf.offset  = 0; dst_buf.size  = VK_WHOLE_SIZE;
+
+    std::array<uint32_t, 3> elements = { S, H, N };
+    ggml_vk_dispatch_pipeline(ctx, subctx, pipeline,
+        { s_in_buf, q_buf, k_buf, v_buf, g_buf, b_buf, dst_buf },
+        pc, elements);
+}
+
 static void ggml_vk_op_f32_opt_step_adamw(ggml_backend_vk_context * ctx, vk_context& subctx, ggml_tensor * dst, const vk_op_push_constants&& pc) {
     const ggml_tensor * x = dst->src[0];
     const ggml_tensor * g = dst->src[1];
@@ -13847,6 +13923,11 @@ static bool ggml_vk_build_graph(ggml_backend_vk_context * ctx, ggml_cgraph * cgr
 
         break;
 
+    case GGML_OP_DELTA_NET_AR:
+        ggml_vk_dnet_ar(ctx, compute_ctx, node);
+
+        break;
+
     case GGML_OP_OPT_STEP_ADAMW:
         ggml_vk_opt_step_adamw(ctx, compute_ctx, node);
 
@@ -16281,6 +16362,18 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
             }
         case GGML_OP_SSM_CONV:
             return op->src[0]->type == GGML_TYPE_F32;
+        case GGML_OP_DELTA_NET_AR:
+            {
+                const ggml_tensor * s_in = op->src[0];
+                if (!s_in || s_in->ne[0] != 128) return false;
+                if (op->type != GGML_TYPE_F32) return false;
+                for (int i = 0; i < 6; ++i) {
+                    if (!op->src[i] || op->src[i]->type != GGML_TYPE_F32) return false;
+                }
+                const int64_t g_ne0 = op->src[4]->ne[0];
+                if (g_ne0 != 1 && g_ne0 != s_in->ne[0]) return false;
+                return true;
+            }
         case GGML_OP_CONV_TRANSPOSE_1D:
             return op->src[0]->type == GGML_TYPE_F32 && op->src[1]->type == GGML_TYPE_F32;
         case GGML_OP_CROSS_ENTROPY_LOSS_BACK:

--- a/ggml/src/ggml-vulkan/vulkan-shaders/dnet_ar.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/dnet_ar.comp
@@ -1,0 +1,97 @@
+#version 450
+
+#extension GL_EXT_control_flow_attributes : require
+
+layout(constant_id = 0) const uint S = 128;
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) readonly buffer S_in   { float s_in_buf[]; };
+layout(binding = 1) readonly buffer Q_buf  { float q_buf[]; };
+layout(binding = 2) readonly buffer K_buf  { float k_buf[]; };
+layout(binding = 3) readonly buffer V_buf  { float v_buf[]; };
+layout(binding = 4) readonly buffer G_buf  { float g_buf[]; };
+layout(binding = 5) readonly buffer B_buf  { float b_buf[]; };
+layout(binding = 6) buffer Dst             { float dst_buf[]; };
+
+layout(push_constant) uniform PushConstants {
+    uint H;
+    uint N;
+    uint g_ne0;
+    uint off_s_in;
+    uint off_q;
+    uint off_k;
+    uint off_v;
+    uint off_g;
+    uint off_b;
+    uint off_o;
+    uint off_s_out;
+};
+
+shared float k_l[128];
+shared float q_l[128];
+shared float v_l[128];
+shared float d_l[128];
+shared float g_l[128];
+shared float beta_v;
+shared float kq_partials[128]; // tree-reduction scratch
+
+void main() {
+    const uint h = gl_WorkGroupID.y;
+    const uint n = gl_WorkGroupID.z;
+    const uint tid = gl_LocalInvocationID.x;
+    const uint hn = n * H + h;
+
+    const uint base_s_in  = off_s_in  + hn * S * S;
+    const uint base_k     = off_k     + hn * S;
+    const uint base_q     = off_q     + hn * S;
+    const uint base_v     = off_v     + hn * S;
+    const uint base_b     = off_b     + hn;
+    const uint base_g     = off_g     + hn * g_ne0;
+    const uint base_o     = off_o     + hn * S;
+    const uint base_s_out = off_s_out + hn * S * S;
+
+    k_l[tid] = k_buf[base_k + tid];
+    q_l[tid] = q_buf[base_q + tid];
+    v_l[tid] = v_buf[base_v + tid];
+    if (g_ne0 == 1) {
+        if (tid == 0) g_l[0] = g_buf[base_g];
+    } else {
+        g_l[tid] = g_buf[base_g + tid];
+    }
+    if (tid == 0) beta_v = b_buf[base_b];
+
+    barrier();
+
+    float sk_j = 0.0;
+    float sq_j = 0.0;
+    [[unroll]] for (uint i = 0; i < S; ++i) {
+        const float g_v   = (g_ne0 == 1u) ? g_l[0] : g_l[i];
+        const float gate  = exp(g_v);
+        const float s_ji  = s_in_buf[base_s_in + tid + i * S];
+        sk_j += s_ji * gate * k_l[i];
+        sq_j += s_ji * gate * q_l[i];
+    }
+
+    const float dj = beta_v * (v_l[tid] - sk_j);
+    d_l[tid] = dj;
+
+    kq_partials[tid] = k_l[tid] * q_l[tid];
+    barrier();
+    for (uint stride = S / 2u; stride > 0u; stride >>= 1u) {
+        if (tid < stride) {
+            kq_partials[tid] += kq_partials[tid + stride];
+        }
+        barrier();
+    }
+    const float kq = kq_partials[0];
+
+    dst_buf[base_o + tid] = sq_j + dj * kq;
+
+    [[unroll]] for (uint i = 0; i < S; ++i) {
+        const float g_v  = (g_ne0 == 1u) ? g_l[0] : g_l[i];
+        const float gate = exp(g_v);
+        const float s_ji = s_in_buf[base_s_in + tid + i * S];
+        dst_buf[base_s_out + tid + i * S] = s_ji * gate + d_l[tid] * k_l[i];
+    }
+}

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -1067,6 +1067,8 @@ void process_shaders() {
 
     string_to_spv("ssm_conv_f32", "ssm_conv.comp", {{"A_TYPE", "float"}});
 
+    string_to_spv("dnet_ar_f32", "dnet_ar.comp", {});
+
     string_to_spv("topk_moe_f32", "topk_moe.comp", {});
 
 #ifdef GGML_VULKAN_BUILD_ADRENO_SHADERS


### PR DESCRIPTION
Add `GGML_OP_DELTA_NET_AR` compute shader and dispatch path so Vulkan no longer falls back to CPU per token on Qwen 3.5 / DeltaNet decode. There is still a regression issue on temp-8189 that makes Qwen 3.5 to take a different path, probably due to the graph scheduler changes. But this change is by-passing this by adding a new shader from upstream.