### PR TITLE
kv-cache : cover GGSQ M-RoPE ext restore

### DIFF
--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -2301,8 +2301,8 @@ bool llama_kv_cache::state_read_meta(llama_io_read_i & io, uint32_t strm, uint32
             return false;
         }
 
-        // TODO: we cannot yet restore llama_kv_cell_ext as the apply_ubatch() does not support it yet
-        //       see: https://github.com/ggml-org/llama.cpp/pull/16825#issuecomment-3460868350
+        // Preserve M-RoPE spatial metadata by passing ext.y/ext.x through the
+        // ubatch position planes; apply_ubatch() writes them back via ext_set().
         apply_ubatch(sinfo, ubatch);
 
         LLAMA_LOG_DEBUG("%s: cell_count = %d, dest_seq_id = %d\n", __func__, cell_count, dest_seq_id);

--- a/tests/test-kv-cache.cpp
+++ b/tests/test-kv-cache.cpp
@@ -1,7 +1,11 @@
 #include "llama-kv-cache.h"
+#include "llama-io.h"
 #include "llama-model.h"
 
+#include <cstring>
 #include <memory>
+#include <stdexcept>
+#include <utility>
 #include <vector>
 
 static constexpr uint32_t TEST_LAYER     = 0;
@@ -26,12 +30,58 @@ static constexpr uint32_t Y_AXIS     = 1;
 static constexpr uint32_t X_AXIS     = 2;
 static constexpr uint32_t OTHER_AXIS = 3;
 
