### PR TITLE
infra[notask]: add concurrency group, timeout, and fix issue-comment trigger in check-approvals

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -12,15 +12,20 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   check-approvals:
     name: Check Approvals
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     continue-on-error: true
     if: >-
       (
         github.event_name == 'issue_comment' &&
-        github.event.comment.body == 'pending_reviews' &&
+        contains(github.event.comment.body, 'review') &&
         github.event.issue.pull_request != null
       ) || (
         github.event_name == 'pull_request_target' &&


### PR DESCRIPTION
## Summary

Three improvements to `check-approvals.yml`, aligning it with the pattern already live on `qvac-workbench`:

### Changes
- `concurrency.group`: scoped to workflow + PR/issue number — prevents duplicate runs for the same PR
- `concurrency.cancel-in-progress: false`: preserves in-flight approval checks (intentional)
- `timeout-minutes: 30`: caps runaway jobs
- `issue_comment` trigger: changed from exact match `== 'pending_reviews'` to `contains(..., 'review')` — makes manual re-trigger consistent across all repos

No approval logic changes.