### PR TITLE
[testing] standalone qwen3vl encoder + CPU repack (do not merge)

### DIFF
--- a/tools/mtmd/CMakeLists.txt
+++ b/tools/mtmd/CMakeLists.txt
@@ -127,3 +127,35 @@ set_target_properties(llama-mtmd-debug PROPERTIES OUTPUT_NAME llama-mtmd-debug)
 target_link_libraries(llama-mtmd-debug PRIVATE llama-common mtmd Threads::Threads)
 target_compile_features(llama-mtmd-debug PRIVATE cxx_std_17)
 endif()
+
+# qvac: standalone Qwen3-VL vision encoder benchmark.
+# Compiles the clip encoder sources DIRECTLY (bypassing the mtmd lib, which
+# links llama) so the resulting binary depends only on ggml + backends. This
+# is the fast desktop/on-device iteration loop for optimizing the shared
+# Vulkan/OpenCL kernels. Enabled by default; toggle with LLAMA_QWEN3VL_ENCODER.
+option(LLAMA_QWEN3VL_ENCODER "build the standalone qwen3vl vision encoder benchmark" ON)
+if (LLAMA_QWEN3VL_ENCODER)
+    file(GLOB MTMD_MODEL_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/models/*.cpp)
+    add_executable(qwen3vl-encoder
+        qwen3vl-encoder/main.cpp
+        clip.cpp
+        mtmd-image.cpp
+        ${MTMD_MODEL_SOURCES}
+    )
+    target_include_directories(qwen3vl-encoder PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/../..            # repo root (ggml headers, etc.)
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../include     # llama.h (header-only, pulled via mtmd.h)
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../vendor       # vendored third-party
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../vendor/stb   # stb_image.h
+    )
+    target_link_libraries(qwen3vl-encoder PRIVATE ggml Threads::Threads)
+    target_compile_features(qwen3vl-encoder PRIVATE cxx_std_17)
+    if (NOT MSVC)
+        # stb_image.h + clip.cpp cast-qual warnings, same as the mtmd lib
+        target_compile_options(qwen3vl-encoder PRIVATE -Wno-cast-qual)
+    endif()
+    if (ANDROID)
+        target_compile_options(qwen3vl-encoder PRIVATE -Wno-missing-prototypes)
+    endif()
+endif()

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -158,6 +158,7 @@ struct clip_ctx {
     ggml_backend_t backend = nullptr;
     ggml_backend_t backend_cpu = nullptr;
     ggml_backend_buffer_ptr buf;
+    ggml_backend_buffer_ptr buf_repack; // CPU repack buffer for quantized weights
 
 
     int max_nodes = 8192;
@@ -2424,6 +2425,71 @@ struct clip_model_loader {
 
             // alloc memory and offload data
             ggml_backend_buffer_type_t buft = ggml_backend_get_default_buffer_type(ctx_clip.backend);
+            // On CPU, place quantized 2D weight matrices in the ggml "repack"
+            // extra buffer type (aarch64 i8mm interleaved layout, x86 AVX2, ...)
+            // so their mul_mat uses the much faster repacked GEMM. Only tensors
+            // the backend can actually repack+matmul go there (probed per-tensor);
+            // non-quant conv weights / biases / norms stay in the default buffer,
+            // else their non-matmul ops would become unsupported. On arches with
+            // no repack kernel the probe rejects everything and this is a no-op.
+            // Opt out with MTMD_CLIP_NO_REPACK=1.
+            if (ctx_clip.backend == ctx_clip.backend_cpu && !getenv("MTMD_CLIP_NO_REPACK")) {
+                ggml_backend_dev_t cpu_dev = ggml_backend_get_device(ctx_clip.backend_cpu);
+                ggml_backend_buffer_type_t repack_buft = nullptr;
+                if (cpu_dev) {
+                    ggml_backend_reg_t cpu_reg = ggml_backend_dev_backend_reg(cpu_dev);
+                    auto get_extra_bufts_fn = (ggml_backend_dev_get_extra_bufts_t)
+                        ggml_backend_reg_get_proc_address(cpu_reg, "ggml_backend_dev_get_extra_bufts");
+                    if (get_extra_bufts_fn) {
+                        ggml_backend_buffer_type_t * extra = get_extra_bufts_fn(cpu_dev);
+                        if (extra && extra[0]) repack_buft = extra[0];
+                    }
+                }
+                if (repack_buft) {
+                    // A weight goes to the repack buffer only if THIS arch can
+                    // actually repack it AND run its mul_mat there (probe like
+                    // llama's buft_supported). This is arch-correct: on x86 q8_0
+                    // isn't repackable so the probe fails and weights stay default;
+                    // on ARM (NEON+i8mm) it passes.
+                    ggml_backend_dev_t probe_dev = ggml_backend_get_device(ctx_clip.backend_cpu);
+                    ggml_backend_buffer_t probe_buf = ggml_backend_buft_alloc_buffer(repack_buft, 0);
+                    auto repack_ok = [&](const ggml_tensor * w) -> bool {
+                        if (ggml_n_dims(w) != 2) return false;
+                        ggml_init_params p = { ggml_tensor_overhead() * 4 + 256, nullptr, true };
+                        ggml_context * mctx = ggml_init(p);
+                        if (!mctx) return false;
+                        ggml_tensor * w2 = ggml_new_tensor_2d(mctx, w->type, w->ne[0], w->ne[1]);
+                        ggml_tensor * s1 = ggml_new_tensor_2d(mctx, GGML_TYPE_F32, w->ne[0], 8);
+                        ggml_tensor * op = ggml_mul_mat(mctx, w2, s1);
+                        w2->buffer = probe_buf; // pretend the weight lives in the repack buffer
+                        bool ok = ggml_backend_dev_supports_op(probe_dev, op);
+                        ggml_free(mctx);
+                        return ok;
+                    };
+                    // collect repackable weights
+                    std::vector<ggml_tensor *> repack_tensors;
+                    const size_t align = ggml_backend_buft_get_alignment(repack_buft);
+                    size_t repack_size = 0;
+                    for (ggml_tensor * t = ggml_get_first_tensor(ctx_clip.ctx_data.get());
+                         t != nullptr; t = ggml_get_next_tensor(ctx_clip.ctx_data.get(), t)) {
+                        if (repack_ok(t)) {
+                            repack_tensors.push_back(t);
+                            repack_size += GGML_PAD(ggml_backend_buft_get_alloc_size(repack_buft, t), align);
+                        }
+                    }
+                    if (probe_buf) ggml_backend_buffer_free(probe_buf);
+                    if (!repack_tensors.empty()) {
+                        ctx_clip.buf_repack.reset(ggml_backend_buft_alloc_buffer(repack_buft, repack_size));
+                        ggml_backend_buffer_set_usage(ctx_clip.buf_repack.get(), GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
+                        ggml_tallocr talloc = ggml_tallocr_new(ctx_clip.buf_repack.get());
+                        for (ggml_tensor * t : repack_tensors) ggml_tallocr_alloc(&talloc, t);
+                        LOG_INF("%s: repacked %zu quantized weights into %s (%.1f MiB)\n",
+                                __func__, repack_tensors.size(), ggml_backend_buft_name(repack_buft),
+                                repack_size / 1024.0 / 1024.0);
+                    }
+                }
+            }
+            // allocate everything not already placed (i.e. the non-repack tensors)
             ctx_clip.buf.reset(ggml_backend_alloc_ctx_tensors_from_buft(ctx_clip.ctx_data.get(), buft));
             ggml_backend_buffer_set_usage(ctx_clip.buf.get(), GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
             std::vector<float>       conv_f32;
@@ -2454,7 +2520,10 @@ struct clip_model_loader {
                                           conv_f32.data(), n);
                     ggml_fp32_to_fp16_row(conv_f32.data(), conv_f16.data(), n);
                     const size_t dst_bytes = ggml_nbytes(cur); // f16 layout
-                    if (ggml_backend_buft_is_host(buft)) {
+                    // check the tensor's OWN buffer (weights may be split
+                    // across the default host buffer and the non-host repack buffer)
+                    const bool cur_is_host = ggml_backend_buft_is_host(ggml_backend_buffer_get_type(cur->buffer));
+                    if (cur_is_host) {
                         memcpy(cur->data, conv_f16.data(), dst_bytes);
                     } else {
                         ggml_backend_tensor_set(cur, conv_f16.data(), 0, dst_bytes);
@@ -2462,7 +2531,8 @@ struct clip_model_loader {
                     continue;
                 }
                 size_t num_bytes = ggml_nbytes(cur);
-                if (ggml_backend_buft_is_host(buft)) {
+                const bool cur_is_host = ggml_backend_buft_is_host(ggml_backend_buffer_get_type(cur->buffer));
+                if (cur_is_host) {
                     // for the CPU and Metal backend, we can read directly into the tensor
                     fin.read(reinterpret_cast<char *>(cur->data), num_bytes);
                 } else {

--- a/tools/mtmd/qwen3vl-encoder/main.cpp
+++ b/tools/mtmd/qwen3vl-encoder/main.cpp
@@ -1,0 +1,508 @@
+// qvac: standalone Qwen3-VL vision encoder benchmark.
+//
+// Runs ONLY the vision encoder (ViT + patch-merge projection) of a Qwen3-VL
+// mmproj GGUF through ggml, with no dependency on libllama / the SSM-LLM half
+// of fabric. This gives a seconds-scale edit -> build -> run loop for
+// optimizing the Vulkan / OpenCL kernels shared with production clip.cpp,
+// plus a cosine-similarity check so every kernel change stays lossless.
+//
+// Build target: qwen3vl-encoder  (see tools/mtmd/CMakeLists.txt)
+//
+// Usage:
+//   qwen3vl-encoder --mmproj <mmproj.gguf> --image <img.jpg>
+//                   [--backend cpu|vulkan|opencl|gpu|all]
+//                   [--device <ggml-dev-name>]
+//                   [--threads N] [--iters N] [--list-devices]
+//                   [--dump <out.bin>]  [--ref <ref.bin>] [--cos-min 0.9999]
+//
+//   --backend cpu      : CPU only
+//   --backend vulkan   : the GPU device whose name contains "Vulkan"
+//   --backend opencl   : the GPU device whose name contains "OpenCL"
+//   --backend gpu      : every GPU device found
+//   --backend all      : CPU + every GPU device found  (used on-device: the
+//                        Pixel emits a Vulkan line, the S25 emits an OpenCL line)
+//   --device <name>    : force one specific ggml backend device by exact name
+//   --dump  <out.bin>  : (single-backend runs) write the raw float32 embedding
+//   --ref   <ref.bin>  : (single-backend runs) cosine-sim vs a reference; exit
+//                        non-zero if below --cos-min (default 0.9999)
+
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"
+
+#include "clip.h"
+#include "clip-impl.h"   // clip_image_u8/f32 structs, clip_get_projector_type
+#include "clip-model.h"  // clip_hparams, clip_get_hparams
+#include "mtmd-image.h"  // mtmd_image_preprocessor_dyn_size
+
+#include "ggml.h"
+#include "ggml-backend.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+static void print_usage(const char * prog) {
+    fprintf(stderr,
+        "usage: %s --mmproj <mmproj.gguf> --image <img.jpg>\n"
+        "          [--backend cpu|vulkan|opencl|gpu|all] [--device <name>]\n"
+        "          [--threads N] [--iters N] [--list-devices]\n"
+        "          [--dump <out.bin>] [--ref <ref.bin>] [--cos-min <f>]\n",
+        prog);
+}
+
+struct options {
+    std::string mmproj;
+    std::string image;
+    std::string backend = "cpu";
+    std::string device;   // explicit ggml device name (optional)
+    std::string dump;
+    std::string ref;
+    int   threads = 4;
+    int   iters   = 10;
+    float cos_min = 0.9999f;
+    bool  list_devices = false;
+};
+
+static std::string to_lower(std::string s) {
+    for (auto & c : s) c = (char) std::tolower((unsigned char) c);
+    return s;
+}
+
+// mobile GPUs (Mali, Adreno) and desktop iGPUs report IGPU (unified memory),
+// discrete cards report GPU. Treat both as "a GPU backend to try".
+static bool is_gpu_like(ggml_backend_dev_t d) {
+    int t = (int) ggml_backend_dev_type(d);
+    return t == GGML_BACKEND_DEVICE_TYPE_GPU || t == GGML_BACKEND_DEVICE_TYPE_IGPU;
+}
+
+static bool parse_args(int argc, char ** argv, options & o) {
+    for (int i = 1; i < argc; i++) {
+        std::string a = argv[i];
+        auto next = [&](const char * name) -> const char * {
+            if (i + 1 >= argc) { fprintf(stderr, "missing value for %s\n", name); return nullptr; }
+            return argv[++i];
+        };
+        if (a == "--mmproj")            { auto v = next("--mmproj");  if (!v) return false; o.mmproj  = v; }
+        else if (a == "--image")        { auto v = next("--image");   if (!v) return false; o.image   = v; }
+        else if (a == "--backend")      { auto v = next("--backend"); if (!v) return false; o.backend = v; }
+        else if (a == "--device")       { auto v = next("--device");  if (!v) return false; o.device  = v; }
+        else if (a == "--dump")         { auto v = next("--dump");    if (!v) return false; o.dump    = v; }
+        else if (a == "--ref")          { auto v = next("--ref");     if (!v) return false; o.ref     = v; }
+        else if (a == "--threads")      { auto v = next("--threads"); if (!v) return false; o.threads = atoi(v); }
+        else if (a == "--iters")        { auto v = next("--iters");   if (!v) return false; o.iters   = atoi(v); }
+        else if (a == "--cos-min")      { auto v = next("--cos-min"); if (!v) return false; o.cos_min = (float) atof(v); }
+        else if (a == "--list-devices") { o.list_devices = true; }
+        else if (a == "-h" || a == "--help") { print_usage(argv[0]); exit(0); }
+        else { fprintf(stderr, "unknown arg: %s\n", a.c_str()); return false; }
+    }
+    return true;
+}
+
+// load an image file (jpg/png/...) into an RGB clip_image_u8 via stb_image.
+static bool load_image_u8(const std::string & path, clip_image_u8 * out) {
+    int nx = 0, ny = 0, nc = 0;
+    unsigned char * data = stbi_load(path.c_str(), &nx, &ny, &nc, 3);
+    if (!data) {
+        fprintf(stderr, "error: failed to load image '%s': %s\n", path.c_str(), stbi_failure_reason());
+        return false;
+    }
+    clip_build_img_from_pixels(data, nx, ny, out);
+    stbi_image_free(data);
+    return true;
+}
+
+static double cosine_similarity(const std::vector<float> & a, const std::vector<float> & b) {
+    if (a.size() != b.size() || a.empty()) return -2.0;
+    double dot = 0.0, na = 0.0, nb = 0.0;
+    for (size_t i = 0; i < a.size(); i++) {
+        dot += (double) a[i] * (double) b[i];
+        na  += (double) a[i] * (double) a[i];
+        nb  += (double) b[i] * (double) b[i];
+    }
+    if (na == 0.0 || nb == 0.0) return -2.0;
+    return dot / (std::sqrt(na) * std::sqrt(nb));
+}
+
+// one backend configuration to run
+struct run_cfg {
+    std::string label;    // human label for the [ENC_RESULT] line
+    bool        use_gpu;
+    std::string device;   // exact ggml device name, or "" for auto
+};
+
+static void list_devices() {
+    size_t n = ggml_backend_dev_count();
+    fprintf(stdout, "[enc] %zu ggml backend device(s):\n", n);
+    for (size_t i = 0; i < n; i++) {
+        ggml_backend_dev_t d = ggml_backend_dev_get(i);
+        const char * name = ggml_backend_dev_name(d);
+        const char * desc = ggml_backend_dev_description(d);
+        int type = (int) ggml_backend_dev_type(d);
+        fprintf(stdout, "  [%zu] name='%s' type=%d desc='%s'\n", i, name ? name : "?", type, desc ? desc : "?");
+    }
+    fflush(stdout);
+}
+
+// find first GPU device whose (lowercased) name contains `key`; "" if none.
+static std::string find_gpu_device(const std::string & key) {
+    std::string k = to_lower(key);
+    size_t n = ggml_backend_dev_count();
+    for (size_t i = 0; i < n; i++) {
+        ggml_backend_dev_t d = ggml_backend_dev_get(i);
+        if (!is_gpu_like(d)) continue;
+        std::string name = to_lower(ggml_backend_dev_name(d) ? ggml_backend_dev_name(d) : "");
+        if (name.find(k) != std::string::npos) return ggml_backend_dev_name(d);
+    }
+    return "";
+}
+
+// run a single backend config end-to-end; returns process-style rc (0 ok).
+// on success the final embedding is written to out_vec (for cross-backend
+// accuracy comparison by the caller).
+static int run_encode(const options & o, const run_cfg & cfg, const clip_image_u8 & u8,
+                      std::vector<float> & out_vec, bool allow_dump_ref) {
+    clip_context_params cp{};
+    cp.use_gpu           = cfg.use_gpu;
+    cp.flash_attn_type   = CLIP_FLASH_ATTN_TYPE_AUTO;
+    cp.image_min_tokens  = -1;
+    cp.image_max_tokens  = -1;
+    cp.warmup            = true;
+    cp.has_bf16_weights  = false;
+    cp.cb_eval           = nullptr;
+    cp.cb_eval_user_data = nullptr;
+    cp.backend_device    = cfg.device.empty() ? nullptr : cfg.device.c_str();
+
+    fprintf(stderr, "[enc] === config '%s' (use_gpu=%d device=%s) ===\n",
+            cfg.label.c_str(), (int) cfg.use_gpu, cfg.device.empty() ? "(auto)" : cfg.device.c_str());
+
+    clip_init_result init = clip_init(o.mmproj.c_str(), cp);
+    clip_ctx * ctx = init.ctx_v;
+    if (!ctx) {
+        fprintf(stderr, "[enc] SKIP '%s': clip_init failed / backend unavailable\n", cfg.label.c_str());
+        return 1;
+    }
+
+    clip_image_f32_batch batch;
+    {
+        mtmd_image_preprocessor_dyn_size pp(ctx);
+        if (!pp.preprocess(u8, batch)) {
+            fprintf(stderr, "[enc] SKIP '%s': preprocess failed\n", cfg.label.c_str());
+            clip_free(ctx);
+            return 1;
+        }
+    }
+
+    const int n_embd = clip_n_mmproj_embd(ctx);
+    size_t total_tokens = 0;
+    for (auto & e : batch.entries) total_tokens += (size_t) clip_n_output_tokens(ctx, e.get());
+    out_vec.assign(total_tokens * (size_t) n_embd, 0.0f);
+    std::vector<float> & vec = out_vec;
+
+    for (int i = 0; i < 3; i++) { // warmup
+        if (!clip_image_batch_encode(ctx, o.threads, &batch, vec.data())) {
+            fprintf(stderr, "[enc] FAIL '%s': encode failed (warmup)\n", cfg.label.c_str());
+            clip_free(ctx);
+            return 1;
+        }
+    }
+
+    const int64_t t0 = ggml_time_us();
+    for (int i = 0; i < o.iters; i++) {
+        if (!clip_image_batch_encode(ctx, o.threads, &batch, vec.data())) {
+            fprintf(stderr, "[enc] FAIL '%s': encode failed (iter %d)\n", cfg.label.c_str(), i);
+            clip_free(ctx);
+            return 1;
+        }
+    }
+    const int64_t t1 = ggml_time_us();
+    const double avg_ms = (t1 - t0) / 1000.0 / o.iters;
+
+    fprintf(stdout,
+        "[ENC_RESULT] label=%s device=%s tokens=%zu embd=%d iters=%d avg_ms=%.3f\n",
+        cfg.label.c_str(), cfg.device.empty() ? "(auto)" : cfg.device.c_str(),
+        total_tokens, n_embd, o.iters, avg_ms);
+    fflush(stdout);
+
+    int rc = 0;
+    if (allow_dump_ref && !o.dump.empty()) {
+        FILE * f = fopen(o.dump.c_str(), "wb");
+        if (f) { fwrite(vec.data(), sizeof(float), vec.size(), f); fclose(f);
+            fprintf(stderr, "[enc] dumped %zu floats to %s\n", vec.size(), o.dump.c_str()); }
+        else { fprintf(stderr, "error: cannot open dump file %s\n", o.dump.c_str()); rc = 1; }
+    }
+    if (allow_dump_ref && !o.ref.empty()) {
+        FILE * f = fopen(o.ref.c_str(), "rb");
+        if (!f) { fprintf(stderr, "error: cannot open ref file %s\n", o.ref.c_str()); rc = 1; }
+        else {
+            std::vector<float> ref(vec.size());
+            size_t got = fread(ref.data(), sizeof(float), ref.size(), f);
+            fclose(f);
+            if (got != ref.size()) {
+                fprintf(stderr, "error: ref size mismatch (got %zu, expected %zu)\n", got, ref.size());
+                rc = 1;
+            } else {
+                double cos = cosine_similarity(vec, ref);
+                fprintf(stdout, "[ENC_COSSIM] label=%s cos=%.8f min=%.8f %s\n",
+                        cfg.label.c_str(), cos, (double) o.cos_min, cos >= o.cos_min ? "PASS" : "FAIL");
+                fflush(stdout);
+                if (cos < o.cos_min) rc = 1;
+            }
+        }
+    }
+
+    clip_free(ctx);
+    return rc;
+}
+
+// CPU tuning sweep: for each flash-attn setting (needs re-init) loop a set of
+// thread counts (per-encode, no re-init) so one on-device run yields the whole
+// matrix. Also reports a compute-only steady-state floor per flash setting via
+// the in-graph re-run (isolates graph-build/alloc overhead from raw compute).
+static int run_cpu_sweep(const options & o, const clip_image_u8 & u8) {
+    const int thread_list[] = { 2, 3, 4, 6 };
+    struct flash_opt { const char * name; clip_flash_attn_type t; };
+    const flash_opt flash_opts[] = {
+        { "faAuto", CLIP_FLASH_ATTN_TYPE_AUTO },
+        { "faOff",  CLIP_FLASH_ATTN_TYPE_DISABLED },
+    };
+
+    int ran = 0;
+    for (const auto & fo : flash_opts) {
+        clip_context_params cp{};
+        cp.use_gpu = false;
+        cp.flash_attn_type = fo.t;
+        cp.image_min_tokens = -1;
+        cp.image_max_tokens = -1;
+        cp.warmup = true;
+        cp.has_bf16_weights = false;
+        cp.cb_eval = nullptr;
+        cp.cb_eval_user_data = nullptr;
+        cp.backend_device = nullptr;
+
+        fprintf(stderr, "[enc] === cpu-sweep flash=%s ===\n", fo.name);
+        clip_init_result init = clip_init(o.mmproj.c_str(), cp);
+        clip_ctx * ctx = init.ctx_v;
+        if (!ctx) { fprintf(stderr, "[enc] sweep: clip_init failed (flash=%s)\n", fo.name); continue; }
+
+        clip_image_f32_batch batch;
+        {
+            mtmd_image_preprocessor_dyn_size pp(ctx);
+            if (!pp.preprocess(u8, batch)) { fprintf(stderr, "[enc] sweep: preprocess failed\n"); clip_free(ctx); continue; }
+        }
+        const int n_embd = clip_n_mmproj_embd(ctx);
+        size_t total_tokens = 0;
+        for (auto & e : batch.entries) total_tokens += (size_t) clip_n_output_tokens(ctx, e.get());
+        std::vector<float> vec(total_tokens * (size_t) n_embd);
+
+        for (int th : thread_list) {
+            for (int i = 0; i < 2; i++) clip_image_batch_encode(ctx, th, &batch, vec.data()); // warmup
+            const int64_t t0 = ggml_time_us();
+            for (int i = 0; i < o.iters; i++) clip_image_batch_encode(ctx, th, &batch, vec.data());
+            const int64_t t1 = ggml_time_us();
+            const double avg = (t1 - t0) / 1000.0 / o.iters;
+            fprintf(stdout, "[ENC_RESULT] label=cpu-%s-t%d tokens=%zu embd=%d iters=%d avg_ms=%.3f\n",
+                    fo.name, th, total_tokens, n_embd, o.iters, avg);
+            fflush(stdout);
+            ran++;
+        }
+        clip_free(ctx);
+    }
+    fprintf(stdout, "[ENC_DONE] cpu-sweep ran=%d rc=%d\n", ran, ran > 0 ? 0 : 1);
+    fflush(stdout);
+    return ran > 0 ? 0 : 1;
+}
+
+// ---- per-op CPU profiler via the scheduler eval callback ----
+// The callback brackets each graph node (ask=true just before, ask=false just
+// after it computes on CPU), so elapsed time attributes to that node's op.
+struct prof_state {
+    std::map<std::string, double> op_ms;   // total ms per op type
+    std::map<std::string, long>   op_cnt;  // node count per op type
+    int64_t t0 = 0;
+    bool    counting = false;              // ignore warmup
+};
+
+static bool prof_eval_cb(struct ggml_tensor * t, bool ask, void * ud) {
+    prof_state * p = static_cast<prof_state *>(ud);
+    if (ask) {
+        p->t0 = ggml_time_us();
+    } else if (p->counting) {
+        const double dt_ms = (ggml_time_us() - p->t0) / 1000.0;
+        const char * name = ggml_op_name(t->op);
+        p->op_ms[name]  += dt_ms;
+        p->op_cnt[name] += 1;
+    }
+    return true; // observe every node
+}
+
+static int run_cpu_prof(const options & o, const clip_image_u8 & u8) {
+    prof_state prof;
+
+    clip_context_params cp{};
+    cp.use_gpu = false;
+    cp.flash_attn_type = CLIP_FLASH_ATTN_TYPE_AUTO;
+    cp.image_min_tokens = -1;
+    cp.image_max_tokens = -1;
+    cp.warmup = true;
+    cp.has_bf16_weights = false;
+    cp.cb_eval = prof_eval_cb;
+    cp.cb_eval_user_data = &prof;
+    cp.backend_device = nullptr;
+
+    clip_init_result init = clip_init(o.mmproj.c_str(), cp);
+    clip_ctx * ctx = init.ctx_v;
+    if (!ctx) { fprintf(stderr, "[enc] prof: clip_init failed\n"); return 1; }
+
+    clip_image_f32_batch batch;
+    {
+        mtmd_image_preprocessor_dyn_size pp(ctx);
+        if (!pp.preprocess(u8, batch)) { fprintf(stderr, "[enc] prof: preprocess failed\n"); clip_free(ctx); return 1; }
+    }
+    const int n_embd = clip_n_mmproj_embd(ctx);
+    size_t total_tokens = 0;
+    for (auto & e : batch.entries) total_tokens += (size_t) clip_n_output_tokens(ctx, e.get());
+    std::vector<float> vec(total_tokens * (size_t) n_embd);
+
+    const int threads = o.threads > 0 ? o.threads : 4;
+    for (int i = 0; i < 2; i++) clip_image_batch_encode(ctx, threads, &batch, vec.data()); // warmup (not counted)
+
+    prof.counting = true;
+    const int iters = o.iters > 0 ? o.iters : 6;
+    const int64_t t0 = ggml_time_us();
+    for (int i = 0; i < iters; i++) clip_image_batch_encode(ctx, threads, &batch, vec.data());
+    const int64_t t1 = ggml_time_us();
+    prof.counting = false;
+    const double total_ms = (t1 - t0) / 1000.0 / iters;
+
+    fprintf(stdout, "[ENC_RESULT] label=cpu-prof-t%d tokens=%zu embd=%d iters=%d avg_ms=%.3f\n",
+            threads, total_tokens, n_embd, iters, total_ms);
+
+    // sort ops by total time desc and print the breakdown (per-encode ms)
+    std::vector<std::pair<std::string, double>> items(prof.op_ms.begin(), prof.op_ms.end());
+    std::sort(items.begin(), items.end(),
+              [](const std::pair<std::string,double>&a, const std::pair<std::string,double>&b){ return a.second > b.second; });
+    for (const auto & it : items) {
+        const double per_encode = it.second / iters;
+        const double pct = 100.0 * it.second / ((t1 - t0) / 1000.0);
+        fprintf(stdout, "[ENC_PROF] op=%-12s ms=%8.2f pct=%5.1f nodes/enc=%ld\n",
+                it.first.c_str(), per_encode, pct, prof.op_cnt[it.first] / iters);
+    }
+    fprintf(stdout, "[ENC_DONE] cpu-prof rc=0\n");
+    fflush(stdout);
+    clip_free(ctx);
+    return 0;
+}
+
+int main(int argc, char ** argv) {
+    options o;
+    if (!parse_args(argc, argv, o)) { print_usage(argv[0]); return 1; }
+
+    if (o.list_devices) { list_devices(); return 0; }
+
+    if (o.mmproj.empty() || o.image.empty()) {
+        fprintf(stderr, "error: --mmproj and --image are required\n");
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    fprintf(stderr, "[enc] mmproj=%s backend=%s threads=%d iters=%d\n",
+            o.mmproj.c_str(), o.backend.c_str(), o.threads, o.iters);
+    list_devices();
+
+    // load the image once (backend-independent u8 RGB).
+    clip_image_u8 * u8 = clip_image_u8_init();
+    if (!load_image_u8(o.image, u8)) { clip_image_u8_free(u8); return 1; }
+
+    // CPU tuning sweep (thread x flash matrix) short-circuits the normal path.
+    if (o.backend == "cpu-sweep") {
+        int rc = run_cpu_sweep(o, *u8);
+        clip_image_u8_free(u8);
+        return rc;
+    }
+    // Per-op CPU profiler (attributes encode time by ggml op).
+    if (o.backend == "cpu-prof") {
+        int rc = run_cpu_prof(o, *u8);
+        clip_image_u8_free(u8);
+        return rc;
+    }
+
+    // build the list of backend configs to run.
+    std::vector<run_cfg> cfgs;
+    if (!o.device.empty()) {
+        cfgs.push_back({ "device:" + o.device, true, o.device });
+    } else if (o.backend == "cpu") {
+        cfgs.push_back({ "cpu", false, "" });
+    } else if (o.backend == "vulkan") {
+        cfgs.push_back({ "vulkan", true, find_gpu_device("vulkan") });
+    } else if (o.backend == "opencl") {
+        cfgs.push_back({ "opencl", true, find_gpu_device("opencl") });
+    } else if (o.backend == "gpu" || o.backend == "all") {
+        if (o.backend == "all") cfgs.push_back({ "cpu", false, "" });
+        size_t n = ggml_backend_dev_count();
+        for (size_t i = 0; i < n; i++) {
+            ggml_backend_dev_t d = ggml_backend_dev_get(i);
+            if (!is_gpu_like(d)) continue;
+            const char * name = ggml_backend_dev_name(d);
+            cfgs.push_back({ std::string("gpu:") + (name ? name : "?"), true, name ? name : "" });
+        }
+    } else {
+        fprintf(stderr, "error: unknown --backend '%s'\n", o.backend.c_str());
+        clip_image_u8_free(u8);
+        return 1;
+    }
+
+    // dump/ref only make sense for a single-config run.
+    const bool allow_dump_ref = (cfgs.size() == 1);
+
+    int rc = 0;
+    int ran = 0;
+    // In multi-backend mode we use the CPU run as the accuracy reference and
+    // report cosine similarity for every GPU backend against it — this is the
+    // on-device losslessness check (token count alone does NOT prove the GPU
+    // embedding is correct).
+    std::vector<float> cpu_ref;
+    bool have_ref = false;
+    for (const auto & cfg : cfgs) {
+        std::vector<float> vec;
+        int r = run_encode(o, cfg, *u8, vec, allow_dump_ref);
+        if (r == 0) ran++;
+
+        if (r == 0 && cfgs.size() > 1) {
+            if (!cfg.use_gpu && !have_ref) {
+                cpu_ref = vec;          // CPU is the trusted reference
+                have_ref = true;
+            } else if (cfg.use_gpu && have_ref) {
+                // Cross-backend (GPU vs CPU) tolerates normal fp16-accumulate
+                // divergence (~0.995); a garbage/broken backend scores ~0. Use a
+                // looser bar than the same-backend regression threshold, but
+                // always print the exact cos so the real accuracy is visible.
+                const double cross_min = 0.99;
+                double cos = cosine_similarity(vec, cpu_ref);
+                bool pass = cos >= cross_min;
+                fprintf(stdout, "[ENC_COSSIM] label=%s cos=%.8f min=%.8f %s (vs cpu)\n",
+                        cfg.label.c_str(), cos, cross_min, pass ? "PASS" : "FAIL");
+                fflush(stdout);
+                if (!pass) rc = 1;      // a GPU backend that truly diverges is a failure
+            }
+        }
+
+        // in multi-backend mode, a skipped/failed backend is non-fatal.
+        if (cfgs.size() == 1) rc = r;
+    }
+    if (cfgs.size() > 1 && ran == 0) rc = 1; // nothing ran at all
+    if (cfgs.size() > 1 && !have_ref) {
+        fprintf(stderr, "[enc] WARN: no CPU reference ran; GPU accuracy not checked\n");
+    }
+
+    clip_image_u8_free(u8);
+    fprintf(stdout, "[ENC_DONE] ran=%d/%zu rc=%d\n", ran, cfgs.size(), rc);
+    fflush(stdout);
+    return rc;
+}

--- a/tools/mtmd/qwen3vl-encoder/standalone_loop.md
+++ b/tools/mtmd/qwen3vl-encoder/standalone_loop.md
@@ -1,0 +1,251 @@
+# Standalone Qwen3-VL Encoder — Firebase Loop Runbook
+
+How to build the standalone vision encoder, cross-compile it for Android, wrap
+it in a game-loop APK, and run it on **Firebase Test Lab** (Pixel 9 Pro / Vulkan
+and Galaxy S25 / OpenCL) — with an on-device cosine-similarity accuracy check.
+
+The encoder (`tools/mtmd/qwen3vl-encoder/main.cpp`) runs ONLY the vision encoder
+(ViT + patch-merge projection) through ggml — **no libllama, no LLM**. It links
+only `ggml` + backends, so builds and iterates fast.
+
+> Paths below are for this dev box. Fabric tree:
+> `/home/olya/claude_folders/qvac-fabric-llm.cpp` (branch
+> `feat/qwen3vl-standalone-encoder`). APK harness:
+> `/home/olya/claude_folders/qwen3vl-encoder-apk`.
+
+---
+
+## 0. Assets
+
+- q8 mmproj: `.../llm-llamacpp/test/model/mmproj-Qwen3.5-0.8B-Q8_0.gguf`
+- image: `.../llm-llamacpp/test/mobile-profile/testAssets/elephant.jpg` (612×408
+  → 247 tokens)
+
+## 1. CLI
+
+```
+qwen3vl-encoder --mmproj <q8.gguf> --image <img>
+                --backend cpu|vulkan|opencl|gpu|all
+                [--device NAME] [--threads N] [--iters N]
+                [--list-devices] [--dump out.bin] [--ref ref.bin] [--cos-min f]
+```
+
+- `--backend all` — CPU + every GPU device. **This is what the APK uses.** CPU
+  runs first as the accuracy reference; every GPU backend is then cos-sim'd
+  against it and prints `[ENC_COSSIM] label=.. cos=.. PASS/FAIL (vs cpu)`.
+- Output lines: `[ENC_RESULT] label=.. tokens=.. avg_ms=..`,
+  `[ENC_COSSIM] ..`, `[ENC_DONE] ran=N/M rc=..`.
+- **Accuracy bar:** same-backend regression (`--ref`) uses `--cos-min` (default
+  0.9999, ~1.0 expected). Cross-backend GPU-vs-CPU uses a built-in 0.99 (normal
+  fp16 divergence ~0.995 PASS; a broken backend ~0.6 FAIL). **Token count alone
+  is NOT correctness** — always read the cos.
+
+---
+
+## 2. Local build + verify (desktop, clang-22, Vulkan)
+
+```bash
+cd /home/olya/claude_folders/qvac-fabric-llm.cpp
+
+cmake -S . -B build-encoder -G Ninja -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER=clang-22 -DCMAKE_CXX_COMPILER=clang++-22 \
+  -DGGML_VULKAN=ON \
+  -DLLAMA_BUILD_TOOLS=OFF -DLLAMA_BUILD_COMMON=OFF -DLLAMA_MTMD=ON \
+  -DLLAMA_BUILD_SERVER=OFF -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF \
+  -DLLAMA_CURL=OFF
+
+cmake --build build-encoder --target qwen3vl-encoder -j12   # only ggml+vulkan+enc
+
+# CPU golden + Vulkan, with cross-backend cos-sim:
+./build-encoder/bin/qwen3vl-encoder --mmproj <q8.gguf> --image <elephant.jpg> \
+  --backend all --iters 5
+```
+
+Expect `tokens=247`, and Vulkan `cos ~0.9952 PASS (vs cpu)`.
+
+---
+
+## 3. Android cross-compile (NDK r27.2, ARM64)
+
+Two **separate** single-backend builds (a combined binary hard-`NEEDED`s both
+`libggml-vulkan.so` AND `libggml-opencl.so`; if `libOpenCL.so` can't resolve on
+a device the whole binary fails to launch — losing the good backend too).
+
+### 3a. Vulkan (for Pixel)
+
+```bash
+NDK=$ANDROID_NDK_HOME
+SPIRV_INC=/usr/local/share/vcpkg/packages/spirv-headers_arm64-android/include
+
+cmake -S . -B build-android-vk -G Ninja \
+  -DCMAKE_TOOLCHAIN_FILE=$NDK/build/cmake/android.toolchain.cmake \
+  -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-30 \
+  -DCMAKE_BUILD_TYPE=Release -DGGML_VULKAN=ON -DGGML_OPENCL=OFF -DGGML_OPENMP=OFF \
+  -DSPIRV-Headers_DIR=/usr/share/cmake/SPIRV-Headers \
+  -DCMAKE_CXX_FLAGS="-I$SPIRV_INC" \
+  -DLLAMA_BUILD_TOOLS=OFF -DLLAMA_BUILD_COMMON=OFF -DLLAMA_MTMD=ON \
+  -DLLAMA_BUILD_SERVER=OFF -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF \
+  -DLLAMA_CURL=OFF
+
+cmake --build build-android-vk --target qwen3vl-encoder -j12
+```
+
+> `-I$SPIRV_INC` is required: `ggml-vulkan.cpp` includes
+> `spirv/unified1/spirv.hpp`, which is NOT in the NDK Vulkan sysroot. NDK 27.2
+> already ships `vulkan.hpp` (v275); if a future NDK doesn't, fetch the matching
+> Vulkan-Hpp into the NDK sysroot.
+
+Produces `build-android-vk/bin/`: `qwen3vl-encoder`, `libggml.so`,
+`libggml-base.so`, `libggml-cpu.so`, `libggml-vulkan.so` (~122 MB, embedded
+shaders).
+
+### 3b. OpenCL (for S25)
+
+```bash
+NDK=$ANDROID_NDK_HOME
+CL_INC=/usr/local/share/vcpkg/packages/opencl-headers_arm64-android/include
+CL_LIB=/usr/local/share/vcpkg/packages/opencl_arm64-android/lib/libOpenCL.so
+
+cmake -S . -B build-android-cl -G Ninja \
+  -DCMAKE_TOOLCHAIN_FILE=$NDK/build/cmake/android.toolchain.cmake \
+  -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-30 \
+  -DCMAKE_BUILD_TYPE=Release -DGGML_VULKAN=OFF \
+  -DGGML_OPENCL=ON -DGGML_OPENCL_EMBED_KERNELS=ON \
+  -DOpenCL_INCLUDE_DIR=$CL_INC -DOpenCL_LIBRARY=$CL_LIB -DGGML_OPENMP=OFF \
+  -DLLAMA_BUILD_TOOLS=OFF -DLLAMA_BUILD_COMMON=OFF -DLLAMA_MTMD=ON \
+  -DLLAMA_BUILD_SERVER=OFF -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF \
+  -DLLAMA_CURL=OFF
+
+cmake --build build-android-cl --target qwen3vl-encoder -j12
+```
+
+`GGML_OPENCL_EMBED_KERNELS=ON` bakes the `.cl` kernels in — no runtime files.
+`libggml-opencl.so` hard-`NEEDED`s `libOpenCL.so`; it resolves on-device from
+`/vendor/lib64` (see LD_LIBRARY_PATH in the APK). Adreno kernels auto-enable.
+
+---
+
+## 4. Build the game-loop APK
+
+Firebase runs APKs, not bare binaries. The harness project is at
+`/home/olya/claude_folders/qwen3vl-encoder-apk` (gradle 8.14.3 wrapper, AGP
+8.6.0, JDK 21, applicationId `com.qvac.encbench`). Key mechanics:
+
+- The encoder exe is shipped as `lib/arm64-v8a/libqwen3vl-encoder.so` in
+  `jniLibs` (it's an ET_DYN PIE, so the packager accepts it as a "lib").
+  `android:extractNativeLibs=true` + `useLegacyPackaging true` → it extracts to
+  `nativeLibraryDir`, an exec-able mount.
+- `MainActivity` (TEST_LOOP intent) copies the mmproj + image assets to
+  `filesDir`, execs the binary with
+  `LD_LIBRARY_PATH=nativeDir:/vendor/lib64:/system/vendor/lib64:/system/lib64`
+  (the vendor dirs supply Adreno/Mali `libOpenCL.so`), and streams stdout/stderr
+  to logcat under tag **`ENCBENCH`**, then `finish()`.
+- Assets (mmproj, elephant.jpg) live in `app/src/main/assets/`; `noCompress
+  'gguf','jpg'`.
+
+Stage assets once:
+
+```bash
+APK=/home/olya/claude_folders/qwen3vl-encoder-apk
+cp <q8.gguf>      $APK/app/src/main/assets/mmproj-Qwen3.5-0.8B-Q8_0.gguf
+cp <elephant.jpg> $APK/app/src/main/assets/elephant.jpg
+```
+
+Build the **Vulkan** APK:
+
+```bash
+FAB=/home/olya/claude_folders/qvac-fabric-llm.cpp
+JNI=$APK/app/src/main/jniLibs/arm64-v8a
+rm -f $JNI/*.so
+cp $FAB/build-android-vk/bin/qwen3vl-encoder $JNI/libqwen3vl-encoder.so
+cp $FAB/build-android-vk/bin/libggml.so $FAB/build-android-vk/bin/libggml-base.so \
+   $FAB/build-android-vk/bin/libggml-cpu.so $FAB/build-android-vk/bin/libggml-vulkan.so $JNI/
+( cd $APK && ./gradlew :app:assembleDebug --no-daemon )
+cp $APK/app/build/outputs/apk/debug/app-debug.apk $APK/encoder-vk.apk
+```
+
+Build the **OpenCL** APK (swap the jniLibs):
+
+```bash
+rm -f $JNI/*.so
+cp $FAB/build-android-cl/bin/qwen3vl-encoder $JNI/libqwen3vl-encoder.so
+cp $FAB/build-android-cl/bin/libggml.so $FAB/build-android-cl/bin/libggml-base.so \
+   $FAB/build-android-cl/bin/libggml-cpu.so $FAB/build-android-cl/bin/libggml-opencl.so $JNI/
+( cd $APK && ./gradlew :app:assembleDebug --no-daemon )
+cp $APK/app/build/outputs/apk/debug/app-debug.apk $APK/encoder-cl.apk
+```
+
+Sanity: `unzip -l encoder-vk.apk | grep vulkan` (1) and
+`unzip -l encoder-cl.apk | grep -c vulkan` (0). Debug-signed APKs are accepted
+by Firebase game-loop.
+
+---
+
+## 5. Run on Firebase Test Lab
+
+Devices: **Pixel 9 Pro = `caiman`** (v34/35, Vulkan), **Galaxy S25 = `pa1q`**
+(v36, OpenCL). (S25 Ultra=`pa3q`, S25+=`pa2q`.) Account `olya.sirkin@tether.to`,
+project `qvac-test`. Use `--async` — synchronous runs exceed the shell timeout,
+and backgrounded blocking submits get killed.
+
+```bash
+GC=/home/olya/google-cloud-sdk/bin/gcloud
+cd $APK
+
+# Pixel 9 Pro / Vulkan
+$GC firebase test android run --type game-loop --app encoder-vk.apk \
+  --device model=caiman,version=34,locale=en,orientation=portrait \
+  --timeout 600s --project qvac-test --async
+
+# Galaxy S25 / OpenCL
+$GC firebase test android run --type game-loop --app encoder-cl.apk \
+  --device model=pa1q,version=36,locale=en,orientation=portrait \
+  --timeout 600s --project qvac-test --async
+```
+
+Each submit prints a **GCS results bucket** like
+`gs://test-lab-.../2026-..._XXXX/`. Save it.
+
+---
+
+## 6. Collect results
+
+Firebase has no simple status poll; poll the bucket for the device logcat. When
+the run completes, `<bucket>/<model>-<ver>-en-portrait/logcat` appears.
+
+```bash
+GC=/home/olya/google-cloud-sdk/bin/gcloud
+BASE=gs://test-lab-.../2026-..._XXXX/        # from the submit output
+DEV=$($GC storage ls "$BASE" | grep -E '/[a-z0-9]+-[0-9]+-[a-z]+-[a-z]+/$' | head -1)
+until $GC storage ls "${DEV}logcat" >/dev/null 2>&1; do sleep 30; done
+$GC storage cat "${DEV}logcat" > logcat.txt
+
+grep -a ' ENCBENCH:' logcat.txt | grep -aE 'ENC_RESULT|ENC_COSSIM|ENC_DONE|exit='
+```
+
+(`poll_fb.sh <label> <bucket>` in the scratchpad automates the wait+extract.)
+
+**Read the cos, not just the tokens.** A backend can emit 247 tokens of garbage.
+`[ENC_COSSIM] ... PASS` (cos ≳0.99) means the GPU output matches the on-device
+CPU reference; `FAIL` (cos ~0.6) means the backend is numerically broken.
+
+### Reference results (2026-07-01, q8 mmproj, elephant, iters=10)
+
+| Device | Backend | tokens | avg ms | cos vs CPU | verdict |
+|---|---|---|---|---|---|
+| Pixel 9 Pro `caiman` | Vulkan (Mali-G715) | 247 | ~4946 | **0.9954** | ✅ correct |
+| Galaxy S25 `pa1q` | OpenCL (Adreno 830) | 247 | ~248 | **0.6367** | ❌ runs but WRONG |
+
+Adreno-OpenCL is fast but mis-computes some ViT op → not usable until fixed.
+Full context in memory `qwen3vl-standalone-encoder.md`.
+
+---
+
+## Fast iteration summary
+
+- **Kernel edit → verify (desktop):** edit `ggml/src/ggml-vulkan/` or
+  `ggml/src/ggml-opencl/` → `cmake --build build-encoder --target
+  qwen3vl-encoder` (rebuilds only the backend + relinks the tiny exe) → run
+  `--backend all` → check `[ENC_COSSIM]`. Seconds.
+- **On-device confirm:** rebuild the android backend, repackage the one APK,
+  `--async` submit, poll logcat. ~15–25 min/run (upload + shared device).


### PR DESCRIPTION
## Summary

Speeds up the **CPU vision encoder** (mtmd/clip) and adds a **standalone
encoder benchmark tool** used to find and validate the win.

On a Pixel 9 Pro, the Qwen3.5-0.8B vision encode (q8_0 mmproj, elephant.jpg,
4 threads) drops from **~1807 ms → ~1114 ms** (1.6×), with **bit-identical**
output.

The production arm64-android build already runs with `GGML_CPU_ALL_VARIANTS=ON`,
so it ships an `armv8.6_1` (i8mm/dotprod) CPU variant that is dlopen-dispatched
at runtime — i.e. the fast i8mm GEMM path is already active in production. This
change is the incremental win on top of that; **no build-config change is
required**. (A CPU build with no i8mm/dotprod variant runs ~2689 ms and this is
a safe no-op there.)

## 1. Repack quantized CLIP weights into the CPU i8mm buffer

`clip.cpp` allocated all weights in the default CPU buffer, so the q8_0/q4_0
matmul matrices used the generic GEMM instead of the interleaved i8mm/AVX2
kernels. This change allocates the *repackable* weights in ggml's CPU "repack"
extra buffer type, so they are repacked into the interleaved layout at load.

- Per-tensor selection via a `ggml_backend_dev_supports_op` probe (mirrors
  llama's `buft_supported`): only tensors the backend can actually repack+matmul
  go to the repack buffer. Conv weights / biases / norms stay in the default
  buffer (otherwise their non-matmul ops become unsupported and the scheduler
  aborts). On arches/variants with no repack kernel the probe rejects everything
  and this is a no-op.
- Weight loading is made per-tensor host-aware, since weights now span the host
  default buffer and the non-host repack buffer.
- **Bit-identical** output (verified via cosine-similarity against a non-repack
  golden). Opt out with `MTMD_CLIP_NO_REPACK=1`.

## 2. Standalone `qwen3vl-encoder` benchmark tool

`tools/mtmd/qwen3vl-encoder`: runs *only* the vision encoder (ViT + patch-merge
projection) through ggml with **no libllama dependency** (it compiles the clip
sources directly). Loads an mmproj gguf, preprocesses an image, and times
`clip_image_batch_encode` across `cpu | vulkan | opencl`, with a
cosine-similarity check (`--dump` / `--ref`) so kernel changes stay lossless.

This gives a seconds-scale edit → build → run loop for optimizing the shared
vision-encoder kernels without the heavy llama build. `standalone_loop.md`
documents the local + Android + Firebase workflow.

```
qwen3vl-encoder --mmproj <mmproj.gguf> --image <img> \
                --backend cpu|vulkan|opencl|all [--threads N] [--iters N] \
                [--ref golden.bin] [--cos-min 0.999]
```

## Testing

- Built for x86-64 (Vulkan) and arm64-android (CPU / Vulkan / OpenCL).
- CPU + Vulkan cross-checked against a golden embedding (cos-sim); repack path
  verified bit-identical to the non-repack path.
- On-device on Pixel 9 Pro (Mali, CPU path) and Galaxy S25 (Adreno) via Firebase
  Test Lab game-loop.