-static std::unique_ptr<llama_model> make_test_model(enum llama_rope_type rope_type = LLAMA_ROPE_TYPE_IMROPE) {
+class vector_writer : public llama_io_write_i {
+public:
+    void write(const void * src, size_t size) override {
+        const auto * bytes = static_cast<const uint8_t *>(src);
+        data.insert(data.end(), bytes, bytes + size);
+    }
+
+    void write_tensor(const ggml_tensor * tensor, size_t offset, size_t size) override {
+        const size_t start = data.size();
+        data.resize(start + size);
+        ggml_backend_tensor_get(tensor, data.data() + start, offset, size);
+    }
+
+    size_t n_bytes() override {
+        return data.size();
+    }
+
+    std::vector<uint8_t> data;
+};
+
+class vector_reader : public llama_io_read_i {
+public:
+    explicit vector_reader(const std::vector<uint8_t> & bytes) : data(bytes) {}
+
+    const uint8_t * read(size_t size) override {
+        if (offset + size > data.size()) {
+            throw std::runtime_error("vector_reader: read past end");
+        }
+        const uint8_t * result = data.data() + offset;
+        offset += size;
+        return result;
+    }
+
+    void read_to(void * dst, size_t size) override {
+        memcpy(dst, read(size), size);
+    }
+
+    size_t n_bytes() override {
+        return offset;
+    }
+
+private:
+    const std::vector<uint8_t> & data;
+    size_t offset = 0;
+};
+
+static std::unique_ptr<llama_model> make_test_model(enum llama_rope_type rope_type = LLAMA_ROPE_TYPE_IMROPE, bool no_alloc = true) {
     llama_model_params params = llama_model_default_params();
     auto model = std::make_unique<llama_model>(params);
 
     llama_hparams & hparams = model->hparams;
-    hparams.no_alloc             = true;
+    hparams.no_alloc             = no_alloc;
     hparams.n_ctx_train          = 512;
     hparams.n_embd               = TEST_N_HEAD * TEST_HEAD_DIM;
     hparams.n_layer              = 1;
@@ -111,6 +161,18 @@ static llama_kv_cache::slot_info make_slot_info() {
     return sinfo;
 }
 
+static std::vector<uint8_t> write_sequence_state(const llama_kv_cache & kv) {
+    vector_writer writer;
+    kv.state_write(writer, TEST_SEQ_ID);
+    return std::move(writer.data);
+}
+
+static void read_sequence_state(llama_kv_cache & kv, const std::vector<uint8_t> & bytes) {
+    vector_reader reader(bytes);
+    kv.state_read(reader, TEST_SEQ_ID);
+    GGML_ASSERT(reader.n_bytes() == bytes.size());
+}
+
 static void test_mrope_k_shift_input_layout() {
     auto model = make_test_model();
     llama_kv_cache kv = make_test_cache(*model, GGML_TYPE_F16);
@@ -150,9 +212,25 @@ static void test_quantized_k_shift_width_pads_to_block() {
     GGML_ASSERT(pq_cache.get_k_shift_width(TEST_LAYER) == TEST_HEAD_DIM);
 }
 
+static void test_sequence_state_roundtrip_preserves_mrope_ext() {
+    auto model = make_test_model(LLAMA_ROPE_TYPE_IMROPE, false);
+
+    llama_kv_cache source = make_test_cache(*model, GGML_TYPE_F16);
+    source.apply_ubatch(make_slot_info(), make_image_grid_ubatch());
+
+    const std::vector<uint8_t> saved = write_sequence_state(source);
+
+    llama_kv_cache restored = make_test_cache(*model, GGML_TYPE_F16);
+    read_sequence_state(restored, saved);
+
+    const std::vector<uint8_t> resaved = write_sequence_state(restored);
+    GGML_ASSERT(resaved == saved);
+}
+
 int main() {
     test_mrope_k_shift_input_layout();
     test_quantized_k_shift_width_pads_to_block();
+    test_sequence_state_roundtrip_preserves_mrope_ext();
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- Replace the stale GGSQ restore TODO in `llama_kv_cache::state_read_meta()` with a comment that reflects the current restore path.
- Add a regression test proving that a GGSQ sequence-state round trip preserves M-RoPE spatial metadata.

## Context
`state_read_meta()` still had a TODO saying `llama_kv_cell_ext` could not be restored because `apply_ubatch()` did not support it yet.

That TODO was originally added in upstream commit `e3af5563bd` / ggml-org llama.cpp #16825 (`llama: store mrope data in KV cell`). The same commit also added `apply_ubatch()` support for writing M-RoPE spatial metadata into KV cells from a 2D ubatch:
- `ubatch.pos[i + ubatch.n_tokens]` becomes `ext.y`
- `ubatch.pos[i + ubatch.n_tokens * 2]` becomes `ext.x`
- `cells.ext_set(idx, ext)` stores the metadata on the KV cell

So the TODO was not stale just because of #16825. At that point, `apply_ubatch()` could write ext metadata, but the GGSQ sequence-state save/restore path was not yet serializing and feeding `llama_kv_cell_ext` through that ubatch restore path.

The TODO became stale after commit `17a425894` / ggml-org llama.cpp #20132 (`kv-cache : fix M-RoPE checkpoints`). That later commit wired M-RoPE ext metadata into the checkpoint path:
- `state_write_meta()` writes `llama_kv_cell_ext` when `hparams.n_pos_per_embd() > 1`
- `state_read_meta()` reads `llama_kv_cell_ext` from the GGSQ stream
- restore then places `ext.y` and `ext.x` into the ubatch position planes before calling `apply_ubatch()`

With both pieces present, GGSQ restore now works like this:
1. `state_read_meta()` reads the serialized cell position and `llama_kv_cell_ext`.
2. It reconstructs a ubatch and copies `ext.y` / `ext.x` into the 2D ubatch position planes.
3. `apply_ubatch()` sees `ubatch.is_pos_2d()` and writes those planes back into the destination KV cells with `cells.ext_set()`.

This PR only updates the stale comment and adds explicit test coverage for that current behavior.

## What the test does
The new `test_sequence_state_roundtrip_preserves_mrope_ext()` test is a focused regression for the GGSQ sequence-state restore path.

It first creates a tiny synthetic IM-RoPE model and KV cache. The test then inserts a fake image-grid ubatch into that cache with 2D positions: the normal token position carries the temporal axis, and the extra ubatch position planes carry `y` and `x`. That mirrors the shape used by M-RoPE / vision tokens, without needing a real model file or real inference.

Next, the test serializes only sequence `0` with `kv.state_write(writer, TEST_SEQ_ID)`. This exercises the GGSQ sequence-save path, including writing each cell position, sequence id, and `llama_kv_cell_ext` metadata.

Then it creates a fresh empty KV cache and restores the saved bytes with `kv.state_read(reader, TEST_SEQ_ID)`. This is the path that used to have the stale TODO. During restore, `state_read_meta()` reconstructs an ubatch from the serialized cells and calls `apply_ubatch()`. If the GGSQ restore path does not preserve the M-RoPE `x/y` ext fields, the restored cache would be missing that spatial metadata.

Finally, the test serializes the restored cache again and compares the new bytes to the original bytes. The byte-for-byte comparison is important because it validates the whole observable GGSQ state, not only one internal field. If `ext.x` or `ext.y` were dropped during restore, the second serialization would not match the first one.

## Why this test is useful
This PR is not trying to add new restore behavior. The restore behavior already exists through the combination of `17a425894` and the existing `apply_ubatch()` 2D position handling. The test documents and locks in that behavior so the stale TODO cannot silently come back as an assumption, and so future refactors of `state_read_meta()` or `apply_ubatch()` do not accidentally break GGSQ restore for M-RoPE spatial metadata.

## Base branch
This PR targets `temp-8828` because the relevant GGSQ/M-RoPE code and stale TODO are present there. Targeting `master` would include unrelated integration commits.

## Test plan
- `cmake -S . -B build-test -DLLAMA_BUILD_TESTS=ON -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_SERVER=OFF`
- `cmake --build build-test --target test-kv-cache`
- `ctest --test-dir build-test -R test-kv-cache --output-on-failure`