### PR TITLE
ggml: GGML_BACKEND_DL support — drop broken SVE/SVE2 on linux-arm64, no Vulkan dep under DL

### DIFF
--- a/ggml/cmake/ggml-config.cmake.in
+++ b/ggml/cmake/ggml-config.cmake.in
@@ -71,7 +71,14 @@ if (NOT GGML_SHARED_LIB)
         set(GGML_OPENCL_INTERFACE_LINK_LIBRARIES $<LINK_ONLY:OpenCL::OpenCL>)
     endif()
 
-    if (GGML_VULKAN)
+    # Under GGML_BACKEND_DL the Vulkan backend ships as a standalone module that
+    # is dlopen'd at runtime; the consumer links only ggml/ggml-base and never
+    # references Vulkan::Vulkan (the backend foreach below is skipped entirely
+    # when GGML_BACKEND_DL is set). Hard-requiring the Vulkan SDK at the
+    # consumer's configure time is therefore spurious for DL builds and breaks
+    # CPU-only consumers (e.g. @qvac/classification-ggml) on build hosts without
+    # a Vulkan SDK. Keep the dependency for non-DL builds, which link it directly.
+    if (GGML_VULKAN AND NOT GGML_BACKEND_DL)
         find_dependency(Vulkan)
         set(GGML_VULKAN_INTERFACE_LINK_LIBRARIES $<LINK_ONLY:Vulkan::Vulkan>)
     endif()

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -399,14 +399,20 @@ if (GGML_CPU_ALL_VARIANTS)
             # Many of these features are optional so we build versions with popular
             # combinations and name the backends based on the version they were
             # first released with
+            # qvac: SVE/SVE2 CPU-variant kernels are numerically broken on real
+            # linux-arm64 hardware (Graviton3/Neoverse-V1) — vla/pi05 integration
+            # diverges from the PyTorch reference (cos ~0.77 vs ~0.999) only when
+            # an SVE-enabled variant is runtime-selected; the same model on a
+            # non-SVE variant matches at ~0.999. Strip *only* SVE/SVE2 here (keep
+            # DOTPROD/FP16/i8mm and SME, which are not implicated). Variants that
+            # collapse to an already-listed feature set after the strip are
+            # dropped (armv8.2_3->8.2_2, armv8.6_2->8.6_1, armv9.2_2->9.2_1).
+            # Android / Apple / other platforms are intentionally untouched.
             ggml_add_cpu_backend_variant(armv8.0_1)
             ggml_add_cpu_backend_variant(armv8.2_1    DOTPROD)
             ggml_add_cpu_backend_variant(armv8.2_2    DOTPROD FP16_VECTOR_ARITHMETIC)
-            ggml_add_cpu_backend_variant(armv8.2_3    DOTPROD FP16_VECTOR_ARITHMETIC SVE)
-            ggml_add_cpu_backend_variant(armv8.6_1    DOTPROD FP16_VECTOR_ARITHMETIC SVE MATMUL_INT8)
-            ggml_add_cpu_backend_variant(armv8.6_2    DOTPROD FP16_VECTOR_ARITHMETIC SVE MATMUL_INT8 SVE2)
-            ggml_add_cpu_backend_variant(armv9.2_1    DOTPROD FP16_VECTOR_ARITHMETIC SVE MATMUL_INT8 SME)
-            ggml_add_cpu_backend_variant(armv9.2_2    DOTPROD FP16_VECTOR_ARITHMETIC SVE MATMUL_INT8 SVE2 SME)
+            ggml_add_cpu_backend_variant(armv8.6_1    DOTPROD FP16_VECTOR_ARITHMETIC MATMUL_INT8)
+            ggml_add_cpu_backend_variant(armv9.2_1    DOTPROD FP16_VECTOR_ARITHMETIC MATMUL_INT8 SME)
         elseif (CMAKE_SYSTEM_NAME MATCHES "Android")
             # Android-specific backends with SoC-compatible feature sets
             ggml_add_cpu_backend_variant(android_armv8.0_1)

--- a/ggml/src/ggml-cpu/CMakeLists.txt
+++ b/ggml/src/ggml-cpu/CMakeLists.txt
@@ -54,6 +54,19 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
         ggml-cpu/ops.cpp
         )
 
+    # clang-22's -O3 optimizer blows up (>6h on a single TU; reproduced
+    # locally as one clang++ pegged at 100% CPU, ~0.8 GB RSS) compiling the AMX
+    # quantized-matmul kernel for the sapphirerapids variant under
+    # GGML_CPU_ALL_VARIANTS. AMX throughput comes from the tile intrinsics, not
+    # the high-level optimizer, so building this one TU at -O1 avoids the
+    # compile-time explosion at negligible runtime cost (-O1: ~5s vs -O3: >40m).
+    # The trailing -O1 overrides the build-type -O3. Skip MSVC: it maps -O1 to
+    # /O1, incompatible with the debug /RTC1 flag (D8016), and it doesn't hit
+    # the clang blow-up anyway.
+    if(NOT MSVC)
+      set_source_files_properties(ggml-cpu/amx/mmq.cpp PROPERTIES COMPILE_OPTIONS "-O1")
+    endif()
+
     target_compile_features(${GGML_CPU_NAME} PRIVATE c_std_11 cxx_std_17)
     target_include_directories(${GGML_CPU_NAME} PRIVATE . ggml-cpu)
 


### PR DESCRIPTION
Source-side changes needed for the `GGML_BACKEND_DL` (dynamic-backend) build used by the qvac addons. Carried as commits here (not vcpkg port patches) since this is a fork we control.

- **Drop SVE/SVE2 from the linux-arm64 `GGML_CPU_ALL_VARIANTS` list (keep SME + i8mm).** The SVE/SVE2 per-microarch CPU kernels are numerically broken on real linux-arm64 hardware (Graviton3 / Neoverse-V1): vla/pi05 integration diverges from the PyTorch reference (cos ~0.77 vs ~0.999) only when an SVE variant is runtime-selected; the same model on a non-SVE variant matches at ~0.999. Strips **only** SVE/SVE2; keeps DOTPROD/FP16/MATMUL_INT8(i8mm) and SME (not implicated). Variants that become exact duplicates after the strip are dropped. **Android / Apple / other platforms untouched.**
- **`ggml-config`: don't `find_dependency(Vulkan)` under `GGML_BACKEND_DL`.** Under DL the Vulkan backend is a runtime-loaded module; consumers must not need the Vulkan SDK at configure time.
- **Lower AMX MMQ optimization level** for the DL build.

Test port (registry `feat/ggml-dl-backends-linux`, `qvac-fabric 8828.1.0#1`) `REF`s this branch; addon CI is validating it.