### PR TITLE
opencl : DocTR ggml-opencl ops on b9341 (CONV_2D_DW, POOL_2D, HARDSWISH, HARDSIGMOID)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -481,8 +481,11 @@ jobs:
       - name: Build (GGML_OPENCL, portable kernels)
         id: cmake_build
         run: |
+          # NOTE: no -DLLAMA_FATAL_WARNINGS=ON — upstream ggml-opencl.cpp has
+          # intentional (un-annotated) case fall-throughs that GCC's
+          # -Wimplicit-fallthrough would turn into errors. This job's purpose is
+          # to run test-backend-ops, not to gate upstream warning-cleanliness.
           cmake -B build \
-            -DLLAMA_FATAL_WARNINGS=ON \
             -DGGML_OPENCL=ON \
             -DLLAMA_BUILD_TOOLS=OFF \
             -DLLAMA_BUILD_EXAMPLES=OFF \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -454,6 +454,57 @@ jobs:
           # test-backend-ops is too slow on llvmpipe, skip it
           ctest -L main -E test-backend-ops --verbose --timeout 900
 
+  ubuntu-24-opencl:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Clone
+        id: checkout
+        uses: actions/checkout@v6
+
+      - name: ccache
+        uses: ggml-org/ccache-action@v1.2.21
+        with:
+          key: ubuntu-24-opencl
+          evict-old-files: 1d
+
+      - name: Dependencies
+        id: depends
+        run: |
+          sudo apt-get update
+          # intel-opencl-icd provides a CPU OpenCL device (same package set the
+          # OpenVINO job installs); the rest is the ICD loader + CL headers.
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake clinfo \
+            ocl-icd-opencl-dev opencl-headers opencl-clhpp-headers intel-opencl-icd
+
+      - name: Build (GGML_OPENCL, portable kernels)
+        id: cmake_build
+        run: |
+          cmake -B build \
+            -DLLAMA_FATAL_WARNINGS=ON \
+            -DGGML_OPENCL=ON \
+            -DLLAMA_BUILD_TOOLS=OFF \
+            -DLLAMA_BUILD_EXAMPLES=OFF \
+            -DLLAMA_BUILD_SERVER=OFF
+          time cmake --build build --config Release -j $(nproc) --target test-backend-ops
+
+      - name: Test backend ops (OpenCL)
+        id: test_backend_ops
+        run: |
+          # Functional coverage for the ggml-opencl ops DocTR uses on Adreno:
+          # CONV_2D (regular direct conv), CONV_2D_DW (depthwise), POOL_2D,
+          # HARDSWISH, HARDSIGMOID. These kernels load unconditionally (no
+          # GGML_OPENCL_USE_ADRENO_KERNELS gate), so they are portable OpenCL C
+          # and run here on the Intel CPU ICD, compared against the CPU
+          # reference. NOTE: a CPU ICD does NOT reproduce Adreno-compiler bugs
+          # (e.g. the char->float type-punning miscompile this PR works around) —
+          # that requires the manual Firebase Test Lab device run. This job is a
+          # regression net for kernel math / indexing / dtype correctness that a
+          # compile-only job cannot catch.
+          clinfo -l || true
+          ./build/bin/test-backend-ops test -o CONV_2D,CONV_2D_DW,POOL_2D,HARDSWISH,HARDSIGMOID
+
   ubuntu-24-webgpu-wasm:
     runs-on: ${{ 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
 

--- a/ggml/src/ggml-opencl/CMakeLists.txt
+++ b/ggml/src/ggml-opencl/CMakeLists.txt
@@ -159,6 +159,9 @@ set(GGML_OPENCL_KERNELS
     mul
     neg
     norm
+    hardsigmoid
+    hardswish
+    pool_2d
     relu
     l2_norm
     gated_delta_net
@@ -192,6 +195,7 @@ set(GGML_OPENCL_KERNELS
     mul_mm_f16_f32_kq_kqv
     conv2d
     conv2d_f16_f32
+    conv2d_dw
     flash_attn_f32_f16
     flash_attn_f16
     flash_attn_f32

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -461,6 +461,9 @@ struct ggml_backend_opencl_context {
     cl_program program_sub;
     cl_program program_norm;
     cl_program program_relu;
+    cl_program program_hardsigmoid;
+    cl_program program_hardswish;
+    cl_program program_pool_2d;
     cl_program program_rms_norm;
     cl_program program_group_norm;
     cl_program program_rope;
@@ -477,6 +480,7 @@ struct ggml_backend_opencl_context {
     cl_program program_conv_2d_f16;
     cl_program program_conv_2d_f32;
     cl_program program_conv_2d_f16_f32;
+    cl_program program_conv_2d_dw;
     cl_program program_tsembd;
     cl_program program_gemv_moe_mxfp4_f32, program_gemm_moe_mxfp4_f32;
     cl_program program_mul_mv_id_q4_0_f32_8x_flat;
@@ -501,6 +505,9 @@ struct ggml_backend_opencl_context {
     cl_kernel kernel_gelu_erf, kernel_gelu_erf_4;
     cl_kernel kernel_gelu_quick, kernel_gelu_quick_4;
     cl_kernel kernel_relu;
+    cl_kernel kernel_hardsigmoid_f32;
+    cl_kernel kernel_hardswish_f32;
+    cl_kernel kernel_pool_2d_f32;
     cl_kernel kernel_sigmoid_f32, kernel_sigmoid_f16;
     cl_kernel kernel_tri;
     cl_kernel kernel_fill;
@@ -604,6 +611,7 @@ struct ggml_backend_opencl_context {
     cl_kernel kernel_conv_2d_f16;
     cl_kernel kernel_conv_2d_f32;
     cl_kernel kernel_conv_2d_f16_f32;
+    cl_kernel kernel_conv_2d_dw_f32_f32;
     cl_kernel kernel_ssm_conv_f32_f32, kernel_ssm_conv_f32_f32_4;
     cl_kernel kernel_timestep_embedding;
     cl_kernel kernel_gemv_moe_mxfp4_f32, kernel_gemm_moe_mxfp4_f32;
@@ -623,12 +631,6 @@ struct ggml_backend_opencl_context {
     std::vector<ProfilingInfo> profiling_info;
 
     void write_profiling_info() {
-        FILE * fperf = fopen("cl_profiling.csv", "w");
-        if (!fperf) {
-            GGML_LOG_ERROR("Failed to open cl_profiling.csv\n");
-            return;
-        }
-
         // Populate profiling info
         for (ProfilingInfo & info : profiling_info) {
             cl_ulong cmd_queued;
@@ -667,7 +669,31 @@ struct ggml_backend_opencl_context {
             info.cmd_total_duration_ns      = cmd_complete  - cmd_queued;
         }
 
-        // Dump a csv
+        // QVAC: aggregate per-kernel device time to logcat (directs OpenCL
+        // op-level optimization on Adreno). Only active with GGML_OPENCL_PROFILING.
+        {
+            std::map<std::string, std::pair<double, int>> agg;
+            double total_ms = 0.0;
+            for (const ProfilingInfo & info : profiling_info) {
+                const double ms = info.cmd_duration_ns / 1.e6;
+                agg[info.kernel_name].first += ms;
+                agg[info.kernel_name].second += 1;
+                total_ms += ms;
+            }
+            for (const auto & kv : agg) {
+                GGML_LOG_WARN("CLPROF kernel=%s total_ms=%.2f calls=%d\n",
+                    kv.first.c_str(), kv.second.first, kv.second.second);
+            }
+            GGML_LOG_WARN("CLPROF TOTAL device_ms=%.2f nodes=%zu\n",
+                total_ms, profiling_info.size());
+        }
+
+        // Dump a csv (best-effort; cwd often not writable on Android — the
+        // logcat CLPROF lines above are the authoritative output there).
+        FILE * fperf = fopen("cl_profiling.csv", "w");
+        if (!fperf) {
+            return;
+        }
         fprintf(fperf, "op name, kernel name, exec duration (ms), global size, local size, output size\n");
         for (const ProfilingInfo & info : profiling_info) {
             fprintf(fperf, "%s,%s,%f,%zux%zux%zu,%zux%zux%zu,%zux%zux%zux%zu\n",
@@ -1882,6 +1908,54 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
         GGML_LOG_CONT(".");
     }
 
+    // hardsigmoid
+    {
+#ifdef GGML_OPENCL_EMBED_KERNELS
+        const std::string kernel_src {
+            #include "hardsigmoid.cl.h"
+        };
+#else
+        const std::string kernel_src = read_file("hardsigmoid.cl");
+#endif
+        backend_ctx->program_hardsigmoid =
+            build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts);
+
+        CL_CHECK((backend_ctx->kernel_hardsigmoid_f32 = clCreateKernel(backend_ctx->program_hardsigmoid, "kernel_hardsigmoid_f32", &err), err));
+        GGML_LOG_CONT(".");
+    }
+
+    // hardswish
+    {
+#ifdef GGML_OPENCL_EMBED_KERNELS
+        const std::string kernel_src {
+            #include "hardswish.cl.h"
+        };
+#else
+        const std::string kernel_src = read_file("hardswish.cl");
+#endif
+        backend_ctx->program_hardswish =
+            build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts);
+
+        CL_CHECK((backend_ctx->kernel_hardswish_f32 = clCreateKernel(backend_ctx->program_hardswish, "kernel_hardswish_f32", &err), err));
+        GGML_LOG_CONT(".");
+    }
+
+    // pool_2d
+    {
+#ifdef GGML_OPENCL_EMBED_KERNELS
+        const std::string kernel_src {
+            #include "pool_2d.cl.h"
+        };
+#else
+        const std::string kernel_src = read_file("pool_2d.cl");
+#endif
+        backend_ctx->program_pool_2d =
+            build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts);
+
+        CL_CHECK((backend_ctx->kernel_pool_2d_f32 = clCreateKernel(backend_ctx->program_pool_2d, "kernel_pool_2d_f32", &err), err));
+        GGML_LOG_CONT(".");
+    }
+
     // rms_norm
     {
 #ifdef GGML_OPENCL_EMBED_KERNELS
@@ -2596,6 +2670,22 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
                     backend_ctx->program_conv_2d_f16_f32 = nullptr;
                     backend_ctx->kernel_conv_2d_f16_f32 = nullptr;
                 }
+    }
+
+    // conv2d_dw
+    {
+#ifdef GGML_OPENCL_EMBED_KERNELS
+        const std::string kernel_src {
+            #include "conv2d_dw.cl.h"
+        };
+#else
+        const std::string kernel_src = read_file("conv2d_dw.cl");
+#endif
+        backend_ctx->program_conv_2d_dw =
+            build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts);
+
+        CL_CHECK((backend_ctx->kernel_conv_2d_dw_f32_f32 = clCreateKernel(backend_ctx->program_conv_2d_dw, "kernel_conv_2d_dw_f32_f32", &err), err));
+        GGML_LOG_CONT(".");
     }
 
     // ssm_conv
@@ -4257,6 +4347,8 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
                 case GGML_UNARY_OP_RELU:
                 case GGML_UNARY_OP_GELU_ERF:
                 case GGML_UNARY_OP_GELU_QUICK:
+                case GGML_UNARY_OP_HARDSIGMOID:
+                case GGML_UNARY_OP_HARDSWISH:
                    return ggml_is_contiguous(op->src[0]) && op->src[0]->type == GGML_TYPE_F32;
                 case GGML_UNARY_OP_SIGMOID:
                     return ggml_is_contiguous(op->src[0]);
@@ -4310,10 +4402,19 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
             return op->src[0]->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32 &&
                    (mode == GGML_SCALE_MODE_NEAREST || mode == GGML_SCALE_MODE_BILINEAR) && !antialias;
         }
+        case GGML_OP_POOL_2D: {
+            const int pool_op = ggml_get_op_params_i32(op, 0);
+            return op->src[0]->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32 &&
+                   ggml_is_contiguous(op->src[0]) && ggml_is_contiguous(op) &&
+                   (pool_op == GGML_OP_POOL_AVG || pool_op == GGML_OP_POOL_MAX);
+        }
         case GGML_OP_CONV_2D:
             return (op->src[0]->type == GGML_TYPE_F16 && op->src[1]->type == GGML_TYPE_F16 && op->type == GGML_TYPE_F16) ||
                    (op->src[0]->type == GGML_TYPE_F32 && op->src[1]->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32) ||
                    (op->src[0]->type == GGML_TYPE_F16 && op->src[1]->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32);
+        case GGML_OP_CONV_2D_DW:
+            return op->src[0]->type == GGML_TYPE_F32 &&
+                   op->src[1]->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32;
         case GGML_OP_SSM_CONV:
             return (op->src[0]->type == GGML_TYPE_F32 && op->src[1]->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32);
         case GGML_OP_CONCAT:
@@ -8054,6 +8155,78 @@ static void ggml_cl_relu(ggml_backend_t backend, const ggml_tensor * src0, const
     backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size_ptr, dst);
 }
 
+static void ggml_cl_hardsigmoid(ggml_backend_t backend, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
+    GGML_ASSERT(src0);
+    GGML_ASSERT(src0->extra);
+    GGML_ASSERT(dst);
+    GGML_ASSERT(dst->extra);
+
+    UNUSED(src1);
+
+    ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;
+
+    ggml_tensor_extra_cl * extra0 = (ggml_tensor_extra_cl *)src0->extra;
+    ggml_tensor_extra_cl * extrad = (ggml_tensor_extra_cl *)dst->extra;
+
+    cl_ulong offset0 = extra0->offset + src0->view_offs;
+    cl_ulong offsetd = extrad->offset + dst->view_offs;
+
+    cl_kernel kernel = backend_ctx->kernel_hardsigmoid_f32;
+
+    CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &extra0->data_device));
+    CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_ulong), &offset0));
+    CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),   &extrad->data_device));
+    CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_ulong), &offsetd));
+
+    const int64_t n = ggml_nelements(dst);
+
+    size_t global_work_size[] = {(size_t)n, 1, 1};
+    size_t local_work_size[] = {64, 1, 1};
+
+    size_t * local_work_size_ptr = local_work_size;
+    if (n % 64 != 0 && !backend_ctx->non_uniform_workgroups) {
+        local_work_size_ptr = nullptr;  // Let driver choose the work-group sizes.
+    }
+
+    backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size_ptr, dst);
+}
+
+static void ggml_cl_hardswish(ggml_backend_t backend, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
+    GGML_ASSERT(src0);
+    GGML_ASSERT(src0->extra);
+    GGML_ASSERT(dst);
+    GGML_ASSERT(dst->extra);
+
+    UNUSED(src1);
+
+    ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;
+
+    ggml_tensor_extra_cl * extra0 = (ggml_tensor_extra_cl *)src0->extra;
+    ggml_tensor_extra_cl * extrad = (ggml_tensor_extra_cl *)dst->extra;
+
+    cl_ulong offset0 = extra0->offset + src0->view_offs;
+    cl_ulong offsetd = extrad->offset + dst->view_offs;
+
+    cl_kernel kernel = backend_ctx->kernel_hardswish_f32;
+
+    CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &extra0->data_device));
+    CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_ulong), &offset0));
+    CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),   &extrad->data_device));
+    CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_ulong), &offsetd));
+
+    const int64_t n = ggml_nelements(dst);
+
+    size_t global_work_size[] = {(size_t)n, 1, 1};
+    size_t local_work_size[] = {64, 1, 1};
+
+    size_t * local_work_size_ptr = local_work_size;
+    if (n % 64 != 0 && !backend_ctx->non_uniform_workgroups) {
+        local_work_size_ptr = nullptr;  // Let driver choose the work-group sizes.
+    }
+
+    backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size_ptr, dst);
+}
+
 static void ggml_cl_sigmoid(ggml_backend_t backend, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
     GGML_ASSERT(src0);
     GGML_ASSERT(src0->extra);
@@ -9824,6 +9997,161 @@ static void ggml_cl_conv_2d(ggml_backend_t backend, const ggml_tensor * src0, co
     size_t local_work_size[] = { (size_t)WG_K, (size_t)WG_NPQ, 1 };
 
     backend_ctx->enqueue_ndrange_kernel(kernel, 2, global_work_size, local_work_size, dst);
+}
+
+static void ggml_cl_pool_2d(ggml_backend_t backend, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
+    GGML_ASSERT(src0);
+    GGML_ASSERT(src0->extra);
+    GGML_ASSERT(dst);
+    GGML_ASSERT(dst->extra);
+
+    UNUSED(src1);
+
+    ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;
+
+    ggml_tensor_extra_cl * extra0 = (ggml_tensor_extra_cl *)src0->extra;
+    ggml_tensor_extra_cl * extrad = (ggml_tensor_extra_cl *)dst->extra;
+
+    cl_ulong offset0 = extra0->offset + src0->view_offs;
+    cl_ulong offsetd = extrad->offset + dst->view_offs;
+
+    const int op = ggml_get_op_params_i32(dst, 0);
+    const int k0 = ggml_get_op_params_i32(dst, 1);
+    const int k1 = ggml_get_op_params_i32(dst, 2);
+    const int s0 = ggml_get_op_params_i32(dst, 3);
+    const int s1 = ggml_get_op_params_i32(dst, 4);
+    const int p0 = ggml_get_op_params_i32(dst, 5);
+    const int p1 = ggml_get_op_params_i32(dst, 6);
+
+    const int IW = src0->ne[0];
+    const int IH = src0->ne[1];
+    const int OW = dst->ne[0];
+    const int OH = dst->ne[1];
+    const int np = (int)((int64_t)dst->ne[2] * dst->ne[3] * OW * OH);
+
+    cl_kernel kernel = backend_ctx->kernel_pool_2d_f32;
+
+    cl_uint idx = 0;
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_mem),   &extra0->data_device));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_ulong), &offset0));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_mem),   &extrad->data_device));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_ulong), &offsetd));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &op));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &k0));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &k1));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &s0));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &s1));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &p0));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &p1));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &IW));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &IH));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &OW));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &OH));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &np));
+
+    size_t global_work_size[] = {(size_t)np, 1, 1};
+    size_t local_work_size[] = {64, 1, 1};
+
+    size_t * local_work_size_ptr = local_work_size;
+    if (np % 64 != 0 && !backend_ctx->non_uniform_workgroups) {
+        local_work_size_ptr = nullptr;  // Let driver choose the work-group sizes.
+    }
+
+    backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size_ptr, dst);
+}
+
+static void ggml_cl_conv_2d_dw(ggml_backend_t backend, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
+    GGML_ASSERT(src0);
+    GGML_ASSERT(src0->extra);
+    GGML_ASSERT(src1);
+    GGML_ASSERT(src1->extra);
+    GGML_ASSERT(dst);
+    GGML_ASSERT(dst->extra);
+
+    ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;
+
+    // src0 = weights, src1 = input
+    ggml_tensor_extra_cl * extra0 = (ggml_tensor_extra_cl *)src0->extra;
+    ggml_tensor_extra_cl * extra1 = (ggml_tensor_extra_cl *)src1->extra;
+    ggml_tensor_extra_cl * extrad = (ggml_tensor_extra_cl *)dst->extra;
+
+    cl_ulong offset0 = extra0->offset + src0->view_offs;
+    cl_ulong offset1 = extra1->offset + src1->view_offs;
+    cl_ulong offsetd = extrad->offset + dst->view_offs;
+
+    const int IW = src1->ne[0];
+    const int IH = src1->ne[1];
+    const int OW = dst->ne[0];
+    const int OH = dst->ne[1];
+    const int OC = dst->ne[2];
+    const int N  = dst->ne[3];
+    const int KW = src0->ne[0];
+    const int KH = src0->ne[1];
+
+    const int s0 = ggml_get_op_params_i32(dst, 0);
+    const int s1 = ggml_get_op_params_i32(dst, 1);
+    const int p0 = ggml_get_op_params_i32(dst, 2);
+    const int p1 = ggml_get_op_params_i32(dst, 3);
+    const int d0 = ggml_get_op_params_i32(dst, 4);
+    const int d1 = ggml_get_op_params_i32(dst, 5);
+
+    // Element strides (nb / type_size). The kernel indexes typed float arrays
+    // rather than doing per-iteration char->float byte-pointer type punning,
+    // which Adreno miscompiles. Strides are passed verbatim from the tensor
+    // nb[] so the kernel stays layout-agnostic (handles both WHCN and CWHN).
+    const size_t ts0 = ggml_type_size(src0->type);
+    const size_t ts1 = ggml_type_size(src1->type);
+    const size_t tsd = ggml_type_size(dst->type);
+    const cl_ulong nb00 = src0->nb[0]/ts0; const cl_ulong nb01 = src0->nb[1]/ts0; const cl_ulong nb03 = src0->nb[3]/ts0;
+    const cl_ulong nb10 = src1->nb[0]/ts1; const cl_ulong nb11 = src1->nb[1]/ts1; const cl_ulong nb12 = src1->nb[2]/ts1; const cl_ulong nb13 = src1->nb[3]/ts1;
+    const cl_ulong nb0  = dst->nb[0]/tsd;  const cl_ulong nb1  = dst->nb[1]/tsd;  const cl_ulong nb2  = dst->nb[2]/tsd;  const cl_ulong nb3  = dst->nb[3]/tsd;
+
+    cl_kernel kernel = backend_ctx->kernel_conv_2d_dw_f32_f32;
+
+    cl_uint idx = 0;
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_mem),   &extra0->data_device));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_ulong), &offset0));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_mem),   &extra1->data_device));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_ulong), &offset1));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_mem),   &extrad->data_device));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_ulong), &offsetd));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &IW));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &IH));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &OW));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &OH));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &OC));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &N));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &KW));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &KH));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &s0));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &s1));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &p0));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &p1));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &d0));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(int),      &d1));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_ulong), &nb00));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_ulong), &nb01));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_ulong), &nb03));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_ulong), &nb10));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_ulong), &nb11));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_ulong), &nb12));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_ulong), &nb13));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_ulong), &nb0));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_ulong), &nb1));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_ulong), &nb2));
+    CL_CHECK(clSetKernelArg(kernel, idx++, sizeof(cl_ulong), &nb3));
+
+    const int64_t total_outputs = (int64_t)N * OC * OH * OW;
+
+    size_t global_work_size[] = {(size_t)total_outputs, 1, 1};
+    size_t local_work_size[] = {64, 1, 1};
+
+    size_t * local_work_size_ptr = local_work_size;
+    if (total_outputs % 64 != 0 && !backend_ctx->non_uniform_workgroups) {
+        local_work_size_ptr = nullptr;  // Let driver choose the work-group sizes.
+    }
+
+    backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size_ptr, dst);
 }
 
 static void ggml_cl_mul_mat_kq_kqv_adreno(ggml_backend_t backend, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
@@ -14075,6 +14403,18 @@ bool ggml_cl_compute_forward(ggml_backend_t backend, struct ggml_tensor * tensor
                     }
                     func = ggml_cl_sigmoid;
                     break;
+                case GGML_UNARY_OP_HARDSIGMOID:
+                    if (!any_on_device) {
+                        return false;
+                    }
+                    func = ggml_cl_hardsigmoid;
+                    break;
+                case GGML_UNARY_OP_HARDSWISH:
+                    if (!any_on_device) {
+                        return false;
+                    }
+                    func = ggml_cl_hardswish;
+                    break;
                 case GGML_UNARY_OP_TANH:
                     if (!any_on_device) {
                         return false;
@@ -14174,11 +14514,23 @@ bool ggml_cl_compute_forward(ggml_backend_t backend, struct ggml_tensor * tensor
             }
             ggml_cl_upscale(backend, tensor->src[0], tensor);
             return true;
+        case GGML_OP_POOL_2D:
+            if (!any_on_device) {
+                return false;
+            }
+            func = ggml_cl_pool_2d;
+            break;
         case GGML_OP_CONV_2D:
             if (!any_on_device) {
                 return false;
             }
             func = ggml_cl_conv_2d;
+            break;
+        case GGML_OP_CONV_2D_DW:
+            if (!any_on_device) {
+                return false;
+            }
+            func = ggml_cl_conv_2d_dw;
             break;
         case GGML_OP_SSM_CONV:
             if (!any_on_device) {

--- a/ggml/src/ggml-opencl/kernels/conv2d_dw.cl
+++ b/ggml/src/ggml-opencl/kernels/conv2d_dw.cl
@@ -1,0 +1,106 @@
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+//------------------------------------------------------------------------------
+// conv_2d_dw (depthwise) - F32 weights + F32 input + F32 output
+//------------------------------------------------------------------------------
+// Ported from the ggml Metal kernel_conv_2d_dw_f32_f32, adapted for Adreno.
+//
+// IMPORTANT (Adreno correctness): the Metal port read every element in the inner
+// loop via byte-pointer type punning, i.e. `*(global const float *)(charptr +
+// byte_offset)`. On Qualcomm Adreno the OpenCL compiler miscompiles such
+// per-iteration char->float type-punned loads, producing wrong results (DocTR
+// detection yielded 0 regions). The working sibling kernel (conv2d.cl)
+// avoids this by casting the base pointer to `global float*`
+// ONCE and then indexing it as a typed array with *element* strides. We do the
+// same here.
+//
+// All strides below are ELEMENT strides (nb / sizeof(float)), supplied by the
+// host dispatch. Because the kernel only ever uses nb[] strides (never assumes a
+// particular contiguity), it is layout-agnostic and matches the CPU reference for
+// BOTH the WHCN (standard contiguous) and CWHN (channel-contiguous) layouts:
+//   - WHCN input : nb10=1, nb11=IW, nb12=IW*IH, nb13=IW*IH*OC
+//                  weight nb00=1, nb01=KW, nb03=KW*KH
+//                  output nb0=1, nb1=OW, nb2=OW*OH, nb3=OW*OH*OC
+//   - CWHN input : nb10=OC, nb11=IW*OC, nb12=1, nb13=IW*IH*OC
+//                  weight nb00=OC, nb01=KW*OC, nb03=1
+//                  output nb0=OC, nb1=OW*OC, nb2=1, nb3=OW*OH*OC
+// In both cases the element-offset arithmetic reproduces the exact indices used
+// by ggml_compute_forward_conv_2d_dw_whcn / _cwhn.
+kernel void kernel_conv_2d_dw_f32_f32(
+        global char * weights,
+        ulong off_weights,
+        global char * src,
+        ulong off_src,
+        global char * dst,
+        ulong off_dst,
+        int IW, int IH,
+        int OW, int OH,
+        int OC,
+        int N,
+        int KW, int KH,
+        int s0, int s1,
+        int p0, int p1,
+        int d0, int d1,
+        ulong nb00, ulong nb01, ulong nb03,
+        ulong nb10, ulong nb11, ulong nb12, ulong nb13,
+        ulong nb0,  ulong nb1,  ulong nb2,  ulong nb3
+) {
+    // Cast bases to typed float pointers ONCE (off_* are byte offsets and are
+    // always a multiple of sizeof(float) for F32 tensors). All nb* below are
+    // element strides, so the per-iteration loads are plain typed-array indexes
+    // rather than char->float type punning.
+    global const float * weights_base = (global const float *)((global char*)weights + off_weights);
+    global const float * src_base     = (global const float *)((global char*)src     + off_src);
+    global       float * dst_base     = (global       float *)((global char*)dst     + off_dst);
+
+    const ulong total_threads = (ulong)get_global_size(0);
+    const ulong total_outputs = (ulong)N * OC * OH * OW;
+
+    for (ulong index = get_global_id(0); index < total_outputs; index += total_threads) {
+        ulong tmp = index;
+
+        const int ow = (int)(tmp % OW); tmp /= OW;
+        const int oh = (int)(tmp % OH); tmp /= OH;
+        const int oc = (int)(tmp % OC); tmp /= OC;
+        const int n  = (int)tmp;
+
+        // Dead-simple form, matching the CPU reference
+        // ggml_compute_forward_conv_2d_dw_whcn EXACTLY: per-tap forward map
+        // src = dst*stride + knl*dilation - pad, with a plain in-bounds check.
+        // (Replaced the Metal ky_start/ky_end clamping, which gave wrong results
+        // on Adreno.) Layout-agnostic via element strides nb*.
+        float acc = 0.0f;
+        const ulong src_b = (ulong)n * nb13 + (ulong)oc * nb12;
+        const ulong w_b   = (ulong)oc * nb03;
+
+        for (int ky = 0; ky < KH; ++ky) {
+            const int iy = oh*s1 + ky*d1 - p1;
+            if (iy < 0 || iy >= IH) {
+                continue;
+            }
+            for (int kx = 0; kx < KW; ++kx) {
+                const int ix = ow*s0 + kx*d0 - p0;
+                if (ix < 0 || ix >= IW) {
+                    continue;
+                }
+                const ulong src_idx = src_b + (ulong)iy * nb11 + (ulong)ix * nb10;
+                const ulong w_idx   = w_b   + (ulong)ky * nb01 + (ulong)kx * nb00;
+                acc += src_base[src_idx] * weights_base[w_idx];
+            }
+        }
+
+        const ulong dst_idx =
+            (ulong)n  * nb3 +
+            (ulong)oc * nb2 +
+            (ulong)oh * nb1 +
+            (ulong)ow * nb0;
+
+        dst_base[dst_idx] = acc;
+    }
+}
+
+// NOTE: DocTR promotes depthwise weights to F32 (so the direct
+// GGML_OP_CONV_2D_DW kernel runs on every backend), so only the F32-weight
+// variant above is used / shipped. An F16-weight variant was dropped as
+// unused — re-add it (plus an F16 supports_op case + host dispatch) if a
+// future consumer needs F16 depthwise weights on OpenCL.

--- a/ggml/src/ggml-opencl/kernels/hardsigmoid.cl
+++ b/ggml/src/ggml-opencl/kernels/hardsigmoid.cl
@@ -1,0 +1,17 @@
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+//------------------------------------------------------------------------------
+// hardsigmoid
+//------------------------------------------------------------------------------
+kernel void kernel_hardsigmoid_f32(
+        global float * src0,
+        ulong offset0,
+        global float * dst,
+        ulong offsetd
+) {
+    src0 = (global float*)((global char*)src0 + offset0);
+    dst = (global float*)((global char*)dst + offsetd);
+
+    float x = src0[get_global_id(0)];
+    dst[get_global_id(0)] = fmin(1.0f, fmax(0.0f, (x + 3.0f) / 6.0f));
+}

--- a/ggml/src/ggml-opencl/kernels/hardswish.cl
+++ b/ggml/src/ggml-opencl/kernels/hardswish.cl
@@ -1,0 +1,17 @@
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+//------------------------------------------------------------------------------
+// hardswish
+//------------------------------------------------------------------------------
+kernel void kernel_hardswish_f32(
+        global float * src0,
+        ulong offset0,
+        global float * dst,
+        ulong offsetd
+) {
+    src0 = (global float*)((global char*)src0 + offset0);
+    dst = (global float*)((global char*)dst + offsetd);
+
+    float x = src0[get_global_id(0)];
+    dst[get_global_id(0)] = x * fmin(1.0f, fmax(0.0f, (x + 3.0f) / 6.0f));
+}

--- a/ggml/src/ggml-opencl/kernels/pool_2d.cl
+++ b/ggml/src/ggml-opencl/kernels/pool_2d.cl
@@ -1,0 +1,68 @@
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+//------------------------------------------------------------------------------
+// pool_2d
+//------------------------------------------------------------------------------
+// Contiguous NCHW F32 src/dst. op: 0 = MAX, 1 = AVG.
+kernel void kernel_pool_2d_f32(
+        global float * src0,
+        ulong offset0,
+        global float * dst,
+        ulong offsetd,
+        int op,
+        int k0,
+        int k1,
+        int s0,
+        int s1,
+        int p0,
+        int p1,
+        int IW,
+        int IH,
+        int OW,
+        int OH,
+        int np
+) {
+    src0 = (global float*)((global char*)src0 + offset0);
+    dst  = (global float*)((global char*)dst  + offsetd);
+
+    const int idx = get_global_id(0);
+    if (idx >= np) {
+        return;
+    }
+
+    const int nc     = idx / (OW * OH);
+    const int cur_oh = (idx / OW) % OH;
+    const int cur_ow = idx % OW;
+
+    global float * i_ptr = src0 + nc * IW * IH;
+    global float * o_ptr = dst  + nc * OW * OH;
+
+    const int start_h = cur_oh * s1 - p1;
+    const int bh      = max(0,  start_h);
+    const int eh      = min(IH, start_h + k1);
+
+    const int start_w = cur_ow * s0 - p0;
+    const int bw      = max(0,  start_w);
+    const int ew      = min(IW, start_w + k0);
+
+    if (op == 0) {
+        // MAX
+        float res = -INFINITY;
+        for (int i = bh; i < eh; ++i) {
+            for (int j = bw; j < ew; ++j) {
+                res = fmax(res, i_ptr[i * IW + j]);
+            }
+        }
+        o_ptr[cur_oh * OW + cur_ow] = res;
+    } else {
+        // AVG
+        float res = 0.0f;
+        for (int i = bh; i < eh; ++i) {
+            for (int j = bw; j < ew; ++j) {
+                res += i_ptr[i * IW + j];
+            }
+        }
+        const float scale = 1.0f / (float)(k0 * k1);
+        o_ptr[cur_oh * OW + cur_ow] = res * scale;
+    }
+}


### PR DESCRIPTION
## What

Re-homes the DocTR ggml-opencl ops onto the **b9341** fabric line. These are the
same kernels reviewed and merged for the 8828 line in
tetherto/qvac-fabric-llm.cpp#157 (tag `v8828.1.2`), cherry-picked onto the
b9341 base so they ship with the fabric version SDK 14 targets.

Ops added (no `CONV_TRANSPOSE_2D` — dropped during #157 review, unused by DocTR/EasyOCR):

- **HARDSIGMOID / HARDSWISH** (UNARY) — MobileNetV3 activations + SE blocks
- **POOL_2D** (AVG/MAX) — global average pool in SE blocks
- **CONV_2D_DW** (F32 weights) — depthwise conv in every inverted-residual block

Regular convs use the existing `conv2d_f16_f32` direct kernel (no new op). The OCR
pipeline runs the whole graph on a single backend, so any unsupported op is a hard
abort rather than a CPU offload — every op DocTR emits must exist in ggml-opencl.

## Why on a separate base

`temp-8828` was the interim test base (#157, `v8828.1.2`). The shipping base is
**b9341**, so the ops must exist there too or the OpenCL OCR feature would be
absent from the released fabric.

## Cherry-pick provenance

| b9341 commit | origin (8828 / #157) |
|---|---|
| `opencl : add CONV_2D_DW, POOL_2D, HARDSWISH, HARDSIGMOID kernels` | `23b0694c` |
| `ci : functionally test the OpenCL ops on an Intel CPU ICD` | `b2d6abbb` |
| `ci : drop -DLLAMA_FATAL_WARNINGS from opencl test job` | `4deb3021` |

Clean auto-merge onto the b9341-restructured `ggml-opencl.cpp` (which now carries
upstream's native `GGML_OP_CONV_2D`). Verified post-merge: all integration points
(struct fields, `load_cl_kernels`, `supports_op`, dispatch funcs,
`ggml_cl_compute_forward` switch, CMakeLists kernel registration) placed correctly;
all referenced symbols present in b9341; no duplicate definitions.

## Verification

The `ubuntu-24-opencl` CI job (added by these commits) compiles with
`GGML_OPENCL=ON` against an Intel CPU ICD and runs
`test-backend-ops test -o CONV_2D,CONV_2D_DW,POOL_2D,HARDSWISH,HARDSIGMOID`.
Numerically validated end-to-end on a Galaxy S25 (Adreno 830) on the 8828 line:
identical region count + OCR output vs CPU.

## ⚠️ Merge order — blocked by #144

This branch is built on top of the b9341 content from
tetherto/qvac-fabric-llm.cpp#144 (`qvac-b9341` → `temp-9341`), so the diff
currently includes that PR's commits. **Merge #144 first**, then this PR's diff
collapses to just the 3 ops commits above. Do not merge before #144.
