### PR TITLE
QVAC-22747 infra: add weekly schedule to the CodeScan caller

### DIFF
--- a/.github/workflows/security-baseline.yml
+++ b/.github/workflows/security-baseline.yml
@@ -16,6 +16,9 @@ on:
     branches:
       - master
   pull_request:
+  schedule:
+    # Weekly full scan (QVAC-19056 rollout). Staggered per repo across weekdays.
+    - cron: "0 7 * * 2"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The canonical CodeScan baseline (`security-baseline.yml`) runs on `push` / `pull_request` / `workflow_dispatch` only, so the **QVAC-19056** commitment to a *weekly* scan is currently unmet on this repo.

## 📝 How does it solve it?

- Adds a `schedule:` cron alongside the existing triggers. Crons are staggered across weekdays per repo to spread scheduled-run load across the fleet.
- No other change — same reusable-workflow pin, inputs, and permissions.

## 🧪 How was it tested?

- `actionlint` clean.
- After merge: confirm the workflow shows under the repo's scheduled workflows and the first weekly run is green (`workflow_dispatch` can smoke-test it immediately).
