### PR TITLE
QVAC-21374 chore: bump @qvac/ci to 0.2.0

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -33,7 +33,7 @@ jobs:
       )
     steps:
       - name: Install @qvac/ci
-        run: npm install -g @qvac/ci@0.1.0
+        run: npm install -g @qvac/ci@0.2.0
 
       - name: Check Approvals
         continue-on-error: true


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

`@qvac/ci` has been published at `0.2.0`. This repo was pinned to `0.1.0` in the `check-approvals.yml` workflow. Staying on an old pin risks missing bug fixes and security patches shipped in the new release.

## 🔧 How does it solve the problem?

Bumps the `npm install -g @qvac/ci@0.1.0` install step to `@qvac/ci@0.2.0`.

## 🧪 How was it tested?

- `actionlint` passes on the updated workflow file (single-line string change, no structural modification)
- No new triggers, permissions, or action pins introduced
- Tested on the qvac-internal repository with the `pull_request` trigger and working as expected
  - Run: https://github.com/tetherto/qvac-internal/actions/runs/28153172039/job/83375393105?pr=38

## 🔗 References

Asana: https://app.asana.com/1/45238840754660/project/1214153063536860/task/1216020371732379