### PR TITLE
fix(common, model-load): init UAF/nullptr and incremental split tied-embedding load

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1141,6 +1141,8 @@ struct common_init_result::impl {
     std::vector<llama_sampler_seq_config> samplers_seq_config;
 };
 
+common_init_result::common_init_result() : pimpl(new impl{}) {}
+
 common_init_result::common_init_result(common_params & params) :
     pimpl(new impl{}) {
     auto mparams = common_model_params_to_llama(params);
@@ -1394,7 +1396,13 @@ common_init_result_ptr common_init_from_model_and_params(llama_model * model, co
         return common_init_result_ptr();
     }
 
-    common_init_result_ptr res(new common_init_result(params));
+    // Adopt the externally-loaded model into an empty result. Do NOT use the
+    // file-based constructor here: it would load a throwaway model from
+    // params.model.path and build a context (and samplers) bound to it, and the
+    // pimpl->model.reset(model) below would then free that file model while its
+    // context/samplers still referenced it -- a heap-use-after-free in
+    // ~llama_context, plus a duplicated logit-bias/sampler setup.
+    common_init_result_ptr res(new common_init_result());
     auto & pimpl = res->pimpl;
     pimpl->model.reset(model);
 

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1393,7 +1393,12 @@ common_init_result_ptr common_init_from_params(common_params & params) {
 // and don't have a params.model.path the file-based constructor can open.
 common_init_result_ptr common_init_from_model_and_params(llama_model * model, common_params & params) {
     if (model == nullptr) {
-        return common_init_result_ptr();
+        // Mirror common_init_from_params: on load failure return a *valid* empty
+        // result (model()/context() == nullptr), never a null pointer. Callers
+        // adopt this result and inspect model()/context() to detect failure
+        // (e.g. and then throw); returning a null common_init_result_ptr here
+        // makes those callers dereference null and crash.
+        return common_init_result_ptr(new common_init_result());
     }
 
     // Adopt the externally-loaded model into an empty result. Do NOT use the

--- a/common/common.h
+++ b/common/common.h
@@ -846,6 +846,12 @@ struct common_init_result {
     std::vector<llama_adapter_lora_ptr> & lora();
 
 private:
+    // Empty result: no model is loaded from params.model.path. Used by the
+    // externally-loaded-model overload of common_init_from_model_and_params so
+    // it can adopt a caller-provided model without first building (and then
+    // freeing) a throwaway file-loaded model and its dependent context.
+    common_init_result();
+
     struct impl;
     std::unique_ptr<impl> pimpl;
 

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -7994,6 +7994,22 @@ bool llama_model::create_split_backend_buffers(
         }
     }
 
+    // Register this split's tensors in tensors_by_name now, while their source
+    // file is still mapped. A later TENSOR_DUPLICATED reference (e.g. a model
+    // with tied embeddings, where output.weight aliases token_embd.weight) is
+    // resolved by looking the original up here (see create_tensor in
+    // load_tensors); without this, the duplicate would instead be (re)created
+    // against this split after release_split() freed its file, failing with
+    // "file not found for tensor ... at split-index N". Capture the pointers
+    // before create_backend_buffers moves the contexts into ctxs_bufs (the
+    // tensor pointers stay valid across that ownership transfer).
+    for (const auto & [buft, ctx_ptr] : ml.ctx_map) {
+        for (auto * cur = ggml_get_first_tensor(ctx_ptr.get()); cur != nullptr;
+             cur = ggml_get_next_tensor(ctx_ptr.get(), cur)) {
+            tensors_by_name.emplace_back(ggml_get_name(cur), cur);
+        }
+    }
+
     const std::size_t split_data_size = ml.incremental_splits_tensor_load->get_split_data_size(idx);
     LLAMA_LOG_CMAKE_DEBUG("%s: creating backend buffers for split %d with size %zu\n", __func__, idx, split_data_size);
     constexpr bool do_print_backend_buffers_info = false;


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- **Heap use-after-free in `common_init_from_model_and_params`:** The `llama_model*` overload built its result via the file-based `common_init_result(params)` constructor, then replaced `pimpl->model` with the caller’s model. That freed the file-loaded model while context and samplers still referenced it; destroying the stale context triggered a UAF in `~llama_context`. EOG logit-bias and sampler setup also ran twice.
- **Null `common_init_result_ptr` on failure:** When `model == nullptr`, the overload returned a null pointer instead of a valid empty result. Callers that adopt the pointer and check `model()`/`context()` dereferenced null and crashed (unlike `common_init_from_params`).
- **Incremental split load + tied embeddings:** On the incremental split-future path, `TENSOR_DUPLICATED` tensors (e.g. `output.weight` → `token_embd.weight`) failed with `file not found for tensor 'token_embd.weight' at split-index N`. `tensors_by_name` was never filled during incremental load (only populated from `ml.ctx_map` after load, when that map was already empty), so duplicates were re-created against a split whose file had already been released.

## 📝 How does it solve it?

- Add a private empty `common_init_result()` constructor and use it in `common_init_from_model_and_params(llama_model*, …)` so the externally loaded model is adopted into a fresh result; context and samplers are built only for that model.
- On `model == nullptr`, return a valid empty `common_init_result` (`model()`/`context()` are null), matching `common_init_from_params`.
- In `create_split_backend_buffers`, register each split’s tensors in `tensors_by_name` while the split file is still mapped, so `create_tensor` can resolve `TENSOR_DUPLICATED` references without re-reading a released split.

## 🧪 How was it tested?

- Clean full runs of llm and embed cpp-tests under asan instrumentation
- `tests/test-model-load-memory-split` on 8-shard tied-embedding **Llama-3.2-1B-Instruct-Q4_0** (reproduces and verifies the split/tied-embedding fix).
- Incremental split load still works for 3-shard **Qwen3** and 8-shard **bitnet** split models.
