### PR TITLE
vulkan: Force f32 src1 through the strided cpy path which uses correct strides

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -7856,6 +7856,8 @@ static void ggml_vk_mul_mat_q_f16(ggml_backend_vk_context * ctx, vk_context& sub
                               !ggml_vk_dim01_contiguous(src0);
     const bool y_non_contig = (ctx->device->coopmat2 && src1->type == GGML_TYPE_F32) ||
                               (src0->type == GGML_TYPE_BF16 && src1->type != GGML_TYPE_BF16) ||
+                              // Force F32 src1 through the strided cpy path which uses correct strides.
+                              ((ctx->device->vendor_id == VK_VENDOR_ID_ARM) && ctx->device->coopmat_support && !ctx->device->coopmat2 && src1->type == GGML_TYPE_F32) ||
                               !ggml_vk_dim01_contiguous(src1);
 
     // If src0 is BF16, try to use a BF16 x BF16 multiply


### PR DESCRIPTION
**Bug**
vk::Queue::submit: ErrorDeviceLost on Pixel 9 Pro (Mali-G715) running BERT-style embedding inference (gte-large_fp16) at `--batch 2048`. The failure is the KQV matmul (attn_scores @ V); src1 is the F32 softmax output that gets dequanted to F16 before the matmul reads it. On Mali coopmat1, the flat dequant_f32 shader path corrupts at certain N values where the strided cpy_f32_f16 shader doesn't.

**Fix**
Route the f32->f16 conversion of src1 through cpy_f32_f16 instead of dequant_f32 on Mali KHR_coopmat1.

