### PR TITLE
Disable weight repacking for training loads

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1734,7 +1734,10 @@ struct llama_model_params common_model_params_to_llama(common_params & params) {
     mparams.use_direct_io   = params.use_direct_io;
     mparams.use_mlock       = params.use_mlock;
     mparams.check_tensors   = params.check_tensors;
-    mparams.use_extra_bufts = !params.no_extra_bufts;
+
+    // Disable weight repacking for training loads, backward ops can't read
+    // repacked layouts.
+    mparams.use_extra_bufts = !params.no_extra_bufts && !params.training;
     mparams.no_host         = params.no_host;
 
     if (params.kv_overrides.empty()) {

--- a/ggml/include/ggml-opt.h
+++ b/ggml/include/ggml-opt.h
@@ -44,7 +44,7 @@ extern "C" {
             int64_t        ne_label,     // number of elements per label
             int64_t        ndata,        // total number of datapoints/labels
             int64_t        ndata_shard); // number of datapoints/labels per shard (unit at which the dataset is shuffled/copied)
-    
+
     GGML_API ggml_opt_dataset_t ggml_opt_dataset_init_with_masks(
             enum ggml_type type_data,    // the type for the internal data tensor
             enum ggml_type type_label,   // the type for the internal labels tensor
@@ -146,6 +146,11 @@ extern "C" {
 
         // only GGML_OPT_OPTIMIZER_TYPE_ADAMW needs m, v momenta per parameter tensor
         enum ggml_opt_optimizer_type optimizer;
+
+        // Backward loss scale (default 1.0 = off). The backward is seeded from
+        // loss*loss_scale so gradient magnitudes stay within fp32 range through deep
+        // backprop.
+        float loss_scale;
     };
 
     // get parameters for an optimization context with defaults set where possible
@@ -174,7 +179,7 @@ extern "C" {
 
     // get the gradient accumulator for a node from the forward graph
     GGML_API struct ggml_tensor * ggml_opt_grad_acc(ggml_opt_context_t opt_ctx, struct ggml_tensor * node);
-    
+
     // get optimizer state tensors (momentum and variance for AdamW)
     GGML_API int64_t ggml_opt_get_iter(ggml_opt_context_t opt_ctx);
     GGML_API void    ggml_opt_set_iter(ggml_opt_context_t opt_ctx, int64_t iter);

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -740,8 +740,9 @@ int ggml_metal_op_acc(ggml_metal_op_t ctx, int idx) {
         ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         2);
 
         const int nth = std::min(ggml_metal_pipeline_max_theads_per_threadgroup(pipeline), ne00);
+        const int nw0 = (ne00 + nth - 1)/nth;
 
-        ggml_metal_encoder_dispatch_threadgroups(enc, ne01, ne02, ne03, nth, 1, 1);
+        ggml_metal_encoder_dispatch_threadgroups(enc, nw0*ne01, ne02, ne03, nth, 1, 1);
 
         ggml_metal_op_concurrency_reset(ctx);
     }
@@ -1833,8 +1834,9 @@ int ggml_metal_op_set(ggml_metal_op_t ctx, int idx) {
         ggml_metal_encoder_set_buffer  (enc, bid_dst,  2);
 
         const int nth = std::min(ggml_metal_pipeline_max_theads_per_threadgroup(pipeline), ne00);
+        const int nw0 = (ne00 + nth - 1)/nth;
 
-        ggml_metal_encoder_dispatch_threadgroups(enc, ne01, ne02, ne03, nth, 1, 1);
+        ggml_metal_encoder_dispatch_threadgroups(enc, nw0*ne01, ne02, ne03, nth, 1, 1);
 
         ggml_metal_op_concurrency_reset(ctx);
     }

--- a/ggml/src/ggml-opt.cpp
+++ b/ggml/src/ggml-opt.cpp
@@ -67,6 +67,10 @@ struct ggml_opt_context {
     int32_t opt_i              = 0;
     bool    loss_per_datapoint = false;
 
+    // Backward loss scale: the backward is seeded from loss*loss_scale so gradient
+    // magnitudes stay within fp32 range through deep backprop.
+    float   loss_scale         = 1.0f;
+
     ggml_opt_get_optimizer_params get_opt_pars    = nullptr;
     void *                        get_opt_pars_ud = nullptr;
     struct ggml_tensor *          opt_step_params = nullptr; // Stores output of get_opt_pars.
@@ -347,6 +351,7 @@ struct ggml_opt_params ggml_opt_default_params(
         /*get_opt_pars    =*/ ggml_opt_get_default_optimizer_params,
         /*get_opt_pars_ud =*/ nullptr,
         /*optimizer       =*/ GGML_OPT_OPTIMIZER_TYPE_ADAMW,
+        /*loss_scale      =*/ 1.0f,
     };
 }
 
@@ -538,8 +543,15 @@ static void ggml_opt_build(ggml_opt_context_t opt_ctx) {
         }
     }
     ggml_set_output(opt_ctx->loss);
-    ggml_set_loss(opt_ctx->loss);
-    ggml_build_forward_expand(opt_ctx->gf, opt_ctx->loss);
+
+    struct ggml_tensor * loss_for_backward = opt_ctx->loss;
+    if (opt_ctx->loss_scale != 1.0f) {
+        loss_for_backward = ggml_scale(ctx_results, opt_ctx->loss, opt_ctx->loss_scale);
+        ggml_set_name(loss_for_backward, "loss_backward_scaled");
+        ggml_set_output(loss_for_backward);
+    }
+    ggml_set_loss(loss_for_backward);
+    ggml_build_forward_expand(opt_ctx->gf, loss_for_backward);
 
     if (opt_ctx->loss_type == GGML_OPT_LOSS_TYPE_CROSS_ENTROPY || opt_ctx->loss_type == GGML_OPT_LOSS_TYPE_CROSS_ENTROPY_MASKED) {
         opt_ctx->pred = ggml_argmax(ctx_results, opt_ctx->outputs);
@@ -676,6 +688,17 @@ ggml_opt_context_t ggml_opt_init(struct ggml_opt_params params) {
     result->get_opt_pars     = params.get_opt_pars;
     result->get_opt_pars_ud  = params.get_opt_pars_ud;
     result->optimizer        = params.optimizer;
+
+    result->loss_scale = params.loss_scale > 0.0f ? params.loss_scale : 1.0f;
+    {
+        const char * ls = getenv("GGML_OPT_LOSS_SCALE");
+        if (ls) {
+            const float s = (float) atof(ls);
+            if (s > 0.0f) {
+                result->loss_scale = s;
+            }
+        }
+    }
 
     GGML_ASSERT(result->opt_period >= 1);
 
@@ -955,7 +978,7 @@ void ggml_opt_eval(ggml_opt_context_t opt_ctx, ggml_opt_result_t result) {
                 adamw_par_data[0] = opt_pars.adamw.alpha;
                 adamw_par_data[1] = opt_pars.adamw.beta1;
                 adamw_par_data[2] = opt_pars.adamw.beta2;
-                adamw_par_data[3] = opt_pars.adamw.eps;
+                adamw_par_data[3] = opt_pars.adamw.eps * opt_ctx->loss_scale;
                 adamw_par_data[4] = opt_pars.adamw.wd;
                 adamw_par_data[5] = beta1h;
                 adamw_par_data[6] = beta2h;
@@ -965,7 +988,7 @@ void ggml_opt_eval(ggml_opt_context_t opt_ctx, ggml_opt_result_t result) {
                 GGML_ASSERT(opt_pars.sgd.wd >= 0.0f);
                 GGML_ASSERT(opt_pars.sgd.wd <= 1.0f);
                 float * sgd = ggml_get_data_f32(opt_ctx->opt_step_params);
-                sgd[0] = opt_pars.sgd.alpha;
+                sgd[0] = opt_pars.sgd.alpha / opt_ctx->loss_scale;
                 sgd[1] = opt_pars.sgd.wd;
             } break;
             default:
@@ -1030,11 +1053,11 @@ void ggml_opt_eval(ggml_opt_context_t opt_ctx, ggml_opt_result_t result) {
     if (opt_ctx->loss_type == GGML_OPT_LOSS_TYPE_CROSS_ENTROPY_MASKED && opt_ctx->masks) {
         int64_t total_valid = 0;
         const int64_t nr = opt_ctx->masks->ne[1];
-        
+
         const size_t mask_size = ggml_nbytes(opt_ctx->masks);
         std::vector<float> mask_data(mask_size / sizeof(float));
         ggml_backend_tensor_get(opt_ctx->masks, mask_data.data(), 0, mask_size);
-        
+
         for (int64_t i1 = 0; i1 < nr; i1++) {
             const size_t idx = i1 * (opt_ctx->masks->ne[0]);
             const float mask_value = mask_data[idx];
@@ -1280,7 +1303,7 @@ bool ggml_opt_save_state(ggml_opt_context_t opt_ctx, const char* filename) {
     gguf_set_val_i32(gguf_ctx, "optimizer.n_params", ggml_opt_get_nparams(opt_ctx));
 
     int32_t total_params = ggml_opt_get_nparams(opt_ctx);
-    
+
     for (int32_t i = 0; i < total_params; ++i) {
         struct ggml_tensor * grad_m = ggml_opt_get_grad_m(opt_ctx, i);
         struct ggml_tensor * grad_v = ggml_opt_get_grad_v(opt_ctx, i);
@@ -1291,10 +1314,10 @@ bool ggml_opt_save_state(ggml_opt_context_t opt_ctx, const char* filename) {
             gguf_add_tensor(gguf_ctx, grad_v);
         }
     }
-    
+
     bool success = gguf_write_to_file(gguf_ctx, filename, false);
     gguf_free(gguf_ctx);
-    
+
     return success;
 }
 
@@ -1307,18 +1330,18 @@ bool ggml_opt_load_state(ggml_opt_context_t opt_ctx, const char* filename) {
         /* .no_alloc = */ true,
         /* .ctx      = */ nullptr,
     };
-    
+
     struct gguf_context * gguf_context = gguf_init_from_file(filename, gguf_params);
     if (!gguf_context) {
         return false;
     }
-    
+
     int key_idx = gguf_find_key(gguf_context, "optimizer.iteration");
     if (key_idx >= 0) {
         int64_t saved_iter = gguf_get_val_i64(gguf_context, key_idx);
         ggml_opt_set_iter(opt_ctx, saved_iter);
     }
-        
+
     gguf_free(gguf_context);
     return true;
 }
@@ -1333,17 +1356,17 @@ bool ggml_opt_load_tensors(ggml_opt_context_t opt_ctx, const char* filename) {
         /* .no_alloc = */ false,
         /* .ctx      = */ &gguf_ctx,
     };
-    
+
     struct gguf_context * gguf_context = gguf_init_from_file(filename, gguf_params);
     if (!gguf_context) {
         return false;
     }
-    
+
     if (!gguf_ctx) {
         gguf_free(gguf_context);
         return false;
     }
-    
+
     int tensor_count = gguf_get_n_tensors(gguf_context);
     int grad_m_loaded = 0, grad_v_loaded = 0;
     const int32_t n_params = ggml_opt_get_nparams(opt_ctx);
@@ -1351,14 +1374,14 @@ bool ggml_opt_load_tensors(ggml_opt_context_t opt_ctx, const char* filename) {
     for (int i = 0; i < tensor_count; ++i) {
         const char* tensor_name = gguf_get_tensor_name(gguf_context, i);
         if (!tensor_name) continue;
-        
+
         struct ggml_tensor* gguf_tensor = ggml_get_tensor(gguf_ctx, tensor_name);
         if (!gguf_tensor) continue;
-        
+
         for (int32_t param_idx = 0; param_idx < n_params; ++param_idx) {
             struct ggml_tensor* grad_m = ggml_opt_get_grad_m(opt_ctx, param_idx);
             struct ggml_tensor* grad_v = ggml_opt_get_grad_v(opt_ctx, param_idx);
-            
+
             if (grad_m && strlen(grad_m->name) > 0 && strcmp(tensor_name, grad_m->name) == 0) {
                 if (grad_m->type == gguf_tensor->type &&
                     ggml_nelements(grad_m) == ggml_nelements(gguf_tensor)) {
@@ -1381,7 +1404,7 @@ bool ggml_opt_load_tensors(ggml_opt_context_t opt_ctx, const char* filename) {
                 break;
             }
         }
-        
+
     }
 
     ggml_free(gguf_ctx);

--- a/ggml/src/ggml-opt.cpp
+++ b/ggml/src/ggml-opt.cpp
@@ -1292,6 +1292,7 @@ bool ggml_opt_save_state(ggml_opt_context_t opt_ctx, const char* filename) {
     gguf_set_val_str(gguf_ctx, "general.type", "optimizer");
     gguf_set_val_i64(gguf_ctx, "optimizer.iteration", ggml_opt_get_iter(opt_ctx));
     gguf_set_val_i32(gguf_ctx, "optimizer.n_params", ggml_opt_get_nparams(opt_ctx));
+    gguf_set_val_f32(gguf_ctx, "optimizer.loss_scale", opt_ctx->loss_scale);
 
     int32_t total_params = ggml_opt_get_nparams(opt_ctx);
 
@@ -1362,6 +1363,17 @@ bool ggml_opt_load_tensors(ggml_opt_context_t opt_ctx, const char* filename) {
     int grad_m_loaded = 0, grad_v_loaded = 0;
     const int32_t n_params = ggml_opt_get_nparams(opt_ctx);
 
+    float loss_scale_file = 1.0f;
+    {
+        const int key_idx = gguf_find_key(gguf_context, "optimizer.loss_scale");
+        if (key_idx >= 0) {
+            loss_scale_file = gguf_get_val_f32(gguf_context, key_idx);
+        }
+    }
+    const bool  rescale = loss_scale_file > 0.0f && loss_scale_file != opt_ctx->loss_scale;
+    const float ratio_m = rescale ? opt_ctx->loss_scale / loss_scale_file : 1.0f;
+    const float ratio_v = ratio_m * ratio_m;
+
     for (int i = 0; i < tensor_count; ++i) {
         const char* tensor_name = gguf_get_tensor_name(gguf_context, i);
         if (!tensor_name) continue;
@@ -1377,6 +1389,12 @@ bool ggml_opt_load_tensors(ggml_opt_context_t opt_ctx, const char* filename) {
                 if (grad_m->type == gguf_tensor->type &&
                     ggml_nelements(grad_m) == ggml_nelements(gguf_tensor)) {
                     if (grad_m->data) {
+                        if (rescale && gguf_tensor->type == GGML_TYPE_F32) {
+                            float * data = (float *) gguf_tensor->data;
+                            for (int64_t j = 0; j < ggml_nelements(gguf_tensor); ++j) {
+                                data[j] *= ratio_m;
+                            }
+                        }
                         ggml_backend_tensor_set(grad_m, gguf_tensor->data, 0, ggml_nbytes(grad_m));
                         grad_m_loaded++;
                     }
@@ -1388,6 +1406,12 @@ bool ggml_opt_load_tensors(ggml_opt_context_t opt_ctx, const char* filename) {
                 if (grad_v->type == gguf_tensor->type &&
                     ggml_nelements(grad_v) == ggml_nelements(gguf_tensor)) {
                     if (grad_v->data) {
+                        if (rescale && gguf_tensor->type == GGML_TYPE_F32) {
+                            float * data = (float *) gguf_tensor->data;
+                            for (int64_t j = 0; j < ggml_nelements(gguf_tensor); ++j) {
+                                data[j] *= ratio_v;
+                            }
+                        }
                         ggml_backend_tensor_set(grad_v, gguf_tensor->data, 0, ggml_nbytes(grad_v));
                         grad_v_loaded++;
                     }

--- a/ggml/src/ggml-opt.cpp
+++ b/ggml/src/ggml-opt.cpp
@@ -690,15 +690,6 @@ ggml_opt_context_t ggml_opt_init(struct ggml_opt_params params) {
     result->optimizer        = params.optimizer;
 
     result->loss_scale = params.loss_scale > 0.0f ? params.loss_scale : 1.0f;
-    {
-        const char * ls = getenv("GGML_OPT_LOSS_SCALE");
-        if (ls) {
-            const float s = (float) atof(ls);
-            if (s > 0.0f) {
-                result->loss_scale = s;
-            }
-        }
-    }
 
     GGML_ASSERT(result->opt_period >= 1);
 
@@ -989,7 +980,7 @@ void ggml_opt_eval(ggml_opt_context_t opt_ctx, ggml_opt_result_t result) {
                 GGML_ASSERT(opt_pars.sgd.wd <= 1.0f);
                 float * sgd = ggml_get_data_f32(opt_ctx->opt_step_params);
                 sgd[0] = opt_pars.sgd.alpha / opt_ctx->loss_scale;
-                sgd[1] = opt_pars.sgd.wd;
+                sgd[1] = opt_pars.sgd.wd * opt_ctx->loss_scale;
             } break;
             default:
                 GGML_ABORT("fatal error");

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -6807,7 +6807,10 @@ static void ggml_acc_or_set(
     if (cgraph->grads[isrc]) {
         cgraph->grads[isrc] = ggml_acc_impl(ctx, cgraph->grads[isrc], tensor_cont, nb1, nb2, nb3, offset, cgraph->grad_accs[isrc]);
     } else {
-        struct ggml_tensor * a_zero = ggml_scale(ctx, src, 0.0f); // FIXME this is going to produce NaN if a contains inf/NaN
+        // Build the zero base with ggml_fill, which never reads src's values.
+        struct ggml_tensor * a_zero = ggml_is_contiguous(src)
+            ? ggml_fill(ctx, src, 0.0f)
+            : ggml_scale(ctx, src, 0.0f); // FIXME this is going to produce NaN if a contains inf/NaN
         cgraph->grads[isrc] = ggml_acc_impl(ctx, a_zero, tensor_cont, nb1, nb2, nb3, offset, false);
     }
     ggml_format_name(cgraph->grads[isrc], "grad for %s", cgraph->visited_hash_set.keys[isrc]->name);

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3277,6 +3277,9 @@ void llama_context::opt_init(struct llama_model * model, struct llama_opt_params
     opt_params.get_opt_pars    = lopt_params.get_opt_pars;
     opt_params.get_opt_pars_ud = lopt_params.get_opt_pars_ud;
     opt_params.optimizer       = lopt_params.optimizer_type;
+    if (llm_arch_is_hybrid(model->arch) || llm_arch_is_recurrent(model->arch)) {
+        opt_params.loss_scale = 1e-10f;
+    }
     opt_ctx = ggml_opt_init(opt_params);
 
     llama_opt_param_filter param_filter = lopt_params.param_filter;
@@ -3429,7 +3432,7 @@ void llama_context::opt_epoch_iter(
             }
             ggml_opt_prepare_alloc(opt_ctx, ctx_compute_opt, gf, res->get_inp_tokens(), res->get_logits());
             ggml_opt_alloc(opt_ctx, train);
-            
+
             // Load optimizer tensors on first training iteration if pending
             if (train && should_load_optimizer_tensors && !optimizer_tensors_loaded) {
                 if (ggml_opt_load_tensors(opt_ctx, pending_optimizer_checkpoint_path.c_str())) {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3277,7 +3277,9 @@ void llama_context::opt_init(struct llama_model * model, struct llama_opt_params
     opt_params.get_opt_pars    = lopt_params.get_opt_pars;
     opt_params.get_opt_pars_ud = lopt_params.get_opt_pars_ud;
     opt_params.optimizer       = lopt_params.optimizer_type;
-    if (llm_arch_is_hybrid(model->arch) || llm_arch_is_recurrent(model->arch)) {
+    // Seed the backward pass from a down-scaled loss for architectures (mixture-of-experts)
+    // whose gradients overflow fp32 before reaching the optimizer.
+    if (model->hparams.n_expert > 0 || llm_arch_is_hybrid(model->arch) || llm_arch_is_recurrent(model->arch)) {
         opt_params.loss_scale = 1e-10f;
     }
     opt_ctx = ggml_opt_init(opt_params);

--- a/tests/test-opt.cpp
+++ b/tests/test-opt.cpp
@@ -64,7 +64,8 @@ static helper_ctx_data helper_get_ctx_data(
         const bool              optimizer_defaults = true,
         int64_t                 nbatch_logical     = 1,
         int64_t                 nbatch_physical    = 1,
-        enum ggml_opt_loss_type loss_type          = GGML_OPT_LOSS_TYPE_SUM) {
+        enum ggml_opt_loss_type loss_type          = GGML_OPT_LOSS_TYPE_SUM,
+        float                   loss_scale         = 1.0f) {
     std::vector<ggml_opt_dataset_t> datasets(ndata);
     for (int64_t ndata_shard = 1; ndata_shard <= ndata; ++ndata_shard) {
         ggml_opt_dataset_t dataset = ggml_opt_dataset_init(
@@ -145,6 +146,7 @@ static helper_ctx_data helper_get_ctx_data(
     opt_params.outputs     = outputs;
     opt_params.opt_period  = opt_period;
     opt_params.optimizer   = optim;
+    opt_params.loss_scale  = loss_scale;
     if (!optimizer_defaults) {
         opt_params.get_opt_pars = helper_get_test_opt_pars;
     }
@@ -839,6 +841,145 @@ static std::pair<int, int> test_regression(
     return std::make_pair(npass, ntest);
 }
 
+static ggml_opt_optimizer_params helper_get_opt_pars_wd(void * userdata) {
+    ggml_opt_optimizer_params result = ggml_opt_get_default_optimizer_params(userdata);
+
+    result.adamw.alpha = 0.1f;
+    result.adamw.beta1 = 0.9f;
+    result.adamw.beta2 = 0.999f;
+    result.adamw.eps   = 1e-8f;
+    result.adamw.wd    = 0.1f;
+    result.sgd.alpha   = 0.1f;
+    result.sgd.wd      = 0.1f;
+
+    return result;
+}
+
+static std::pair<int, int> test_loss_scale(
+        enum ggml_opt_optimizer_type optim, ggml_backend_sched_t backend_sched, ggml_backend_t backend) {
+    int ntest = 0;
+    int npass = 0;
+
+    const float scales[2] = { 1.0f, 1e-3f };
+    float       results[2] = { 0.0f, 0.0f };
+
+    for (int is = 0; is < 2; ++is) {
+        struct helper_ctx_data cd = helper_get_ctx_data(
+            optim, backend_sched, backend, /*init_opt_ctx =*/ false, /*optimizer_defaults =*/ true,
+            /*nbatch_logical =*/ 1, /*nbatch_physical =*/ 1, GGML_OPT_LOSS_TYPE_SUM, scales[is]);
+
+        cd.opt_params.get_opt_pars = helper_get_opt_pars_wd;
+        cd.opt_ctx = ggml_opt_init(cd.opt_params);
+
+        for (int idata = 0; idata < ndata; ++idata) {
+            const float idataf = idata;
+            ggml_opt_alloc(cd.opt_ctx, /*backward =*/ true);
+            ggml_backend_tensor_set(cd.inputs, &idataf, 0, ggml_nbytes(cd.inputs));
+            ggml_opt_eval(cd.opt_ctx, cd.result);
+        }
+
+        ggml_backend_tensor_get(cd.weights, &results[is], 0, sizeof(float));
+
+        helper_free_ctx_data(cd);
+    }
+
+    const bool subtest_ok = almost_equal(results[0], results[1], 1e-4);
+    printf("  %s(subtest=weights_after_scaled_backward, optimizer=%s): unscaled=%f scaled=%f ",
+           __func__, ggml_opt_optimizer_name(optim), results[0], results[1]);
+    print_ok(subtest_ok);
+    if (subtest_ok) {
+        npass++;
+    }
+    ntest++;
+
+    return std::make_pair(npass, ntest);
+}
+
+static std::pair<int, int> test_loss_scale_state(
+        enum ggml_opt_optimizer_type optim, ggml_backend_sched_t backend_sched, ggml_backend_t backend) {
+    int ntest = 0;
+    int npass = 0;
+
+    const char * fname = "test-opt-loss-scale-state.gguf";
+
+    // reference: six steps entirely at scale 1e-3
+    float w_ref = 0.0f;
+    {
+        struct helper_ctx_data cd = helper_get_ctx_data(
+            optim, backend_sched, backend, /*init_opt_ctx =*/ false, /*optimizer_defaults =*/ true,
+            /*nbatch_logical =*/ 1, /*nbatch_physical =*/ 1, GGML_OPT_LOSS_TYPE_SUM, 1e-3f);
+        cd.opt_params.get_opt_pars = helper_get_opt_pars_wd;
+        cd.opt_ctx = ggml_opt_init(cd.opt_params);
+
+        for (int idata = 0; idata < ndata; ++idata) {
+            const float idataf = idata;
+            ggml_opt_alloc(cd.opt_ctx, /*backward =*/ true);
+            ggml_backend_tensor_set(cd.inputs, &idataf, 0, ggml_nbytes(cd.inputs));
+            ggml_opt_eval(cd.opt_ctx, cd.result);
+        }
+        ggml_backend_tensor_get(cd.weights, &w_ref, 0, sizeof(float));
+        helper_free_ctx_data(cd);
+    }
+
+    // first half at scale 1.0, state saved
+    float w_mid = 0.0f;
+    {
+        struct helper_ctx_data cd = helper_get_ctx_data(
+            optim, backend_sched, backend, /*init_opt_ctx =*/ false, /*optimizer_defaults =*/ true,
+            /*nbatch_logical =*/ 1, /*nbatch_physical =*/ 1, GGML_OPT_LOSS_TYPE_SUM, 1.0f);
+        cd.opt_params.get_opt_pars = helper_get_opt_pars_wd;
+        cd.opt_ctx = ggml_opt_init(cd.opt_params);
+
+        for (int idata = 0; idata < ndata/2; ++idata) {
+            const float idataf = idata;
+            ggml_opt_alloc(cd.opt_ctx, /*backward =*/ true);
+            ggml_backend_tensor_set(cd.inputs, &idataf, 0, ggml_nbytes(cd.inputs));
+            ggml_opt_eval(cd.opt_ctx, cd.result);
+        }
+        ggml_backend_tensor_get(cd.weights, &w_mid, 0, sizeof(float));
+        ggml_opt_save_state(cd.opt_ctx, fname);
+        helper_free_ctx_data(cd);
+    }
+
+    // second half at scale 1e-3, resumed from that state
+    float w_resumed = 0.0f;
+    {
+        struct helper_ctx_data cd = helper_get_ctx_data(
+            optim, backend_sched, backend, /*init_opt_ctx =*/ false, /*optimizer_defaults =*/ true,
+            /*nbatch_logical =*/ 1, /*nbatch_physical =*/ 1, GGML_OPT_LOSS_TYPE_SUM, 1e-3f);
+        cd.opt_params.get_opt_pars = helper_get_opt_pars_wd;
+        cd.opt_ctx = ggml_opt_init(cd.opt_params);
+
+        ggml_backend_tensor_set(cd.weights, &w_mid, 0, sizeof(float));
+        ggml_opt_load_state(cd.opt_ctx, fname);
+        ggml_opt_load_tensors(cd.opt_ctx, fname);
+
+        for (int idata = ndata/2; idata < ndata; ++idata) {
+            const float idataf = idata;
+            ggml_opt_alloc(cd.opt_ctx, /*backward =*/ true);
+            ggml_backend_tensor_set(cd.inputs, &idataf, 0, ggml_nbytes(cd.inputs));
+            ggml_opt_eval(cd.opt_ctx, cd.result);
+        }
+        ggml_backend_tensor_get(cd.weights, &w_resumed, 0, sizeof(float));
+        helper_free_ctx_data(cd);
+    }
+
+    remove(fname);
+
+    // the first half ran unscaled, so only the momenta carried across the scale change are
+    // being checked here; they must reproduce the reference trajectory
+    const bool subtest_ok = almost_equal(w_ref, w_resumed, 1e-3);
+    printf("  %s(subtest=weights_after_rescaled_resume, optimizer=%s): reference=%f resumed=%f ",
+           __func__, ggml_opt_optimizer_name(optim), w_ref, w_resumed);
+    print_ok(subtest_ok);
+    if (subtest_ok) {
+        npass++;
+    }
+    ntest++;
+
+    return std::make_pair(npass, ntest);
+}
+
 static std::pair<int, int> test_backend(
     ggml_backend_sched_t backend_sched, ggml_backend_t backend, enum ggml_opt_optimizer_type optim) {
     int npass = 0;
@@ -851,6 +992,16 @@ static std::pair<int, int> test_backend(
     }
     {
         std::pair<int, int> partial = test_grad(optim, backend_sched, backend);
+        npass += partial.first;
+        ntest += partial.second;
+    }
+    {
+        std::pair<int, int> partial = test_loss_scale(optim, backend_sched, backend);
+        npass += partial.first;
+        ntest += partial.second;
+    }
+    {
+        std::pair<int, int> partial = test_loss_scale_state(optim, backend_sched, backend);
         npass += partial.first;
         ntest += partial.second;
     }


### PR DESCRIPTION
Disable weight repacking for training loads, backward ops can't read repacked layouts.

Reference: https://app.asana.com/1/45238840754660/project/1213827293956136/task/1216772832472526