### PR TITLE
Keep TQ1_0/TQ2_0 on F32-src1 matmul path on Mali coopmat1

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -7875,7 +7875,11 @@ static void ggml_vk_mul_mat_q_f16(ggml_backend_vk_context * ctx, vk_context& sub
     const bool y_non_contig = (ctx->device->coopmat2 && src1->type == GGML_TYPE_F32) ||
                               (src0->type == GGML_TYPE_BF16 && src1->type != GGML_TYPE_BF16) ||
                               // Force F32 src1 through the strided cpy path which uses correct strides.
-                              ((ctx->device->vendor_id == VK_VENDOR_ID_ARM) && ctx->device->coopmat_support && !ctx->device->coopmat2 && src1->type == GGML_TYPE_F32) ||
+                              // Skip for TQ1_0/TQ2_0: those have a dedicated TQ x F32 f32acc pipeline,
+                              // and forcing the F16 cast path here causes first-step NaN in bitnet finetuning
+                              // because F32 activations >65504 overflow F16. Mirrors the !is_tq guard below.
+                              ((ctx->device->vendor_id == VK_VENDOR_ID_ARM) && ctx->device->coopmat_support && !ctx->device->coopmat2 && src1->type == GGML_TYPE_F32 &&
+                               src0->type != GGML_TYPE_TQ1_0 && src0->type != GGML_TYPE_TQ2_0) ||
                               !ggml_vk_dim01_contiguous(src1);
 
     // If src0 is BF16, try to use a BF16 x BF16 multiply


### PR DESCRIPTION
Keep TQ1_0/TQ2_0 on F32-src1 matmul path on Mali `coopmat1`.