### PR TITLE
llama: add sequence token count memory API

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -793,6 +793,15 @@ extern "C" {
             llama_memory_t mem,
               llama_seq_id seq_id);
 
+    // Returns the number of memory cells currently associated with the
+    // specified sequence. This differs from pos_max - pos_min + 1 for models
+    // that can map multiple cache cells to the same logical position, such as
+    // M-RoPE multimodal image embeddings.
+    // seq_id < 0 : count all non-empty cells
+    LLAMA_API uint32_t llama_memory_seq_token_count(
+            llama_memory_t mem,
+              llama_seq_id seq_id);
+
     // Check if the memory supports shifting
     LLAMA_API bool llama_memory_can_shift(llama_memory_t mem);
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3657,6 +3657,16 @@ llama_pos llama_memory_seq_pos_max(
     return mem->seq_pos_max(seq_id);
 }
 
+uint32_t llama_memory_seq_token_count(
+        llama_memory_t mem,
+          llama_seq_id seq_id) {
+    if (!mem) {
+        return 0;
+    }
+
+    return mem->seq_token_count(seq_id);
+}
+
 bool llama_memory_can_shift(llama_memory_t mem) {
     if (!mem) {
         return false;

--- a/src/llama-kv-cache-iswa.cpp
+++ b/src/llama-kv-cache-iswa.cpp
@@ -115,6 +115,12 @@ llama_pos llama_kv_cache_iswa::seq_pos_max(llama_seq_id seq_id) const {
     return kv_swa->seq_pos_max(seq_id);
 }
 
+uint32_t llama_kv_cache_iswa::seq_token_count(llama_seq_id seq_id) const {
+    return std::max(
+        kv_base->seq_token_count(seq_id),
+        kv_swa->seq_token_count(seq_id));
+}
+
 std::map<ggml_backend_buffer_type_t, size_t> llama_kv_cache_iswa::memory_breakdown() const {
     std::map<ggml_backend_buffer_type_t, size_t> mb = kv_base->memory_breakdown();
     for (const auto & buft_size : kv_swa->memory_breakdown()) {

--- a/src/llama-kv-cache-iswa.h
+++ b/src/llama-kv-cache-iswa.h
@@ -55,6 +55,7 @@ public:
 
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
+    uint32_t  seq_token_count(llama_seq_id seq_id) const override;
 
     std::map<ggml_backend_buffer_type_t, size_t> memory_breakdown() const override;
 

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -708,6 +708,22 @@ llama_pos llama_kv_cache::seq_pos_max(llama_seq_id seq_id) const {
     return cells.seq_pos_max(seq_id);
 }
 
+uint32_t llama_kv_cache::seq_token_count(llama_seq_id seq_id) const {
+    if (seq_id < 0) {
+        uint32_t result = 0;
+        for (const auto & cells : v_cells) {
+            result += cells.seq_token_count(seq_id);
+        }
+        return result;
+    }
+
+    GGML_ASSERT((size_t) seq_id < seq_to_stream.size());
+
+    const auto & cells = v_cells[seq_to_stream[seq_id]];
+
+    return cells.seq_token_count(seq_id);
+}
+
 std::map<ggml_backend_buffer_type_t, size_t> llama_kv_cache::memory_breakdown() const {
     std::map<ggml_backend_buffer_type_t, size_t> ret;
     for (const auto & [ctx, buf] : ctxs_bufs) {

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -135,6 +135,7 @@ public:
 
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
+    uint32_t  seq_token_count(llama_seq_id seq_id) const override;
 
     std::map<ggml_backend_buffer_type_t, size_t> memory_breakdown() const override;
 

--- a/src/llama-kv-cells.h
+++ b/src/llama-kv-cells.h
@@ -334,6 +334,22 @@ public:
         return seq[i].test(seq_id);
     }
 
+    // number of cache cells that contain seq_id.
+    // seq_id < 0 counts all non-empty cells.
+    uint32_t seq_token_count(llama_seq_id seq_id) const {
+        if (seq_id < 0) {
+            return get_used();
+        }
+
+        uint32_t result = 0;
+        for (const uint32_t i : used) {
+            if (seq[i].test(seq_id)) {
+                ++result;
+            }
+        }
+        return result;
+    }
+
     // note: call only if the cell is not empty and the seq_id is not in the cell
     void seq_add(uint32_t i, llama_seq_id seq_id) {
         assert(i < pos.size());

--- a/src/llama-memory-hybrid-iswa.cpp
+++ b/src/llama-memory-hybrid-iswa.cpp
@@ -182,6 +182,12 @@ llama_pos llama_memory_hybrid_iswa::seq_pos_max(llama_seq_id seq_id) const {
     return std::min(mem_attn->seq_pos_max(seq_id), mem_recr->seq_pos_max(seq_id));
 }
 
+uint32_t llama_memory_hybrid_iswa::seq_token_count(llama_seq_id seq_id) const {
+    return std::max(
+        mem_attn->seq_token_count(seq_id),
+        mem_recr->seq_token_count(seq_id));
+}
+
 std::map<ggml_backend_buffer_type_t, size_t> llama_memory_hybrid_iswa::memory_breakdown() const {
     std::map<ggml_backend_buffer_type_t, size_t> mb = mem_attn->memory_breakdown();
     for (const auto & buft_size : mem_recr->memory_breakdown()) {

--- a/src/llama-memory-hybrid-iswa.h
+++ b/src/llama-memory-hybrid-iswa.h
@@ -68,6 +68,7 @@ public:
 
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
+    uint32_t  seq_token_count(llama_seq_id seq_id) const override;
 
     std::map<ggml_backend_buffer_type_t, size_t> memory_breakdown() const override;
 

--- a/src/llama-memory-hybrid.cpp
+++ b/src/llama-memory-hybrid.cpp
@@ -176,6 +176,12 @@ llama_pos llama_memory_hybrid::seq_pos_max(llama_seq_id seq_id) const {
     return std::min(mem_attn->seq_pos_max(seq_id), mem_recr->seq_pos_max(seq_id));
 }
 
+uint32_t llama_memory_hybrid::seq_token_count(llama_seq_id seq_id) const {
+    return std::max(
+        mem_attn->seq_token_count(seq_id),
+        mem_recr->seq_token_count(seq_id));
+}
+
 std::map<ggml_backend_buffer_type_t, size_t> llama_memory_hybrid::memory_breakdown() const {
     std::map<ggml_backend_buffer_type_t, size_t> mb = mem_attn->memory_breakdown();
     for (const auto & buft_size : mem_recr->memory_breakdown()) {

--- a/src/llama-memory-hybrid.h
+++ b/src/llama-memory-hybrid.h
@@ -68,6 +68,7 @@ public:
 
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
+    uint32_t  seq_token_count(llama_seq_id seq_id) const override;
 
     std::map<ggml_backend_buffer_type_t, size_t> memory_breakdown() const override;
 

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -389,6 +389,18 @@ llama_pos llama_memory_recurrent::seq_pos_max(llama_seq_id seq_id) const {
     return result;
 }
 
+uint32_t llama_memory_recurrent::seq_token_count(llama_seq_id seq_id) const {
+    uint32_t result = 0;
+
+    for (uint32_t i = 0; i < size; ++i) {
+        if (seq_id < 0 ? !cells[i].is_empty() : cells[i].has_seq_id(seq_id)) {
+            ++result;
+        }
+    }
+
+    return result;
+}
+
 void llama_memory_recurrent::set_rs_idx(llama_seq_id seq_id, uint32_t idx) {
     if (seq_id < 0 || (size_t) seq_id >= rs_idx.size()) {
         return;

--- a/src/llama-memory-recurrent.h
+++ b/src/llama-memory-recurrent.h
@@ -51,6 +51,7 @@ public:
 
     llama_pos seq_pos_min(llama_seq_id seq_id) const override;
     llama_pos seq_pos_max(llama_seq_id seq_id) const override;
+    uint32_t  seq_token_count(llama_seq_id seq_id) const override;
 
     std::map<ggml_backend_buffer_type_t, size_t> memory_breakdown() const override;
 

--- a/src/llama-memory.h
+++ b/src/llama-memory.h
@@ -111,6 +111,7 @@ struct llama_memory_i {
 
     virtual llama_pos seq_pos_min(llama_seq_id seq_id) const = 0;
     virtual llama_pos seq_pos_max(llama_seq_id seq_id) const = 0;
+    virtual uint32_t  seq_token_count(llama_seq_id seq_id) const = 0;
 
     virtual std::map<ggml_backend_buffer_type_t, size_t> memory_breakdown() const = 0;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -278,6 +278,10 @@ set_tests_properties(test-state-restore-fragmented PROPERTIES FIXTURES_REQUIRED 
 llama_build_and_test(test-save-load-state.cpp LABEL "model" ARGS -m "${MODEL_DEST}")
 set_tests_properties(test-save-load-state PROPERTIES FIXTURES_REQUIRED test-download-model)
 
+# Test sequence token-count memory API
+llama_build_and_test(test-memory-seq-token-count.cpp LABEL "model" ARGS -m "${MODEL_DEST}")
+set_tests_properties(test-memory-seq-token-count PROPERTIES FIXTURES_REQUIRED test-download-model)
+
 if (NOT GGML_BACKEND_DL)
     # these tests use the backends directly and cannot be built with dynamic loading
     llama_build_and_test(test-barrier.cpp)

--- a/tests/test-memory-seq-token-count.cpp
+++ b/tests/test-memory-seq-token-count.cpp
@@ -1,0 +1,87 @@
+#include "arg.h"
+#include "common.h"
+#include "llama.h"
+
+#include <cstdio>
+#include <vector>
+
+static bool decode_prompt(llama_context * ctx, const std::vector<llama_token> & tokens) {
+    llama_batch batch = llama_batch_init(tokens.size(), 0, 1);
+    for (size_t i = 0; i < tokens.size(); ++i) {
+        common_batch_add(batch, tokens[i], i, { 0 }, i == tokens.size() - 1);
+    }
+
+    const bool ok = llama_decode(ctx, batch) == 0;
+    llama_batch_free(batch);
+    return ok;
+}
+
+int main(int argc, char ** argv) {
+    common_params params;
+    params.n_ctx     = 128;
+    params.n_batch   = 32;
+    params.n_ubatch  = 32;
+    params.n_predict = 1;
+
+    common_init();
+
+    if (!common_params_parse(argc, argv, params, LLAMA_EXAMPLE_COMMON)) {
+        return 1;
+    }
+
+    ggml_backend_load_all();
+
+    common_init_result_ptr llama_init = common_init_from_params(params);
+    llama_model *          model      = llama_init->model();
+    llama_context *        ctx        = llama_init->context();
+
+    if (model == nullptr || ctx == nullptr) {
+        fprintf(stderr, "%s : failed to init\n", __func__);
+        return 1;
+    }
+
+    llama_memory_t mem = llama_get_memory(ctx);
+    if (mem == nullptr) {
+        fprintf(stderr, "%s : failed to get memory\n", __func__);
+        return 1;
+    }
+
+    GGML_ASSERT(llama_memory_seq_token_count(mem, 0) == 0);
+    GGML_ASSERT(llama_memory_seq_token_count(mem, -1) == 0);
+
+    std::vector<llama_token> tokens = common_tokenize(ctx, "The quick brown fox", true);
+    if (tokens.size() < 2) {
+        fprintf(stderr, "%s : prompt tokenized to fewer than two tokens\n", __func__);
+        return 1;
+    }
+
+    if (!decode_prompt(ctx, tokens)) {
+        fprintf(stderr, "%s : failed to decode prompt\n", __func__);
+        return 1;
+    }
+
+    const uint32_t n_tokens = static_cast<uint32_t>(tokens.size());
+    GGML_ASSERT(llama_memory_seq_token_count(mem, 0) == n_tokens);
+    GGML_ASSERT(llama_memory_seq_token_count(mem, -1) == n_tokens);
+    GGML_ASSERT(llama_memory_seq_pos_max(mem, 0) == static_cast<llama_pos>(n_tokens - 1));
+
+    if (!llama_memory_seq_rm(mem, 0, static_cast<llama_pos>(n_tokens - 1), -1)) {
+        fprintf(stderr, "%s : failed to remove tail token\n", __func__);
+        return 1;
+    }
+
+    GGML_ASSERT(llama_memory_seq_token_count(mem, 0) == n_tokens - 1);
+    GGML_ASSERT(llama_memory_seq_token_count(mem, -1) == n_tokens - 1);
+    GGML_ASSERT(llama_memory_seq_pos_max(mem, 0) == static_cast<llama_pos>(n_tokens - 2));
+
+    if (!llama_memory_seq_rm(mem, 0, -1, -1)) {
+        fprintf(stderr, "%s : failed to clear sequence\n", __func__);
+        return 1;
+    }
+
+    GGML_ASSERT(llama_memory_seq_token_count(mem, 0) == 0);
+    GGML_ASSERT(llama_memory_seq_token_count(mem, -1) == 0);
+    GGML_ASSERT(llama_memory_seq_pos_max(mem, 0) == -1);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add `llama_memory_seq_token_count()` to expose per-sequence memory cell occupancy.
- Implement the count across KV, recurrent, hybrid, and iSWA memory backends.
- Count physical cache cells so multimodal M-RoPE callers can distinguish cache occupancy from logical position spans.

## Test plan
- `cmake --build build --target llama`

