### PR TITLE
Hardened grad-accumulation paths to MoE/hybrid/recurrent models

### DIFF
--- a/ggml/include/ggml-opt.h
+++ b/ggml/include/ggml-opt.h
@@ -151,6 +151,8 @@ extern "C" {
         // loss*loss_scale so gradient magnitudes stay within fp32 range through deep
         // backprop.
         float loss_scale;
+
+        bool wide_grad_acc;
     };
 
     // get parameters for an optimization context with defaults set where possible

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -1244,7 +1244,7 @@ extern "C" {
            struct ggml_context * ctx,
            struct ggml_tensor  * grad,
            struct ggml_tensor  * g);
-    
+
     // a - dy
     // b - x
     GGML_API struct ggml_tensor * ggml_sigmoid_back(
@@ -2834,7 +2834,7 @@ extern "C" {
     GGML_API struct ggml_tensor * ggml_cross_entropy_loss_masked(
             struct ggml_context * ctx,
             struct ggml_tensor  * a,  // logits
-            struct ggml_tensor  * b,  // labels  
+            struct ggml_tensor  * b,  // labels
             struct ggml_tensor  * c); // mask (1 for assistant tokens, 0 for masked)
     GGML_API struct ggml_tensor * ggml_cross_entropy_loss_masked_back(
             struct ggml_context * ctx,
@@ -2901,6 +2901,12 @@ extern "C" {
         struct ggml_context *  ctx,        // context for gradient computation
         struct ggml_cgraph  *  cgraph,
         struct ggml_tensor  ** grad_accs);
+
+    GGML_API void ggml_build_backward_expand_ext(
+        struct ggml_context *  ctx,        // context for gradient computation
+        struct ggml_cgraph  *  cgraph,
+        struct ggml_tensor  ** grad_accs,
+        bool                   wide_grad_acc);
 
     // graph allocation in a context
     GGML_API struct ggml_cgraph * ggml_new_graph       (struct ggml_context * ctx); // size = GGML_DEFAULT_GRAPH_SIZE, grads = false

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -786,7 +786,9 @@ int ggml_metal_op_acc(ggml_metal_op_t ctx, int idx) {
         ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         2);
 
         const int nth = std::min(ggml_metal_pipeline_max_theads_per_threadgroup(pipeline), ne00);
-        const int nw0 = (ne00 + nth - 1)/nth;
+
+        const bool wide = ((const int32_t *) op->op_params)[5] != 0;
+        const int  nw0  = wide ? (ne00 + nth - 1)/nth : 1;
 
         ggml_metal_encoder_dispatch_threadgroups(enc, nw0*ne01, ne02, ne03, nth, 1, 1);
 

--- a/ggml/src/ggml-opt.cpp
+++ b/ggml/src/ggml-opt.cpp
@@ -71,6 +71,9 @@ struct ggml_opt_context {
     // magnitudes stay within fp32 range through deep backprop.
     float   loss_scale         = 1.0f;
 
+    // Use the hardened gradient-accumulation paths when building the backward graph.
+    bool    wide_grad_acc      = true;
+
     ggml_opt_get_optimizer_params get_opt_pars    = nullptr;
     void *                        get_opt_pars_ud = nullptr;
     struct ggml_tensor *          opt_step_params = nullptr; // Stores output of get_opt_pars.
@@ -352,6 +355,7 @@ struct ggml_opt_params ggml_opt_default_params(
         /*get_opt_pars_ud =*/ nullptr,
         /*optimizer       =*/ GGML_OPT_OPTIMIZER_TYPE_ADAMW,
         /*loss_scale      =*/ 1.0f,
+        /*wide_grad_acc   =*/ true,
     };
 }
 
@@ -616,7 +620,7 @@ static void ggml_opt_build(ggml_opt_context_t opt_ctx) {
 
     // gb_grad == graph backward gradients, forward pass, then backward pass to calculate gradients.
     opt_ctx->gb_grad = ggml_graph_dup(opt_ctx->ctx_compute, opt_ctx->gf, /*force_grads =*/ true);
-    ggml_build_backward_expand(opt_ctx->ctx_compute, opt_ctx->gb_grad, opt_ctx->grad_accs.data());
+    ggml_build_backward_expand_ext(opt_ctx->ctx_compute, opt_ctx->gb_grad, opt_ctx->grad_accs.data(), opt_ctx->wide_grad_acc);
 
     if (opt_ctx->buf_static) {
         if (opt_ctx->build_type == GGML_OPT_BUILD_TYPE_GRAD) {
@@ -689,7 +693,8 @@ ggml_opt_context_t ggml_opt_init(struct ggml_opt_params params) {
     result->get_opt_pars_ud  = params.get_opt_pars_ud;
     result->optimizer        = params.optimizer;
 
-    result->loss_scale = params.loss_scale > 0.0f ? params.loss_scale : 1.0f;
+    result->loss_scale    = params.loss_scale > 0.0f ? params.loss_scale : 1.0f;
+    result->wide_grad_acc = params.wide_grad_acc;
 
     GGML_ASSERT(result->opt_period >= 1);
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -2246,7 +2246,7 @@ static struct ggml_tensor * ggml_acc_impl(
 
     struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
-    int32_t params[] = { nb1, nb2, nb3, offset, inplace ? 1 : 0 };
+    int32_t params[] = { nb1, nb2, nb3, offset, inplace ? 1 : 0, 1 };
     ggml_set_op_params(result, params, sizeof(params));
 
     result->op     = GGML_OP_ACC;
@@ -6971,7 +6971,8 @@ static void ggml_acc_or_set(
         const  size_t         nb1,
         const  size_t         nb2,
         const  size_t         nb3,
-        const  size_t         offset) {
+        const  size_t         offset,
+        const  bool           wide_grad_acc) {
     struct ggml_tensor * src = cgraph->visited_hash_set.keys[isrc];
     GGML_ASSERT(src);
     struct ggml_tensor * tensor_cont = ggml_is_contiguous(tensor) ? tensor : ggml_cont(ctx, tensor);
@@ -6979,10 +6980,13 @@ static void ggml_acc_or_set(
         cgraph->grads[isrc] = ggml_acc_impl(ctx, cgraph->grads[isrc], tensor_cont, nb1, nb2, nb3, offset, cgraph->grad_accs[isrc]);
     } else {
         // Build the zero base with ggml_fill, which never reads src's values.
-        struct ggml_tensor * a_zero = ggml_is_contiguous(src)
+        struct ggml_tensor * a_zero = (wide_grad_acc && ggml_is_contiguous(src))
             ? ggml_fill(ctx, src, 0.0f)
             : ggml_scale(ctx, src, 0.0f); // FIXME this is going to produce NaN if a contains inf/NaN
         cgraph->grads[isrc] = ggml_acc_impl(ctx, a_zero, tensor_cont, nb1, nb2, nb3, offset, false);
+    }
+    if (!wide_grad_acc) {
+        ggml_set_op_params_i32(cgraph->grads[isrc], 5, 0);
     }
     ggml_format_name(cgraph->grads[isrc], "grad for %s", cgraph->visited_hash_set.keys[isrc]->name);
     ggml_build_forward_expand(cgraph, cgraph->grads[isrc]);
@@ -7021,7 +7025,7 @@ static void ggml_sub_or_set(
 }
 
 static void ggml_compute_backward(
-        struct ggml_context * ctx, struct ggml_cgraph * cgraph, int i, const bool * grads_needed) {
+        struct ggml_context * ctx, struct ggml_cgraph * cgraph, int i, const bool * grads_needed, const bool wide_grad_acc) {
     struct ggml_tensor * tensor = cgraph->nodes[i];
     struct ggml_tensor * grad   = ggml_graph_get_grad(cgraph, tensor);
 
@@ -7319,7 +7323,7 @@ static void ggml_compute_backward(
                     nb3 = (nb3 / n0) * ng;
                 }
 
-                ggml_acc_or_set(ctx, cgraph, isrc0, grad, nb1, nb2, nb3, offset);
+                ggml_acc_or_set(ctx, cgraph, isrc0, grad, nb1, nb2, nb3, offset, wide_grad_acc);
             }
         } break;
         case GGML_OP_PERMUTE: {
@@ -7720,6 +7724,14 @@ void ggml_build_backward_expand(
         struct ggml_context *  ctx,
         struct ggml_cgraph  *  cgraph,
         struct ggml_tensor  ** grad_accs) {
+    ggml_build_backward_expand_ext(ctx, cgraph, grad_accs, /*wide_grad_acc =*/ true);
+}
+
+void ggml_build_backward_expand_ext(
+        struct ggml_context *  ctx,
+        struct ggml_cgraph  *  cgraph,
+        struct ggml_tensor  ** grad_accs,
+        bool                   wide_grad_acc) {
     GGML_ASSERT(cgraph->n_nodes > 0);
     GGML_ASSERT(cgraph->grads);
     GGML_ASSERT(cgraph->grad_accs);
@@ -7818,7 +7830,7 @@ void ggml_build_backward_expand(
     for (int i = n_nodes_f - 1; i >= 0; --i) {
         // inplace operations to add gradients are not created by ggml_compute_backward except for gradient accumulation
         // use allocator to automatically make inplace operations
-        ggml_compute_backward(ctx, cgraph, i, grads_needed);
+        ggml_compute_backward(ctx, cgraph, i, grads_needed, wide_grad_acc);
     }
 
     free(grads_needed);

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3290,11 +3290,12 @@ void llama_context::opt_init(struct llama_model * model, struct llama_opt_params
     opt_params.get_opt_pars    = lopt_params.get_opt_pars;
     opt_params.get_opt_pars_ud = lopt_params.get_opt_pars_ud;
     opt_params.optimizer       = lopt_params.optimizer_type;
-    // Seed the backward pass from a down-scaled loss for architectures (mixture-of-experts)
-    // whose gradients overflow fp32 before reaching the optimizer.
-    if (model->hparams.n_expert > 0 || llm_arch_is_hybrid(model->arch) || llm_arch_is_recurrent(model->arch)) {
+
+    const bool hardened_grads = model->hparams.n_expert > 0 || llm_arch_is_hybrid(model->arch) || llm_arch_is_recurrent(model->arch);
+    if (hardened_grads) {
         opt_params.loss_scale = 1e-10f;
     }
+    opt_params.wide_grad_acc = hardened_grads;
     opt_ctx = ggml_opt_init(opt_params);
 
     llama_opt_param_filter param_filter = lopt_params.param_filter;


### PR DESCRIPTION
Guard the MOE training.

As reported here https://app.asana.com/1/45238840754660/project/1213827293956136/task/1216915277641963?focus=true with the latest changes in https://github.com/tetherto/qvac-fabric-llm.cpp/pull/187 the moe models pass the finetuning tests, however on iPhone 16, it causes instabilities. This PR, puts the changes behind a guard, and only applies the changes for moe/hybrid models.