### PR TITLE
QVAC-21914 fix: clip FA AUTO on non-coopmat GPUs + ggml-opencl submission hardening (Pixel 9 OOM, S25 Adreno abort)

### DIFF
--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -18,6 +18,7 @@
 #include <inttypes.h>
 #include <string.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <fstream>
@@ -4234,6 +4235,22 @@ static void ggml_opencl_op_group_norm_fused(ggml_backend_t backend, ggml_tensor 
 static ggml_status ggml_backend_opencl_graph_compute(ggml_backend_t backend, ggml_cgraph * cgraph) {
     ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;
 
+    // QVAC-21914: bound the driver's per-submission work on giant graphs.
+    // Large vision graphs (e.g. a monolithic 16k-patch ViT encode: thousands
+    // of nodes, ~48 s of GPU work) enqueue everything between two host
+    // synchronization points. On Adreno the GSL command-buffer manager
+    // accumulates the whole stream and the GPU faults near the tail
+    // (log_gpu_snapshot), after which the next submission aborts the process
+    // from cl_a8x_cmdbuf_mgr_submit_ibs (os_exit) — observed on Galaxy S25
+    // Ultra / Adreno 830. Periodically flushing hands the driver bounded
+    // batches instead. clFlush only submits (no host stall), so the overhead
+    // is negligible; 0 disables.
+    static const int flush_interval = [] {
+        const char * env = std::getenv("GGML_OPENCL_FLUSH_INTERVAL");
+        return env && env[0] ? atoi(env) : 64;
+    }();
+    int nodes_since_flush = 0;
+
     for (int i = 0; i < cgraph->n_nodes; i++) {
         ggml_tensor * node = cgraph->nodes[i];
 
@@ -4250,19 +4267,31 @@ static ggml_status ggml_backend_opencl_graph_compute(ggml_backend_t backend, ggm
             continue;
         }
 
+        // Submit the accumulated batch to the driver every flush_interval
+        // enqueued nodes (see the QVAC-21914 note above).
+        auto maybe_flush = [&]() {
+            if (flush_interval > 0 && ++nodes_since_flush >= flush_interval) {
+                CL_CHECK(clFlush(backend_ctx->queue));
+                nodes_since_flush = 0;
+            }
+        };
+
         if (!backend_ctx->disable_fusion && ggml_opencl_can_fuse(cgraph, i, { GGML_OP_NORM, GGML_OP_MUL, GGML_OP_ADD })) {
             ggml_opencl_op_norm_fused(backend, node, cgraph->nodes[i+1], cgraph->nodes[i+2]);
             i += 2;
+            maybe_flush();
             continue;
         }
         if (!backend_ctx->disable_fusion && ggml_opencl_can_fuse(cgraph, i, { GGML_OP_GROUP_NORM, GGML_OP_MUL, GGML_OP_ADD })) {
             ggml_opencl_op_group_norm_fused(backend, node, cgraph->nodes[i+1], cgraph->nodes[i+2]);
             i += 2;
+            maybe_flush();
             continue;
         }
         if (!backend_ctx->disable_fusion && ggml_opencl_can_fuse(cgraph, i, { GGML_OP_RMS_NORM, GGML_OP_MUL })) {
             ggml_opencl_op_rms_norm_fused(backend, node, cgraph->nodes[i+1]);
             i++;
+            maybe_flush();
             continue;
         }
 
@@ -4271,6 +4300,7 @@ static ggml_status ggml_backend_opencl_graph_compute(ggml_backend_t backend, ggm
             GGML_LOG_ERROR("%s: error: op not supported %s (%s)\n", __func__, node->name, ggml_op_name(node->op));
         }
         GGML_ASSERT(ok);
+        maybe_flush();
     }
 
     return GGML_STATUS_SUCCESS;
@@ -9928,11 +9958,45 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         size_t global_work_size[] = { wg_size, (size_t)(n_head * n_batch) };
         backend_ctx->enqueue_ndrange_kernel(kernel, 2, global_work_size, local_work_size, dst);
     } else {
+        // QVAC-21914: chunk very large dispatches along the q-rows so no
+        // single kernel runs unboundedly long. A monolithic ViT encode at
+        // image_max_tokens=4096 puts n_q = n_kv = 16384 through one dispatch
+        // whose every workgroup loops the full 16k KV — on Adreno 830
+        // (Galaxy S25 Ultra, OpenCL) the GPU faults near the end of such
+        // encodes and the driver then kills the process on the next
+        // submission (cl_a8x_cmdbuf_mgr_submit_ibs -> os_exit). Splitting is
+        // exact: the kernel resolves its q row as
+        // group_id(0)*BLOCK_M + tid relative to the Q/O/mask base offsets,
+        // is_causal is always 0 (masking is explicit) and alibi/sinks depend
+        // on the head index only, so shifting the row base via the byte
+        // offsets while shrinking n_q is mathematically identical. clFlush
+        // between chunks hands the driver bounded submissions; 0 disables.
+        static const int fa_max_nq = [] {
+            const char * env = std::getenv("GGML_OPENCL_FA_MAX_NQ");
+            return env && env[0] ? atoi(env) : 4096;
+        }();
         const int block_m = backend_ctx->kernels_flash_attn_bm.at(dk_dv);
         const size_t wg_size = block_m;
-        size_t local_work_size[] = { wg_size, 1 };
-        size_t global_work_size[] = { (size_t)((n_q + block_m - 1) / block_m) * wg_size, (size_t)(n_head * n_batch) };
-        backend_ctx->enqueue_ndrange_kernel(kernel, 2, global_work_size, local_work_size, dst);
+        const int chunk_rows = (fa_max_nq > 0 && n_q > fa_max_nq) ? fa_max_nq : n_q;
+
+        for (int q_base = 0; q_base < n_q; q_base += chunk_rows) {
+            const int n_q_chunk = std::min(chunk_rows, n_q - q_base);
+            if (q_base > 0 || n_q_chunk != n_q) {
+                const cl_ulong offset_q_chunk    = offset_q + (cl_ulong)q_base * q_nb1;
+                const cl_ulong offset_o_chunk    = offset_o + (cl_ulong)q_base * o_nb1;
+                const cl_ulong offset_mask_chunk = mask ? offset_mask + (cl_ulong)q_base * mask_nb1 : offset_mask;
+                CL_CHECK(clSetKernelArg(kernel, 1,  sizeof(cl_ulong), &offset_q_chunk));
+                CL_CHECK(clSetKernelArg(kernel, 7,  sizeof(cl_ulong), &offset_o_chunk));
+                CL_CHECK(clSetKernelArg(kernel, 9,  sizeof(int),      &n_q_chunk));
+                CL_CHECK(clSetKernelArg(kernel, 32, sizeof(cl_ulong), &offset_mask_chunk));
+            }
+            size_t local_work_size[] = { wg_size, 1 };
+            size_t global_work_size[] = { (size_t)((n_q_chunk + block_m - 1) / block_m) * wg_size, (size_t)(n_head * n_batch) };
+            backend_ctx->enqueue_ndrange_kernel(kernel, 2, global_work_size, local_work_size, dst);
+            if (q_base + chunk_rows < n_q) {
+                CL_CHECK(clFlush(backend_ctx->queue));
+            }
+        }
     }
 }
 

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -4324,39 +4324,39 @@ static ggml_status ggml_backend_opencl_graph_compute(ggml_backend_t backend, ggm
             continue;
         }
 
-        // Single touch point for the submission bound (see the QVAC-21914 note
-        // above): estimate this node's work before dispatching it and submit
-        // the accumulated batch once the budget is exceeded. Fused ops are
-        // accounted by their anchor node — precision is irrelevant here.
+        // Accumulate this node's estimated work before dispatch; the budget
+        // check + flush runs AFTER the node is enqueued (bottom of the loop),
+        // so the node that crosses the budget is part of the flushed batch
+        // rather than deferred into a fresh, potentially-unflushed final
+        // batch. Fused ops are accounted by their anchor node — precision is
+        // irrelevant here (see the QVAC-21914 note above).
         if (backend_ctx->flush_work_budget > 0) {
             work_since_flush += ggml_opencl_node_work_estimate(node);
-            if (work_since_flush >= backend_ctx->flush_work_budget) {
-                CL_CHECK(clFlush(backend_ctx->queue));
-                work_since_flush = 0;
-            }
         }
 
+        // if/else (not `continue`) so every dispatch path reaches the single
+        // budget-flush touch point below.
         if (!backend_ctx->disable_fusion && ggml_opencl_can_fuse(cgraph, i, { GGML_OP_NORM, GGML_OP_MUL, GGML_OP_ADD })) {
             ggml_opencl_op_norm_fused(backend, node, cgraph->nodes[i+1], cgraph->nodes[i+2]);
             i += 2;
-            continue;
-        }
-        if (!backend_ctx->disable_fusion && ggml_opencl_can_fuse(cgraph, i, { GGML_OP_GROUP_NORM, GGML_OP_MUL, GGML_OP_ADD })) {
+        } else if (!backend_ctx->disable_fusion && ggml_opencl_can_fuse(cgraph, i, { GGML_OP_GROUP_NORM, GGML_OP_MUL, GGML_OP_ADD })) {
             ggml_opencl_op_group_norm_fused(backend, node, cgraph->nodes[i+1], cgraph->nodes[i+2]);
             i += 2;
-            continue;
-        }
-        if (!backend_ctx->disable_fusion && ggml_opencl_can_fuse(cgraph, i, { GGML_OP_RMS_NORM, GGML_OP_MUL })) {
+        } else if (!backend_ctx->disable_fusion && ggml_opencl_can_fuse(cgraph, i, { GGML_OP_RMS_NORM, GGML_OP_MUL })) {
             ggml_opencl_op_rms_norm_fused(backend, node, cgraph->nodes[i+1]);
             i++;
-            continue;
+        } else {
+            bool ok = ggml_cl_compute_forward(backend, node);
+            if (!ok) {
+                GGML_LOG_ERROR("%s: error: op not supported %s (%s)\n", __func__, node->name, ggml_op_name(node->op));
+            }
+            GGML_ASSERT(ok);
         }
 
-        bool ok = ggml_cl_compute_forward(backend, node);
-        if (!ok) {
-            GGML_LOG_ERROR("%s: error: op not supported %s (%s)\n", __func__, node->name, ggml_op_name(node->op));
+        if (backend_ctx->flush_work_budget > 0 && work_since_flush >= backend_ctx->flush_work_budget) {
+            CL_CHECK(clFlush(backend_ctx->queue));
+            work_since_flush = 0;
         }
-        GGML_ASSERT(ok);
     }
 
     return GGML_STATUS_SUCCESS;

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -19,6 +19,7 @@
 #include <string.h>
 
 #include <algorithm>
+#include <cerrno>
 #include <cstddef>
 #include <cstdint>
 #include <fstream>
@@ -404,6 +405,13 @@ struct ggml_backend_opencl_context {
     bool fp16_support;
     bool has_vector_subgroup_broadcast;
     bool disable_fusion;
+
+    // QVAC-21914 submission bounds (resolved once at init from env, logged there).
+    // flush_work_budget: bytes of estimated enqueued work per driver submission in
+    // graph_compute; 0 disables. fa_max_nq: max q rows per flash-attention dispatch;
+    // 0 disables chunking.
+    int64_t flush_work_budget;
+    int     fa_max_nq;
 
     bool adreno_has_large_buffer;
     bool adreno_use_large_buffer;
@@ -3655,6 +3663,31 @@ static ggml_backend_opencl_context * ggml_cl2_init(ggml_backend_dev_t dev) {
 
     backend_ctx->disable_fusion = getenv("GGML_OPENCL_DISABLE_FUSION") != nullptr;
 
+    // QVAC-21914 submission bounds. Robust parse (strtol, clamp, warn on garbage
+    // instead of silently disabling the mitigation) and log the effective values,
+    // matching the file's other env knobs.
+    auto parse_env_i64 = [](const char * name, int64_t defval, int64_t maxval) -> int64_t {
+        const char * env = std::getenv(name);
+        if (!env || !env[0]) {
+            return defval;
+        }
+        errno = 0;
+        char * end = nullptr;
+        long long v = std::strtoll(env, &end, 10);
+        if (errno != 0 || end == env || *end != '\0' || v < 0) {
+            GGML_LOG_WARN("ggml_opencl: invalid %s='%s', using default %lld\n",
+                          name, env, (long long) defval);
+            return defval;
+        }
+        return v > maxval ? maxval : (int64_t) v;
+    };
+    backend_ctx->flush_work_budget = parse_env_i64("GGML_OPENCL_FLUSH_WORK_MB", 512, INT64_MAX >> 20) * (1ll << 20);
+    backend_ctx->fa_max_nq         = (int) parse_env_i64("GGML_OPENCL_FA_MAX_NQ", 4096, INT32_MAX);
+    GGML_LOG_INFO("ggml_opencl: flush work budget: %lld MB (0 = disabled)\n",
+                  (long long) (backend_ctx->flush_work_budget >> 20));
+    GGML_LOG_INFO("ggml_opencl: flash attention max q rows per dispatch: %d (0 = disabled)\n",
+                  backend_ctx->fa_max_nq);
+
     dev_ctx->backend_ctx = backend_ctx.release();
     return dev_ctx->backend_ctx;
 }
@@ -4232,6 +4265,26 @@ static void ggml_opencl_op_rms_norm_fused(ggml_backend_t backend, ggml_tensor * 
 static void ggml_opencl_op_norm_fused(ggml_backend_t backend, ggml_tensor * norm_tensor, ggml_tensor * mul_tensor, ggml_tensor * add_tensor);
 static void ggml_opencl_op_group_norm_fused(ggml_backend_t backend, ggml_tensor * gn_tensor, ggml_tensor * mul_tensor, ggml_tensor * add_tensor);
 
+// QVAC-21914: cheap per-node proxy for enqueued GPU work, used to bound the
+// driver's per-submission batch in graph_compute. Precision is irrelevant —
+// only the ~3 orders of magnitude between a per-token decode step (~10-50 ms
+// of GPU work) and a monolithic 16k-patch ViT encode (~48 s) must separate,
+// and they do: reduction-heavy ops scale by how often their inputs are re-read.
+static int64_t ggml_opencl_node_work_estimate(const ggml_tensor * node) {
+    switch (node->op) {
+        case GGML_OP_MUL_MAT:
+        case GGML_OP_MUL_MAT_ID:
+            // src0 (weights) is streamed once per output column.
+            return (int64_t) ggml_nbytes(node->src[0]) * std::max<int64_t>(node->ne[1], 1);
+        case GGML_OP_FLASH_ATTN_EXT:
+            // K and V are re-read for every q row.
+            return ((int64_t) ggml_nbytes(node->src[1]) + (int64_t) ggml_nbytes(node->src[2])) *
+                   std::max<int64_t>(node->src[0]->ne[1], 1);
+        default:
+            return (int64_t) ggml_nbytes(node);
+    }
+}
+
 static ggml_status ggml_backend_opencl_graph_compute(ggml_backend_t backend, ggml_cgraph * cgraph) {
     ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;
 
@@ -4242,14 +4295,13 @@ static ggml_status ggml_backend_opencl_graph_compute(ggml_backend_t backend, ggm
     // accumulates the whole stream and the GPU faults near the tail
     // (log_gpu_snapshot), after which the next submission aborts the process
     // from cl_a8x_cmdbuf_mgr_submit_ibs (os_exit) — observed on Galaxy S25
-    // Ultra / Adreno 830. Periodically flushing hands the driver bounded
-    // batches instead. clFlush only submits (no host stall), so the overhead
-    // is negligible; 0 disables.
-    static const int flush_interval = [] {
-        const char * env = std::getenv("GGML_OPENCL_FLUSH_INTERVAL");
-        return env && env[0] ? atoi(env) : 64;
-    }();
-    int nodes_since_flush = 0;
+    // Ultra / Adreno 830. Flushing whenever the estimated enqueued work
+    // exceeds flush_work_budget hands the driver bounded batches instead.
+    // Gating on WORK (not a node count) keeps the per-token LLM decode hot
+    // path submission-free by construction: a decode step never accumulates
+    // anywhere near the budget, while the giant encode flushes dozens of
+    // times. clFlush only submits (no host stall).
+    int64_t work_since_flush = 0;
 
     for (int i = 0; i < cgraph->n_nodes; i++) {
         ggml_tensor * node = cgraph->nodes[i];
@@ -4267,31 +4319,31 @@ static ggml_status ggml_backend_opencl_graph_compute(ggml_backend_t backend, ggm
             continue;
         }
 
-        // Submit the accumulated batch to the driver every flush_interval
-        // enqueued nodes (see the QVAC-21914 note above).
-        auto maybe_flush = [&]() {
-            if (flush_interval > 0 && ++nodes_since_flush >= flush_interval) {
+        // Single touch point for the submission bound (see the QVAC-21914 note
+        // above): estimate this node's work before dispatching it and submit
+        // the accumulated batch once the budget is exceeded. Fused ops are
+        // accounted by their anchor node — precision is irrelevant here.
+        if (backend_ctx->flush_work_budget > 0) {
+            work_since_flush += ggml_opencl_node_work_estimate(node);
+            if (work_since_flush >= backend_ctx->flush_work_budget) {
                 CL_CHECK(clFlush(backend_ctx->queue));
-                nodes_since_flush = 0;
+                work_since_flush = 0;
             }
-        };
+        }
 
         if (!backend_ctx->disable_fusion && ggml_opencl_can_fuse(cgraph, i, { GGML_OP_NORM, GGML_OP_MUL, GGML_OP_ADD })) {
             ggml_opencl_op_norm_fused(backend, node, cgraph->nodes[i+1], cgraph->nodes[i+2]);
             i += 2;
-            maybe_flush();
             continue;
         }
         if (!backend_ctx->disable_fusion && ggml_opencl_can_fuse(cgraph, i, { GGML_OP_GROUP_NORM, GGML_OP_MUL, GGML_OP_ADD })) {
             ggml_opencl_op_group_norm_fused(backend, node, cgraph->nodes[i+1], cgraph->nodes[i+2]);
             i += 2;
-            maybe_flush();
             continue;
         }
         if (!backend_ctx->disable_fusion && ggml_opencl_can_fuse(cgraph, i, { GGML_OP_RMS_NORM, GGML_OP_MUL })) {
             ggml_opencl_op_rms_norm_fused(backend, node, cgraph->nodes[i+1]);
             i++;
-            maybe_flush();
             continue;
         }
 
@@ -4300,7 +4352,6 @@ static ggml_status ggml_backend_opencl_graph_compute(ggml_backend_t backend, ggm
             GGML_LOG_ERROR("%s: error: op not supported %s (%s)\n", __func__, node->name, ggml_op_name(node->op));
         }
         GGML_ASSERT(ok);
-        maybe_flush();
     }
 
     return GGML_STATUS_SUCCESS;
@@ -9952,6 +10003,12 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     CL_CHECK(clSetKernelArg(kernel, 38, sizeof(cl_mem),   &sinks_buffer));
     CL_CHECK(clSetKernelArg(kernel, 39, sizeof(cl_ulong), &offset_sinks));
 
+    if (n_q == 0) {
+        // Degenerate empty dispatch: nothing to compute. Guard explicitly so
+        // the chunk loop below cannot be entered with a zero row count.
+        return;
+    }
+
     if (n_q == 1) {
         const size_t wg_size = 64;
         size_t local_work_size[] = { wg_size, 1 };
@@ -9970,11 +10027,15 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         // is_causal is always 0 (masking is explicit) and alibi/sinks depend
         // on the head index only, so shifting the row base via the byte
         // offsets while shrinking n_q is mathematically identical. clFlush
-        // between chunks hands the driver bounded submissions; 0 disables.
-        static const int fa_max_nq = [] {
-            const char * env = std::getenv("GGML_OPENCL_FA_MAX_NQ");
-            return env && env[0] ? atoi(env) : 4096;
-        }();
+        // between chunks hands the driver bounded submissions; 0 disables
+        // (GGML_OPENCL_FA_MAX_NQ, resolved at init).
+        //
+        // The kernel's causal-boundary formula needs the TOTAL n_q; chunks
+        // after the first would silently corrupt output if causal FA were
+        // ever enabled here. This backend always passes explicit masks
+        // (is_causal == 0) — keep it loud if that invariant ever changes.
+        GGML_ASSERT(is_causal == 0 && "FA q-chunking requires total n_q for the causal boundary");
+        const int fa_max_nq = backend_ctx->fa_max_nq;
         const int block_m = backend_ctx->kernels_flash_attn_bm.at(dk_dv);
         const size_t wg_size = block_m;
         const int chunk_rows = (fa_max_nq > 0 && n_q > fa_max_nq) ? fa_max_nq : n_q;

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -4302,10 +4302,14 @@ static ggml_status ggml_backend_opencl_graph_compute(ggml_backend_t backend, ggm
     // from cl_a8x_cmdbuf_mgr_submit_ibs (os_exit) — observed on Galaxy S25
     // Ultra / Adreno 830. Flushing whenever the estimated enqueued work
     // exceeds flush_work_budget hands the driver bounded batches instead.
-    // Gating on WORK (not a node count) keeps the per-token LLM decode hot
-    // path submission-free by construction: a decode step never accumulates
-    // anywhere near the budget, while the giant encode flushes dozens of
-    // times. clFlush only submits (no host stall).
+    // Gating on WORK (not a node count) scales the flush cadence to the batch
+    // size: the ~48 s encode flushes many times, while a per-token LLM decode
+    // (its work ~= the model size streamed once, i.e. a few flushes per token
+    // at the default budget for a multi-GB model) is far lighter. clFlush only
+    // submits (no host stall), so the decode-path cost is negligible in
+    // practice (measured GPU decode TPS within noise of pre-hardening), but it
+    // is NOT literally zero for large models — raise flush_work_budget past the
+    // model size, or set it to 0, to make decode fully submission-free.
     int64_t work_since_flush = 0;
 
     for (int i = 0; i < cgraph->n_nodes; i++) {
@@ -9872,6 +9876,11 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
 
     ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;
 
+    // QVAC-21914: n_q is int; the q-chunk loop below accumulates into an int
+    // (q_base += chunk_rows) and derives cl_ulong byte offsets from it. Guard
+    // the int64->int truncation so a pathological q-row count can't wrap
+    // negative and produce an out-of-bounds device offset.
+    GGML_ASSERT(q->ne[1] <= INT32_MAX);
     const int n_q = q->ne[1];
     const int n_kv = k->ne[1];
     const int d_head_q = q->ne[0];

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -3679,7 +3679,12 @@ static ggml_backend_opencl_context * ggml_cl2_init(ggml_backend_dev_t dev) {
                           name, env, (long long) defval);
             return defval;
         }
-        return v > maxval ? maxval : (int64_t) v;
+        if (v > maxval) {
+            GGML_LOG_WARN("ggml_opencl: %s=%lld exceeds max, clamping to %lld\n",
+                          name, v, (long long) maxval);
+            return maxval;
+        }
+        return (int64_t) v;
     };
     backend_ctx->flush_work_budget = parse_env_i64("GGML_OPENCL_FLUSH_WORK_MB", 512, INT64_MAX >> 20) * (1ll << 20);
     backend_ctx->fa_max_nq         = (int) parse_env_i64("GGML_OPENCL_FA_MAX_NQ", 4096, INT32_MAX);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -261,6 +261,13 @@ llama_build_and_test(test-backend-ops.cpp)
 # subgroup size. Auto-skips when no GPU backend is available.
 llama_build_and_test(test-copy-tbq-subgroups.cpp)
 
+# QVAC-21914: ggml-opencl flash-attention q-chunking parity vs the CPU
+# backend. Unconditional and self-skipping at runtime when no OpenCL device is
+# present (like test-copy-tbq-subgroups above), so it exercises chunking
+# wherever OpenCL exists (Adreno devices, desktop OpenCL, PoCL). Does not link
+# mtmd, so it is intentionally outside the LLAMA_MTMD block below.
+llama_build_and_test(test-opencl-fa-chunking.cpp)
+
 llama_build_and_test(test-model-load-cancel.cpp       LABEL "model")
 llama_build_and_test(test-model-load-disk.cpp         LABEL "model")
 llama_build_and_test(test-model-load-memory.cpp       LABEL "model")
@@ -298,19 +305,13 @@ if (LLAMA_MTMD)
     target_link_libraries(${LLAMA_TEST_NAME} PRIVATE mtmd)
     unset(LLAMA_TEST_NAME)
 
-    # qvac QVAC-21914: clip flash-attention AUTO budget arithmetic (pure CPU).
+    # QVAC-21914: clip flash-attention AUTO budget arithmetic (pure CPU).
     set(LLAMA_TEST_NAME test-clip-fa-cutoff)
     llama_build_and_test(test-clip-fa-cutoff.cpp)
     target_link_libraries(${LLAMA_TEST_NAME} PRIVATE mtmd)
     target_include_directories(${LLAMA_TEST_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/tools/mtmd)
     unset(LLAMA_TEST_NAME)
 endif()
-
-# qvac QVAC-21914: ggml-opencl flash-attention q-chunking parity vs the CPU
-# backend. Self-skipping at runtime when no OpenCL device is present, so it is
-# registered unconditionally and exercises chunking wherever OpenCL exists
-# (Adreno devices, desktop OpenCL, PoCL).
-llama_build_and_test(test-opencl-fa-chunking.cpp)
 
 # GGUF model data fetcher library for tests that need real model metadata
 # Only compile when cpp-httplib has SSL support (CPPHTTPLIB_OPENSSL_SUPPORT)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -297,7 +297,20 @@ if (LLAMA_MTMD)
     llama_build_and_test(test-mtmd-c-api.c)
     target_link_libraries(${LLAMA_TEST_NAME} PRIVATE mtmd)
     unset(LLAMA_TEST_NAME)
+
+    # qvac QVAC-21914: clip flash-attention AUTO budget arithmetic (pure CPU).
+    set(LLAMA_TEST_NAME test-clip-fa-cutoff)
+    llama_build_and_test(test-clip-fa-cutoff.cpp)
+    target_link_libraries(${LLAMA_TEST_NAME} PRIVATE mtmd)
+    target_include_directories(${LLAMA_TEST_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/tools/mtmd)
+    unset(LLAMA_TEST_NAME)
 endif()
+
+# qvac QVAC-21914: ggml-opencl flash-attention q-chunking parity vs the CPU
+# backend. Self-skipping at runtime when no OpenCL device is present, so it is
+# registered unconditionally and exercises chunking wherever OpenCL exists
+# (Adreno devices, desktop OpenCL, PoCL).
+llama_build_and_test(test-opencl-fa-chunking.cpp)
 
 # GGUF model data fetcher library for tests that need real model metadata
 # Only compile when cpp-httplib has SSL support (CPPHTTPLIB_OPENSSL_SUPPORT)

--- a/tests/test-clip-fa-cutoff.cpp
+++ b/tests/test-clip-fa-cutoff.cpp
@@ -1,0 +1,83 @@
+// QVAC-21914: unit test for the clip flash-attention AUTO budget arithmetic
+// (clip_fa_effective_min_kv in tools/mtmd/clip.cpp — pure function, exposed
+// via clip.h). Locks in both halves of the design:
+//   - the fast explicit path survives momentary memory pressure (the cutoff
+//     is clamped by STABLE total memory, and free memory may only lower it
+//     by the hard-fit requirement — never the old free/2 heuristic), and
+//   - the OOM guard fails SAFE: unknown memory info caps the cutoff at a
+//     conservative constant instead of trusting the raw default.
+
+#include "clip.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+static int g_failures = 0;
+
+static void expect_eq(const char * what, int got, int expected) {
+    if (got != expected) {
+        std::printf("FAIL %s: got %d, expected %d\n", what, got, expected);
+        g_failures++;
+    } else {
+        std::printf("ok   %s: %d\n", what, got);
+    }
+}
+
+static void expect_range(const char * what, int got, int lo, int hi) {
+    if (got < lo || got > hi) {
+        std::printf("FAIL %s: got %d, expected in [%d, %d]\n", what, got, lo, hi);
+        g_failures++;
+    } else {
+        std::printf("ok   %s: %d in [%d, %d]\n", what, got, lo, hi);
+    }
+}
+
+int main() {
+    const size_t GB = 1000ull * 1000ull * 1000ull;
+
+    // Cutoff disabled (or negative) passes through untouched — AUTO stays in
+    // legacy "FA whenever supported" mode regardless of memory info.
+    expect_eq("disabled cutoff, no mem",        clip_fa_effective_min_kv(0,    0,       0,      16), 0);
+    expect_eq("disabled cutoff, with mem",      clip_fa_effective_min_kv(0,    16 * GB, 8 * GB, 16), 0);
+    expect_eq("negative cutoff passes through", clip_fa_effective_min_kv(-1,   16 * GB, 0,      16), -1);
+
+    // Plentiful total memory: the 4096 default survives (16 GB, n_head=16:
+    // total clamp = sqrt((16e9/2)/(24*16)) ~= 4564 > 4096).
+    expect_eq("16GB total keeps default", clip_fa_effective_min_kv(4096, 16 * GB, 0, 16), 4096);
+
+    // 12 GB-class device (Pixel 9-class): total clamp ~= sqrt((12e9/2)/384)
+    // ~= 3952 — trims only the topmost band of the default.
+    expect_range("12GB total trims to ~3950", clip_fa_effective_min_kv(4096, 12 * GB, 0, 16), 3900, 4000);
+
+    // P2 regression guard: high total + momentarily low free must NOT fall
+    // back to the old volatile free/2 heuristic (~1976 at 1.5 GB free). The
+    // hard-fit bound sqrt(1.5e9/(12*16)) ~= 2795 is the correct floor.
+    expect_range("1.5GB free -> hard-fit, not free/2",
+                 clip_fa_effective_min_kv(4096, 16 * GB, (size_t)(1.5 * (double) GB), 16), 2700, 2900);
+
+    // Ample free memory does not restrict below the total clamp...
+    expect_eq("8GB free does not restrict", clip_fa_effective_min_kv(4096, 16 * GB, 8 * GB, 16), 4096);
+    // ...and free memory can never RAISE the cutoff past the total clamp.
+    expect_range("huge free cannot raise past total clamp",
+                 clip_fa_effective_min_kv(4096, 2 * GB, 64 * GB, 16), 1550, 1700);
+
+    // No memory info at all: fail SAFE at the conservative constant cap
+    // (2048), never the raw 4096 default (~3.2 GB scratch at n_head=16).
+    expect_eq("no meminfo caps at 2048",        clip_fa_effective_min_kv(4096, 0, 0, 16), 2048);
+    expect_eq("no meminfo keeps smaller cutoff", clip_fa_effective_min_kv(1000, 0, 0, 16), 1000);
+
+    // Degenerate n_head is guarded (treated as 1), not a crash/div-by-zero.
+    expect_eq("n_head=0 guarded", clip_fa_effective_min_kv(2048, 0, 0, 0), 2048);
+
+    // Fewer heads => larger permissible n (scratch is linear in n_head):
+    // same 1.5 GB free, n_head=4 -> sqrt(1.5e9/48) ~= 5590, so the 4096
+    // default survives untouched.
+    expect_eq("fewer heads relax the fit bound", clip_fa_effective_min_kv(4096, 16 * GB, (size_t)(1.5 * (double) GB), 4), 4096);
+
+    if (g_failures) {
+        std::printf("%d failure(s)\n", g_failures);
+        return 1;
+    }
+    std::printf("all ok\n");
+    return 0;
+}

--- a/tests/test-clip-fa-cutoff.cpp
+++ b/tests/test-clip-fa-cutoff.cpp
@@ -67,7 +67,12 @@ int main() {
     expect_eq("no meminfo keeps smaller cutoff", clip_fa_effective_min_kv(1000, 0, 0, 16), 1000);
 
     // Degenerate n_head is guarded (treated as 1), not a crash/div-by-zero.
-    expect_eq("n_head=0 guarded", clip_fa_effective_min_kv(2048, 0, 0, 0), 2048);
+    // Must pass memory info so a sqrt(.../n_head) branch actually runs — with
+    // total_mem==free_mem==0 the NO_MEMINFO short-circuit returns before the
+    // guard is reached, leaving it untested. At 16 GB total, n_head=1:
+    // total clamp = sqrt((16e9/2)/24) ~= 18257 > 4096, so the default 4096
+    // survives (and the run completing at all proves no div-by-zero).
+    expect_eq("n_head=0 guarded (total mem path)", clip_fa_effective_min_kv(4096, 16 * GB, 0, 0), 4096);
 
     // Fewer heads => larger permissible n (scratch is linear in n_head):
     // same 1.5 GB free, n_head=4 -> sqrt(1.5e9/48) ~= 5590, so the 4096

--- a/tests/test-opencl-fa-chunking.cpp
+++ b/tests/test-opencl-fa-chunking.cpp
@@ -1,0 +1,178 @@
+// QVAC-21914: numerical parity test for the ggml-opencl flash-attention
+// q-row chunking (ggml_cl_flash_attn). With GGML_OPENCL_FA_MAX_NQ=64 the
+// chunked dispatch path engages cheaply; every case is computed on both the
+// CPU backend and the OpenCL backend and compared within FA tolerance.
+// Covers: unchunked (n_q <= max), exact multi-chunk, partial last chunk,
+// n_q == 1 (dedicated kernel), masked (exercises the per-chunk mask-offset
+// rewrite) and unmasked (the bidirectional vision-tower shape that crashes
+// Adreno 830 at 16k patches without the fix).
+//
+// SKIPS (exit 0) when no OpenCL device is present — it runs where the
+// backend exists (Adreno devices, desktop OpenCL, PoCL).
+
+#include "ggml.h"
+#include "ggml-alloc.h"
+#include "ggml-backend.h"
+#include "ggml-cpu.h"
+
+#include <cctype>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+static void set_env(const char * name, const char * value) { _putenv_s(name, value); }
+#else
+static void set_env(const char * name, const char * value) { setenv(name, value, 1); }
+#endif
+
+struct fa_case {
+    int  n_q;
+    bool mask;
+};
+
+// Deterministic LCG so both backends see identical inputs without seeding races.
+static uint32_t g_rng;
+static float frand() {
+    g_rng = g_rng * 1664525u + 1013904223u;
+    return ((g_rng >> 8) & 0xffffff) / (float) 0x1000000 * 2.0f - 1.0f;  // [-1, 1)
+}
+
+static const int D    = 64;  // head size (dk == dv == 64 — supported on OpenCL FA)
+static const int NH   = 4;   // heads (no GQA)
+static const int N_KV = 256;
+
+// Build + run one FA graph on `backend`; returns the output tensor data (f32).
+static std::vector<float> run_case(ggml_backend_t backend, const fa_case & c, uint32_t seed) {
+    ggml_init_params ip = {
+        /*.mem_size   =*/ 64 * 1024 * 1024,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context * ctx = ggml_init(ip);
+
+    ggml_tensor * q = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, D, c.n_q, NH, 1);
+    ggml_tensor * k = ggml_new_tensor_4d(ctx, GGML_TYPE_F16, D, N_KV, NH, 1);
+    ggml_tensor * v = ggml_new_tensor_4d(ctx, GGML_TYPE_F16, D, N_KV, NH, 1);
+    ggml_tensor * m = c.mask ? ggml_new_tensor_4d(ctx, GGML_TYPE_F16, N_KV, c.n_q, 1, 1) : nullptr;
+
+    ggml_tensor * out = ggml_flash_attn_ext(ctx, q, k, v, m, 1.0f / std::sqrt((float) D), 0.0f, 0.0f);
+    ggml_flash_attn_ext_set_prec(out, GGML_PREC_F32);
+
+    ggml_cgraph * gf = ggml_new_graph(ctx);
+    ggml_build_forward_expand(gf, out);
+
+    ggml_backend_buffer_t buf = ggml_backend_alloc_ctx_tensors(ctx, backend);
+    GGML_ASSERT(buf != nullptr);
+
+    // Identical data on every backend: reset the PRNG per tensor fill.
+    g_rng = seed;
+    {
+        std::vector<float> qd((size_t) D * c.n_q * NH);
+        for (auto & x : qd) x = frand();
+        ggml_backend_tensor_set(q, qd.data(), 0, qd.size() * sizeof(float));
+
+        std::vector<ggml_fp16_t> h((size_t) D * N_KV * NH);
+        for (auto & x : h) x = ggml_fp32_to_fp16(frand());
+        ggml_backend_tensor_set(k, h.data(), 0, h.size() * sizeof(ggml_fp16_t));
+        for (auto & x : h) x = ggml_fp32_to_fp16(frand());
+        ggml_backend_tensor_set(v, h.data(), 0, h.size() * sizeof(ggml_fp16_t));
+
+        if (m) {
+            // Causal-like deterministic pattern; row i sees k rows
+            // j <= (i+1)*N_KV/n_q, so every q row keeps >= 1 visible key
+            // (no all-masked softmax). Chunk boundaries land mid-pattern,
+            // so a wrong per-chunk mask offset shows up immediately.
+            std::vector<ggml_fp16_t> md((size_t) N_KV * c.n_q);
+            for (int i = 0; i < c.n_q; i++) {
+                const int visible = (int) (((int64_t) (i + 1) * N_KV) / c.n_q);
+                for (int j = 0; j < N_KV; j++) {
+                    md[(size_t) i * N_KV + j] = ggml_fp32_to_fp16(j <= visible ? 0.0f : -INFINITY);
+                }
+            }
+            ggml_backend_tensor_set(m, md.data(), 0, md.size() * sizeof(ggml_fp16_t));
+        }
+    }
+
+    const ggml_status st = ggml_backend_graph_compute(backend, gf);
+    GGML_ASSERT(st == GGML_STATUS_SUCCESS);
+
+    std::vector<float> res(ggml_nelements(out));
+    ggml_backend_tensor_get(out, res.data(), 0, res.size() * sizeof(float));
+
+    ggml_backend_buffer_free(buf);
+    ggml_free(ctx);
+    return res;
+}
+
+static double nmse(const std::vector<float> & a, const std::vector<float> & b) {
+    double se = 0.0, ref = 1e-12;
+    for (size_t i = 0; i < a.size(); i++) {
+        const double d = (double) a[i] - (double) b[i];
+        se  += d * d;
+        ref += (double) a[i] * (double) a[i];
+    }
+    return se / ref;
+}
+
+int main() {
+    // Must be set before the OpenCL context initializes: engage chunking at
+    // tiny sizes and a small work budget so the intra-graph flush runs too.
+    set_env("GGML_OPENCL_FA_MAX_NQ", "64");
+    set_env("GGML_OPENCL_FLUSH_WORK_MB", "1");
+
+    ggml_backend_dev_t ocl_dev = nullptr;
+    for (size_t i = 0; i < ggml_backend_dev_count(); i++) {
+        ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+        std::string name = ggml_backend_dev_name(dev);
+        for (auto & ch : name) ch = (char) tolower(ch);
+        if (name.find("opencl") != std::string::npos) {
+            ocl_dev = dev;
+            break;
+        }
+    }
+    if (!ocl_dev) {
+        std::printf("no OpenCL device found — test skipped\n");
+        return 0;
+    }
+
+    ggml_backend_t cpu = ggml_backend_dev_init(ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU), nullptr);
+    ggml_backend_t ocl = ggml_backend_dev_init(ocl_dev, nullptr);
+    GGML_ASSERT(cpu && ocl);
+
+    // With MAX_NQ=64: 1 = dedicated n_q==1 kernel; 63/64 = unchunked
+    // boundary; 65 = 64 + 1-row partial chunk; 128 = two exact chunks;
+    // 135 = two full + 7-row partial.
+    const fa_case cases[] = {
+        {  1, false}, {  1, true},
+        { 63, true},  { 64, true},
+        { 65, false}, { 65, true},
+        {128, true},
+        {135, false}, {135, true},
+    };
+
+    int failures = 0;
+    uint32_t seed = 0xC0FFEE;
+    for (const auto & c : cases) {
+        seed += 101;
+        const std::vector<float> ref = run_case(cpu, c, seed);
+        const std::vector<float> got = run_case(ocl, c, seed);
+        const double err = nmse(ref, got);
+        const bool ok = err < 5e-4;  // FA tolerance, matches test-backend-ops
+        std::printf("%s n_q=%3d mask=%d nmse=%.3e\n", ok ? "ok  " : "FAIL", c.n_q, c.mask ? 1 : 0, err);
+        if (!ok) failures++;
+    }
+
+    ggml_backend_free(ocl);
+    ggml_backend_free(cpu);
+
+    if (failures) {
+        std::printf("%d failure(s)\n", failures);
+        return 1;
+    }
+    std::printf("all ok\n");
+    return 0;
+}

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -176,6 +176,11 @@ struct clip_ctx {
     bool   fa_budget_cached = false;
     int    fa_auto_min_kv   = 0;   // explicit-attention cutoff (n_patches); <=0 disables it
     size_t fa_mem_capacity  = 0;   // device memory used to cap the cutoff (0 = unknown)
+    // Set at warmup when the backend reports it lacks efficient (coopmat) FA
+    // (ggml_backend_supports_efficient_fa == false, e.g. Mali via ggml-vulkan).
+    // Turns on the AUTO cutoff default so the budget heuristic prefers the
+    // explicit path for short sequences but keeps scalar FA for huge ones.
+    bool   fa_backend_inefficient = false;
 
     bool debug_output_embeddings = false;
     clip_image_tile_mode tile_mode = CLIP_IMAGE_TILE_MODE_SEQUENTIAL;
@@ -334,7 +339,12 @@ static clip_flash_attn_type clip_resolve_flash_attn_type(clip_ctx * ctx, int n_p
         if (env_min_kv && env_min_kv[0]) {
             ctx->fa_auto_min_kv = (int) std::strtol(env_min_kv, nullptr, 10);
         } else {
-            ctx->fa_auto_min_kv = clip_backend_is_mali(ctx) ? CLIP_AUTO_FA_MIN_KV_MALI_DEFAULT : 0;
+            // Default the cutoff on for any backend without efficient (coopmat)
+            // FA — detected either at warmup via the backend query
+            // (fa_backend_inefficient) or by Mali device detection (covers
+            // paths where the warmup GPU-only probe doesn't run).
+            ctx->fa_auto_min_kv = (ctx->fa_backend_inefficient || clip_backend_is_mali(ctx))
+                                      ? CLIP_AUTO_FA_MIN_KV_MALI_DEFAULT : 0;
         }
         size_t free_mem = 0, total_mem = 0;
         ggml_backend_dev_t dev = ctx->backend ? ggml_backend_get_device(ctx->backend) : nullptr;
@@ -2723,12 +2733,18 @@ struct clip_model_loader {
     static void warmup(clip_ctx & ctx_clip, const clip_image_f32_batch & batch) {
         support_info_graph info;
 
-        // Disable FA on GPU projectors that lack efficient (coopmat) flash attention.
-        // Without coopmat, Vulkan uses FA_SCALAR which is ~2.6x slower than the matmul path
-        // for CLIP encoder attention (Mali-G715: 38 vs ~100 GFLOPS/s). Coopmat-capable GPUs
-        // keep FA enabled. Resolved at runtime via proc_address — no compile-time backend dep.
-        // Acts on AUTO *and* ENABLED (the addon enables FA by default) — an inefficient
-        // scalar-FA GPU should never be forced into FA; only explicit DISABLED is left alone.
+        // Downgrade FA to AUTO on GPU projectors that lack efficient (coopmat) flash
+        // attention. Without coopmat, Vulkan uses FA_SCALAR which is ~2.6x slower than the
+        // matmul path for CLIP encoder attention (Mali-G715: 38 vs ~100 GFLOPS/s).
+        // Coopmat-capable GPUs keep FA enabled. Resolved at runtime via proc_address — no
+        // compile-time backend dep. Acts on AUTO *and* ENABLED (the addon enables FA by
+        // default) — an inefficient scalar-FA GPU should never be forced into FA; only
+        // explicit DISABLED is left alone. AUTO (not DISABLED, QVAC-21914): a hard disable
+        // forces the explicit path whose O(n_patches^2 * n_head) score matrix OOMs at high
+        // n_pos (image_tile_mode=disabled + large image_max_tokens killed Pixel 9 Pro at
+        // ~12 GB RSS); AUTO keeps the fast explicit path for normal images via the budget
+        // heuristic in clip_resolve_flash_attn_type() and falls back to memory-frugal
+        // scalar FA for huge ones — slow-but-alive beats fast-but-OOM.
         // Default when the backend can't confirm efficient FA = KEEP it. Only ggml-vulkan
         // implements the query (returning false for Mali/non-coopmat); backends that don't
         // answer (Metal, CUDA, …) have efficient FA and must keep it — disabling there forces
@@ -2748,7 +2764,8 @@ struct clip_model_loader {
                 }
             }
             if (!efficient_fa) {
-                ctx_clip.flash_attn_type = CLIP_FLASH_ATTN_TYPE_DISABLED;
+                ctx_clip.flash_attn_type = CLIP_FLASH_ATTN_TYPE_AUTO;
+                ctx_clip.fa_backend_inefficient = true;
             }
         }
 

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -312,47 +312,10 @@ static bool clip_backend_is_mali(const clip_ctx * ctx) {
 // (7056) uses flash-attention (explicit would OOM there).
 static const int CLIP_AUTO_FA_MIN_KV_MALI_DEFAULT = 4096;
 
-// Conservative cutoff cap when the device reports no memory information at
-// all: 2048 patches keeps the explicit scratch around ~0.8 GB at n_head=16
-// instead of trusting the raw 4096 default (~3.2 GB) blind.
-static const int CLIP_AUTO_FA_MIN_KV_NO_MEMINFO_CAP = 2048;
-
-// Pure arithmetic for the AUTO budget decision (exported for unit tests, see
-// tests/test-clip-fa-cutoff.cpp). Returns the effective explicit-attention
-// cutoff in n_patches given the configured cutoff and the device memory probe:
-//
-//  - total memory provides the STABLE fast-path clamp (session-independent —
-//    the explicit scratch, ~3*n^2*n_head*4 bytes, must fit in half of total):
-//    normal-size images keep the fast explicit path regardless of momentary
-//    memory pressure.
-//  - free memory (a volatile, load-dependent number) may only LOWER the
-//    cutoff further, and only by the hard-fit requirement: when reported,
-//    the explicit scratch must also fit in what is actually free right now.
-//    It can never extend the explicit path beyond the total-memory clamp.
-//  - neither reported: fail SAFE toward memory-frugal FA with a conservative
-//    constant cap instead of the raw default.
-int clip_fa_effective_min_kv(int auto_min_kv, size_t total_mem, size_t free_mem, int n_head) {
-    if (auto_min_kv <= 0) {
-        return auto_min_kv;
-    }
-    const double heads = (double) (n_head > 0 ? n_head : 1);
-    int eff_min_kv = auto_min_kv;
-    if (total_mem > 0) {
-        // Stable clamp: explicit scratch (3 * n^2 * n_head * 4) <= total/4
-        // =>  n <= sqrt((total/2) / (24*n_head))
-        const double n_max_total = std::sqrt(((double) total_mem / 2.0) / (24.0 * heads));
-        eff_min_kv = std::min(eff_min_kv, (int) n_max_total);
-    }
-    if (free_mem > 0) {
-        // Hard fit: 3 * n^2 * n_head * 4 <= free  =>  n <= sqrt(free / (12*n_head))
-        const double n_max_free = std::sqrt((double) free_mem / (12.0 * heads));
-        eff_min_kv = std::min(eff_min_kv, (int) n_max_free);
-    }
-    if (total_mem == 0 && free_mem == 0) {
-        eff_min_kv = std::min(eff_min_kv, CLIP_AUTO_FA_MIN_KV_NO_MEMINFO_CAP);
-    }
-    return eff_min_kv;
-}
+// clip_fa_effective_min_kv() — the pure AUTO-budget arithmetic — is defined
+// inline in clip.h (so unit tests can exercise it without linking an
+// unexported symbol across the Windows mtmd.dll boundary). See there for the
+// full behavior contract.
 
 // Resolve the effective flash-attention mode for a single image graph.
 //

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -175,7 +175,8 @@ struct clip_ctx {
     // change between images. Populated lazily on the first AUTO resolve.
     bool   fa_budget_cached = false;
     int    fa_auto_min_kv   = 0;   // explicit-attention cutoff (n_patches); <=0 disables it
-    size_t fa_mem_capacity  = 0;   // device memory used to cap the cutoff (0 = unknown)
+    size_t fa_mem_total     = 0;   // device total memory, stable clamp input (0 = unknown)
+    size_t fa_mem_free      = 0;   // device free memory at first resolve, hard-fit check only (0 = unknown)
     // Set at warmup when the backend reports it lacks efficient (coopmat) FA
     // (ggml_backend_supports_efficient_fa == false, e.g. Mali via ggml-vulkan).
     // Turns on the AUTO cutoff default so the budget heuristic prefers the
@@ -311,6 +312,48 @@ static bool clip_backend_is_mali(const clip_ctx * ctx) {
 // (7056) uses flash-attention (explicit would OOM there).
 static const int CLIP_AUTO_FA_MIN_KV_MALI_DEFAULT = 4096;
 
+// Conservative cutoff cap when the device reports no memory information at
+// all: 2048 patches keeps the explicit scratch around ~0.8 GB at n_head=16
+// instead of trusting the raw 4096 default (~3.2 GB) blind.
+static const int CLIP_AUTO_FA_MIN_KV_NO_MEMINFO_CAP = 2048;
+
+// Pure arithmetic for the AUTO budget decision (exported for unit tests, see
+// tests/test-clip-fa-cutoff.cpp). Returns the effective explicit-attention
+// cutoff in n_patches given the configured cutoff and the device memory probe:
+//
+//  - total memory provides the STABLE fast-path clamp (session-independent —
+//    the explicit scratch, ~3*n^2*n_head*4 bytes, must fit in half of total):
+//    normal-size images keep the fast explicit path regardless of momentary
+//    memory pressure.
+//  - free memory (a volatile, load-dependent number) may only LOWER the
+//    cutoff further, and only by the hard-fit requirement: when reported,
+//    the explicit scratch must also fit in what is actually free right now.
+//    It can never extend the explicit path beyond the total-memory clamp.
+//  - neither reported: fail SAFE toward memory-frugal FA with a conservative
+//    constant cap instead of the raw default.
+int clip_fa_effective_min_kv(int auto_min_kv, size_t total_mem, size_t free_mem, int n_head) {
+    if (auto_min_kv <= 0) {
+        return auto_min_kv;
+    }
+    const double heads = (double) (n_head > 0 ? n_head : 1);
+    int eff_min_kv = auto_min_kv;
+    if (total_mem > 0) {
+        // Stable clamp: explicit scratch (3 * n^2 * n_head * 4) <= total/4
+        // =>  n <= sqrt((total/2) / (24*n_head))
+        const double n_max_total = std::sqrt(((double) total_mem / 2.0) / (24.0 * heads));
+        eff_min_kv = std::min(eff_min_kv, (int) n_max_total);
+    }
+    if (free_mem > 0) {
+        // Hard fit: 3 * n^2 * n_head * 4 <= free  =>  n <= sqrt(free / (12*n_head))
+        const double n_max_free = std::sqrt((double) free_mem / (12.0 * heads));
+        eff_min_kv = std::min(eff_min_kv, (int) n_max_free);
+    }
+    if (total_mem == 0 && free_mem == 0) {
+        eff_min_kv = std::min(eff_min_kv, CLIP_AUTO_FA_MIN_KV_NO_MEMINFO_CAP);
+    }
+    return eff_min_kv;
+}
+
 // Resolve the effective flash-attention mode for a single image graph.
 //
 // ENABLED/DISABLED are explicit user choices and are honored as-is. AUTO is
@@ -351,10 +394,8 @@ static clip_flash_attn_type clip_resolve_flash_attn_type(clip_ctx * ctx, int n_p
         if (dev) {
             ggml_backend_dev_memory(dev, &free_mem, &total_mem);
         }
-        // Prefer free memory when the backend reports it; many mobile drivers
-        // report 0, so fall back to total. If neither is known, rely on the
-        // threshold alone.
-        ctx->fa_mem_capacity = free_mem > 0 ? free_mem : total_mem;
+        ctx->fa_mem_total = total_mem;
+        ctx->fa_mem_free  = free_mem;
         ctx->fa_budget_cached = true;
     }
 
@@ -368,19 +409,14 @@ static clip_flash_attn_type clip_resolve_flash_attn_type(clip_ctx * ctx, int n_p
     // Explicit attention (mul_mat + softmax) is faster than the scalar FA kernel
     // on no-coopmat GPUs for short sequences, but it materializes an
     // O(n_patches^2 * n_head) score matrix. Memory-constrained devices can't
-    // hold that, so cap the "use explicit" cutoff by how much device memory is
-    // available: the effective cutoff is the smaller of the configured threshold
-    // and the largest n_patches whose explicit scratch (scores + softmax/kqv
-    // temporaries, ~3x) fits in ~half of device memory. This only ever lowers
-    // the cutoff, so low-memory devices fall back to memory-frugal FA sooner.
-    int eff_min_kv = auto_fa_min_kv;
-    const size_t capacity = ctx->fa_mem_capacity;
-    if (capacity > 0) {
-        const size_t n_head = (size_t) ctx->model.hparams.n_head;
-        // 3 * n^2 * n_head * 4 bytes <= capacity / 2  =>  n <= sqrt(capacity / (24*n_head))
-        const double n_max = std::sqrt((double) capacity / (24.0 * (double) std::max<size_t>(n_head, 1)));
-        eff_min_kv = std::min(eff_min_kv, (int) n_max);
-    }
+    // hold that, so cap the "use explicit" cutoff by the memory budget (see
+    // clip_fa_effective_min_kv above: total memory = stable clamp, free memory
+    // = hard-fit check only, no memory info = conservative constant). This only
+    // ever lowers the cutoff, so constrained devices fall back to memory-frugal
+    // FA sooner.
+    const int eff_min_kv = clip_fa_effective_min_kv(
+        auto_fa_min_kv, ctx->fa_mem_total, ctx->fa_mem_free,
+        (int) ctx->model.hparams.n_head);
 
     return (n_patches < eff_min_kv) ? CLIP_FLASH_ATTN_TYPE_DISABLED
                                     : CLIP_FLASH_ATTN_TYPE_ENABLED;
@@ -2747,9 +2783,12 @@ struct clip_model_loader {
         // scalar FA for huge ones — slow-but-alive beats fast-but-OOM.
         // Default when the backend can't confirm efficient FA = KEEP it. Only ggml-vulkan
         // implements the query (returning false for Mali/non-coopmat); backends that don't
-        // answer (Metal, CUDA, …) have efficient FA and must keep it — disabling there forces
-        // explicit attention whose QK^T overflows the clip compute buffer at high n_pos
-        // (GGML_ASSERT in ggml-backend, e.g. image_tile_mode=disabled + large image_max_tokens).
+        // answer (Metal, CUDA, and also ggml-opencl) have (or are assumed to have) efficient
+        // FA and must keep it — disabling there forces explicit attention whose QK^T
+        // overflows the clip compute buffer at high n_pos (GGML_ASSERT in ggml-backend,
+        // e.g. image_tile_mode=disabled + large image_max_tokens). ggml-opencl's own
+        // giant-encode driver fault at high n_pos is handled inside that backend
+        // (submission bounding: periodic clFlush + FA q-chunking), not via this gate.
         if (ctx_clip.flash_attn_type != CLIP_FLASH_ATTN_TYPE_DISABLED &&
             ctx_clip.backend && ctx_clip.backend != ctx_clip.backend_cpu) {
             bool efficient_fa = true;

--- a/tools/mtmd/clip.h
+++ b/tools/mtmd/clip.h
@@ -142,4 +142,11 @@ bool clip_has_whisper_encoder(const struct clip_ctx * ctx);
 // summed with the scheduler's compute reservations. Used by mtmd_get_memory_usage
 // (and ultimately by common/fit.cpp's heuristic). Restored from upstream b9341.
 std::map<ggml_backend_dev_t, size_t> clip_get_mem_usage(const struct clip_ctx * ctx);
+
+// qvac QVAC-21914: pure arithmetic of the flash-attention AUTO budget decision —
+// the effective explicit-attention cutoff (n_patches) from the configured cutoff
+// and the device memory probe (total = stable clamp, free = hard-fit check only,
+// neither = conservative constant cap). Exposed for unit testing
+// (tests/test-clip-fa-cutoff.cpp); behavior documented at the definition.
+int clip_fa_effective_min_kv(int auto_min_kv, size_t total_mem, size_t free_mem, int n_head);
 #endif

--- a/tools/mtmd/clip.h
+++ b/tools/mtmd/clip.h
@@ -6,6 +6,8 @@
 #include <stddef.h>
 #include <stdint.h>
 #ifdef __cplusplus
+#include <algorithm>
+#include <cmath>
 #include <map>
 #endif
 
@@ -143,10 +145,48 @@ bool clip_has_whisper_encoder(const struct clip_ctx * ctx);
 // (and ultimately by common/fit.cpp's heuristic). Restored from upstream b9341.
 std::map<ggml_backend_dev_t, size_t> clip_get_mem_usage(const struct clip_ctx * ctx);
 
-// qvac QVAC-21914: pure arithmetic of the flash-attention AUTO budget decision —
-// the effective explicit-attention cutoff (n_patches) from the configured cutoff
-// and the device memory probe (total = stable clamp, free = hard-fit check only,
-// neither = conservative constant cap). Exposed for unit testing
-// (tests/test-clip-fa-cutoff.cpp); behavior documented at the definition.
-int clip_fa_effective_min_kv(int auto_min_kv, size_t total_mem, size_t free_mem, int n_head);
+// qvac QVAC-21914: pure arithmetic of the flash-attention AUTO budget decision.
+// Returns the effective explicit-attention cutoff in n_patches given the
+// configured cutoff and the device memory probe:
+//
+//  - total memory provides the STABLE fast-path clamp (session-independent —
+//    the explicit scratch, ~3*n^2*n_head*4 bytes, must fit in a quarter of
+//    total): normal-size images keep the fast explicit path regardless of
+//    momentary memory pressure.
+//  - free memory (a volatile, load-dependent number) may only LOWER the cutoff
+//    further, and only by the hard-fit requirement: when reported, the explicit
+//    scratch must also fit in what is actually free right now. It can never
+//    extend the explicit path beyond the total-memory clamp.
+//  - neither reported: fail SAFE toward memory-frugal FA with a conservative
+//    constant cap instead of the raw default.
+//
+// Defined inline here (not out-of-line in clip.cpp) so unit tests can exercise
+// it without linking an unexported symbol across the Windows mtmd.dll boundary
+// — the internal clip_* API carries no MTMD_API export decoration.
+inline int clip_fa_effective_min_kv(int auto_min_kv, size_t total_mem, size_t free_mem, int n_head) {
+    // Conservative cutoff cap when the device reports no memory information at
+    // all: 2048 patches keeps the explicit scratch around ~0.8 GB at n_head=16
+    // instead of trusting the raw 4096 default (~3.2 GB) blind.
+    constexpr int NO_MEMINFO_CAP = 2048;
+    if (auto_min_kv <= 0) {
+        return auto_min_kv;
+    }
+    const double heads = (double) (n_head > 0 ? n_head : 1);
+    int eff_min_kv = auto_min_kv;
+    if (total_mem > 0) {
+        // Stable clamp: explicit scratch (3 * n^2 * n_head * 4) <= total/4
+        // =>  n <= sqrt((total/2) / (24*n_head))
+        const double n_max_total = std::sqrt(((double) total_mem / 2.0) / (24.0 * heads));
+        eff_min_kv = std::min(eff_min_kv, (int) n_max_total);
+    }
+    if (free_mem > 0) {
+        // Hard fit: 3 * n^2 * n_head * 4 <= free  =>  n <= sqrt(free / (12*n_head))
+        const double n_max_free = std::sqrt((double) free_mem / (12.0 * heads));
+        eff_min_kv = std::min(eff_min_kv, (int) n_max_free);
+    }
+    if (total_mem == 0 && free_mem == 0) {
+        eff_min_kv = std::min(eff_min_kv, NO_MEMINFO_CAP);
+    }
+    return eff_min_kv;
+}
 #endif

--- a/tools/mtmd/clip.h
+++ b/tools/mtmd/clip.h
@@ -145,7 +145,7 @@ bool clip_has_whisper_encoder(const struct clip_ctx * ctx);
 // (and ultimately by common/fit.cpp's heuristic). Restored from upstream b9341.
 std::map<ggml_backend_dev_t, size_t> clip_get_mem_usage(const struct clip_ctx * ctx);
 
-// qvac QVAC-21914: pure arithmetic of the flash-attention AUTO budget decision.
+// QVAC-21914: pure arithmetic of the flash-attention AUTO budget decision.
 // Returns the effective explicit-attention cutoff in n_patches given the
 // configured cutoff and the device memory probe:
 //


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

`runQwen35ImageTileModeTokensTest` (GPU-default mmproj, `image_max_tokens=4096`, `image_tile_mode=disabled` → a **monolithic 16,384-patch ViT encode**, the heaviest vision encode in the suite) crashes two of the three Android Device-Farm flagships (QVAC-21914):

- **Pixel 9 Pro (Mali-G715 / Vulkan): lmkd kill at ~11.9 GB RSS.** The non-coopmat FA hard-disable introduced in #174 replaces AUTO/ENABLED with DISABLED at warmup, which **bypasses the budget-aware AUTO heuristic** (`clip_resolve_flash_attn_type`) built precisely for this case — the forced explicit-attention path materializes an O(n²·n_head) score matrix that cannot fit at 16k patches.
- **Galaxy S25 Ultra (Adreno 830 / OpenCL): driver abort.** The GPU faults near the tail of the giant encode (`Adreno-GSL log_gpu_snapshot` fires **before any decode work** reaches the device), after which Qualcomm's UMD kills the process from `cl_a8x_cmdbuf_mgr_submit_ibs` (`os_exit`) on the next submission — no CL error ever surfaces to the app. Logcat forensics on both crashing runs revised the initial "decode abort" attribution: the 512-token image-chunk **decode is exonerated** (304 clean full-512-row ubatch decodes in the S25 benchmark); only the monolithic encode — 5–8× beyond anything previously run on this backend — triggers the fault.

**Why S25 and not S26:** not a backend split — S26 Ultra (Adreno 840) runs the **same ggml-opencl path** (`Adreno GPU version 840 found keeping OpenCL backend`, 102× `Chosen GPU OpenCL` in its shard log). S26 completes the identical encode in ~29.5 s on a newer Android-16 UMD; S25 (Android-15 / 830 UMD) faulted ~48 s in. The fault is per-submission-magnitude dependent — fix 2 makes S25 pass **without shortening the workload**.

## 📝 How does it solve it?

Two independent fixes (the S25 crash reproduced twice with fix 1 alone — original signature — confirming independence):

1. **`clip.cpp`: downgrade the non-coopmat FA hard-disable to budget-aware AUTO** (`ef71f2b15`). When the backend answers `ggml_backend_supports_efficient_fa == false`, set `CLIP_FLASH_ATTN_TYPE_AUTO` (not DISABLED) and record `clip_ctx::fa_backend_inefficient`, which now also enables the AUTO cutoff default (4096 patches; previously Mali-detection only). Normal images keep the fast explicit path #174 optimized for; huge encodes fall back to memory-frugal scalar FA — slow-but-alive beats fast-but-OOM. Explicit user `DISABLED` and `MTMD_CLIP_AUTO_FA_MIN_KV` honored as before; backends without the query (Metal/CUDA/OpenCL) unchanged.
2. **`ggml-opencl.cpp`: bound driver submissions** (`ee727efe9`, refined in `d1fe2fad0`).
   - `graph_compute` flushes when the estimated **enqueued work** since the last flush exceeds `GGML_OPENCL_FLUSH_WORK_MB` (default 512 MB, `0` disables) — previously entire multi-thousand-node graphs (~48 s of GPU work) were enqueued with zero intra-graph flushes. Gating on work (not a node count) keeps the per-token LLM decode graph submission-free by construction (it never accumulates near the budget), while the 16k-patch encode flushes dozens of times.
   - `ggml_cl_flash_attn` chunks dispatches along q-rows at `GGML_OPENCL_FA_MAX_NQ` rows (default 4096, `0` disables) with a flush between chunks. The split is exact: the kernel resolves its q row relative to the Q/O/mask base byte offsets, `is_causal` is always 0 (masking is explicit — guarded by `GGML_ASSERT`), and alibi/sinks depend only on the head index — **no `.cl` kernel changes**. For `n_q ≤ 4096` the dispatch path is byte-identical to before.

3. **`clip.cpp`: memory-clamp rework + review hardening** (`d1fe2fad0`). The AUTO cutoff is now clamped by **total** memory (stable, session-independent: explicit scratch ≤ total/4); free memory may only *lower* it via a hard-fit check (scratch ≤ free), never the earlier free/2 heuristic that could push normal-size Mali images onto the slow scalar-FA path under momentary memory pressure. No memory info at all fails **safe** at a conservative 2048-patch cap instead of the raw 4096 default. Plus: both OpenCL env knobs resolved once at init with `strtol` (clamp + warn, not silent-disable) and logged; `is_causal` assert; `n_q == 0` guard.

**CPU paths are untouched**: the warmup change is gated on `backend != backend_cpu`, and both hardening changes live inside the OpenCL backend module.

## 🧪 How was it tested?

All on-device validation via the consumer branch `tetherto/qvac` `test/QVAC-21914-tile-mode-fa-fix` (GPU-default mmproj) carrying this branch as a self-contained vcpkg overlay port; local compile checks for both the CPU-only `mtmd` target and `ggml-opencl` (Khronos headers/ICD loader).

**Crash fix — funcShardE per device, vs the crashing baseline ([28865241320](https://github.com/tetherto/qvac/actions/runs/28865241320), stock v9341.1.5):**

| Device | Stock v9341.1.5 | Fix 1 only (2 runs) | Fix 1 + 2 (this PR) |
|---|---|---|---|
| Pixel 9 Pro (Mali) | ❌ lmkd kill @ ~11.9 GB in tile-mode | ✅ 11/11 passed, twice (tile-mode 386 s) | ✅ 11/11 passed |
| Galaxy S25 Ultra (Adreno 830) | ❌ driver abort in tile-mode | ❌ crashed twice (original `cl_a8x` signature; once earlier in MultiInstance — flaky driver heap corruption) | ✅ **funcShardE 3/3 — first-ever full pass** |
| Galaxy S26 Ultra (Adreno 840) | ✅ | ✅ | ✅ |

- **Targeted S25 gate** ([28898009992](https://github.com/tetherto/qvac/actions/runs/28898009992)): tile-mode test alone on an S25 Ultra — PASS in 266 s, `crashed:false`, **zero driver-fault lines in logcat** (no `log_gpu_snapshot`, no `os_exit`, no SIGABRT).
- **Full Android integration** ([28900670167](https://github.com/tetherto/qvac/actions/runs/28900670167)): all 6 shard-runs × Pixel 9 Pro / S25 Ultra / S26 Ultra — **18/18 device-slots green** (includes `runImageMmprojGpuTest` asserting the GPU projector on all devices).

**Performance A/B — VLM benchmark (qwen3.5-q8, cognitive preset ×3 samples, CPU+GPU cells, 30/30 samples per device, 0 errors), post-hardening ([28900672031](https://github.com/tetherto/qvac/actions/runs/28900672031)) vs pre-hardening baselines (runs #252/#253):**

| Metric | pixel9 CPU / GPU | S25 CPU / GPU (OpenCL) | S26 CPU / GPU (OpenCL) |
|---|---|---|---|
| Quality (Overall %) | 31.1 / 40.0 | 31.1 / **31.1 (Δ0)** | 31.1 / **31.1 (Δ0)** |
| mmproj-encode (ms) | 3920 / 4814 | 1465 / 1061 | 1394 / 669 |
| vs pre-hardening | ±2% | GPU/CPU ratio 0.72 vs 0.76 | GPU 669 vs 672 ms |

GPU quality per-task identical to CPU on both Adreno devices; encode/decode within cross-unit noise of the pre-hardening numbers — **no measurable overhead** from the flushes/chunking (benchmark images are ≤ ~3072 patches, so the chunking path only engages on the huge encodes it exists for). _(This A/B ran the `ee727efe9` hardening; the `d1fe2fad0` refinements are behavior-preserving for these shapes — work-budget gating only removes decode-path flushes, the memory clamp only matters at low free memory — and are re-validated by the S25 gate below.)_

**Unit + parity tests** (`d1fe2fad0`, `tests/`):
- `test-clip-fa-cutoff` — pure-CPU coverage of the AUTO budget arithmetic: fast path survives low free memory, the P2 regression guard (1.5 GB free → hard-fit ~2795, not free/2 ~1976), the no-meminfo fail-safe cap, and edge cases. **Passing locally.**
- `test-opencl-fa-chunking` — chunked-vs-CPU numerical parity (`GGML_OPENCL_FA_MAX_NQ=64`) over unchunked / exact-chunk / partial-last-chunk / `n_q==1`, masked and unmasked. Self-skips without an FP16-capable OpenCL device (PoCL lacks FP16), so it runs on Adreno-class hardware / desktop OpenCL — not on the CI Linux host.

**Re-validation of the refined build** (`d1fe2fad0`) — all green, no regression:
- Targeted S25 tile-mode gate ([28924019133](https://github.com/tetherto/qvac/actions/runs/28924019133)): **PASS in 281 s, `crashed:false`, zero driver-fault lines**.
- Full Android integration ([28926370595](https://github.com/tetherto/qvac/actions/runs/28926370595)): **18/18 device-slots green** — funcShardE 3/3 on Pixel 9 Pro + S25 Ultra + S26 Ultra.
- Benchmark ([28926372393](https://github.com/tetherto/qvac/actions/runs/28926372393)): 30/30 per device, GPU quality Δ0, encode/decode within noise of the pre-review-fix build (S26 GPU 619 ms; S25/S26 GPU decode TPS 30.9/33.5 confirms the work-budget flush leaves the decode hot path unaffected).

**Windows DLL link fix** (`dacb473f9`): `test-clip-fa-cutoff` linked an internal `clip_*` symbol absent from the Windows `mtmd.dll` import lib (no `MTMD_API` export) → `LNK2019` on Windows only. Fixed by moving `clip_fa_effective_min_kv` inline into `clip.h` — no export of an internal helper, builds on every platform. Behavior-identical on Android, re-validated end-to-end at the PR tip: S25 gate ([28928563147](https://github.com/tetherto/qvac/actions/runs/28928563147)) tile-mode PASS 264 s / `crashed:false` / 0 driver-fault lines; full Android integration ([28929513759](https://github.com/tetherto/qvac/actions/runs/28929513759)) **18/18 green**; benchmark ([28929516001](https://github.com/tetherto/qvac/actions/runs/28929516001)) 30/30 per device, GPU quality Δ0, encode within noise (S26 GPU 600 ms).

**PR review comments** (`645e684d7`): `parse_env_i64` now warns when it clamps an oversized `GGML_OPENCL_FLUSH_WORK_MB`/`GGML_OPENCL_FA_MAX_NQ` (was silent); `test-clip-fa-cutoff`'s `n_head=0` case reworked to pass `total_mem>0` so the div-by-zero guard is actually exercised. Windows/CPU-only; no Android behavior change.

**Flush-ordering fix** (`39e0a8641`, @gianni-cor): the work-budget flush ran *before* the budget-crossing node was dispatched, so that node began a fresh batch that could reach graph end unflushed — defeating the bound. Moved the check below dispatch (fused-op `continue` chain → `if/else`, single touch point) so the crossing node is in the flushed batch. Behavioral (tighter bound), so re-validated at PR-head `c720b2b6b`: full Android integration ([28938583459](https://github.com/tetherto/qvac/actions/runs/28938583459)) **18/18 green** (funcShardE 3/3 × Pixel 9 / S25 / S26) + benchmark ([28938585754](https://github.com/tetherto/qvac/actions/runs/28938585754)) 30/30 per device, GPU quality Δ0, encode/decode within noise (S26 GPU 565 ms, S25/S26 decode 29.6/34.6 TPS) — no regression from the reordered flush.

**Review cleanups** (`c720b2b6b`): corrected the "submission-free by construction" flush comment to describe the real per-model cadence, added `n_q <= INT32_MAX` assert, normalized ticket tags, and relocated the OpenCL FA-chunking test in CMakeLists. Non-behavioral — covered by the same PR-head `c720b2b6b` on-device runs as the flush-ordering fix above: full Android integration ([28938583459](https://github.com/tetherto/qvac/actions/runs/28938583459)) **18/18 green** (funcShardE 3/3 × Pixel 9 / S25 / S26) + benchmark ([28938585754](https://github.com/tetherto/qvac/actions/runs/28938585754)) 30/30 per device, GPU quality Δ0.

## ⚠️ Breaking changes

None. Fix 1 only changes behavior on backends that affirmatively report inefficient FA (today: Mali via ggml-vulkan); explicit `DISABLED` and the env override are honored, Metal/CUDA/OpenCL projectors unchanged. Fix 2 is OpenCL-module-only, mathematically exact, byte-identical dispatch for `n_q ≤ 4096`, and both knobs can be disabled at runtime (`GGML_OPENCL_FLUSH_WORK_MB=0`, `GGML_OPENCL_FA_MAX_NQ=0`). CPU inference paths are untouched.

## ✅ Consumer overlay validation (Phase A)

All 6 qvac consumers validated against PR head `c720b2b6b` via a self-contained vcpkg overlay port (branch `validate/QVAC-21914-fabric-overlay-pr181`, commit `d4dee909` — no baseline/version changes). `merge-guard / validate-pr` red is expected on a no-PR dispatch branch; the only retried jobs were infra flakes unrelated to this PR (win32 npm tooling setup, a loaded-runner test timeout):

- classification-ggml: https://github.com/tetherto/qvac/actions/runs/28947785997
- embed-llamacpp: https://github.com/tetherto/qvac/actions/runs/28947788176
- llm-llamacpp: https://github.com/tetherto/qvac/actions/runs/28947790751
- ocr-ggml: https://github.com/tetherto/qvac/actions/runs/28947793129
- translation-nmtcpp: https://github.com/tetherto/qvac/actions/runs/28947795569
- vla-ggml: https://github.com/tetherto/qvac/actions/runs/28947798189






