### PR TITLE
vulkan: fix strided concat addressing

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -14668,11 +14668,17 @@ static void ggml_vk_concat(ggml_backend_vk_context * ctx, vk_context& subctx, co
     const uint32_t src1_ne0 = quantized ? ggml_row_size(src1->type, src1->ne[0]) : src1->ne[0];
     const uint32_t dst_ne0  = quantized ? ggml_row_size(dst->type,  dst->ne[0])  : dst->ne[0];
 
+    // Quantized rows are copied as byte arrays, so dimension 0 is byte-contiguous.
+    // Non-quantized pipelines are typed and must preserve dimension-0 view strides.
+    const uint32_t src0_nb0 = quantized ? 1 : (uint32_t) src0->nb[0] / src0_type_size;
+    const uint32_t src1_nb0 = quantized ? 1 : (uint32_t) src1->nb[0] / src1_type_size;
+    const uint32_t dst_nb0  = quantized ? 1 : (uint32_t)  dst->nb[0] /  dst_type_size;
+
     ggml_vk_op_f32<vk_op_binary_push_constants>(ctx, subctx, src0, src1, nullptr, nullptr, dst, GGML_OP_CONCAT, {
         quantized ? (uint32_t)ggml_nbytes(dst) : (uint32_t)ggml_nelements(dst),
-        src0_ne0, (uint32_t)src0->ne[1], (uint32_t)src0->ne[2], (uint32_t)src0->ne[3], 1, (uint32_t)src0->nb[1] / src0_type_size, (uint32_t)src0->nb[2] / src0_type_size, (uint32_t)src0->nb[3] / src0_type_size,
-        src1_ne0, (uint32_t)src1->ne[1], (uint32_t)src1->ne[2], (uint32_t)src1->ne[3], 1, (uint32_t)src1->nb[1] / src1_type_size, (uint32_t)src1->nb[2] / src1_type_size, (uint32_t)src1->nb[3] / src1_type_size,
-        dst_ne0,  (uint32_t) dst->ne[1], (uint32_t) dst->ne[2],  (uint32_t) dst->ne[3],  1, (uint32_t) dst->nb[1] /  dst_type_size, (uint32_t) dst->nb[2] /  dst_type_size, (uint32_t) dst->nb[3] /  dst_type_size,
+        src0_ne0, (uint32_t)src0->ne[1], (uint32_t)src0->ne[2], (uint32_t)src0->ne[3], src0_nb0, (uint32_t)src0->nb[1] / src0_type_size, (uint32_t)src0->nb[2] / src0_type_size, (uint32_t)src0->nb[3] / src0_type_size,
+        src1_ne0, (uint32_t)src1->ne[1], (uint32_t)src1->ne[2], (uint32_t)src1->ne[3], src1_nb0, (uint32_t)src1->nb[1] / src1_type_size, (uint32_t)src1->nb[2] / src1_type_size, (uint32_t)src1->nb[3] / src1_type_size,
+        dst_ne0,  (uint32_t) dst->ne[1], (uint32_t) dst->ne[2],  (uint32_t) dst->ne[3],  dst_nb0, (uint32_t) dst->nb[1] /  dst_type_size, (uint32_t) dst->nb[2] /  dst_type_size, (uint32_t) dst->nb[3] /  dst_type_size,
         0,
         0.0f, 0.0f, op_params[0],
     });

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -6201,7 +6201,7 @@ struct test_concat : public test_case {
     const std::array<int64_t, 4> ne_a;
     const int64_t ne_b_d;
     const int dim;
-    const int v; // view (1 << 0: non-cont a, 1 << 1: non-cont b)
+    const int v; // view (1 << 0: non-cont a, 1 << 1: non-cont b, 1 << 2: strided dim 0 a, 1 << 3: strided dim 0 b)
 
     std::string vars() override {
         return VARS_TO_STR5(type, ne_a, ne_b_d, dim, v);
@@ -6217,7 +6217,15 @@ struct test_concat : public test_case {
         auto ne_b = ne_a;
         ne_b[dim] = ne_b_d;
         ggml_tensor * a;
-        if (v & 1) {
+        if (v & 4) {
+            auto ne = ne_a;
+            std::swap(ne[0], ne[1]);
+            a = ggml_new_tensor(ctx, type, 4, ne.data());
+            ggml_set_name(a, "a");
+
+            a = ggml_permute(ctx, a, 1, 0, 2, 3);
+            ggml_set_name(a, "permuted_a");
+        } else if (v & 1) {
             auto ne = ne_a; ne[0] *= 2; ne[1] *= 4; ne[2] *= 3;
             a = ggml_new_tensor(ctx, type, 4, ne.data());
             ggml_set_name(a, "a");
@@ -6229,7 +6237,15 @@ struct test_concat : public test_case {
             ggml_set_name(a, "a");
         }
         ggml_tensor * b;
-        if (v & 2) {
+        if (v & 8) {
+            auto ne = ne_b;
+            std::swap(ne[0], ne[1]);
+            b = ggml_new_tensor(ctx, type, 4, ne.data());
+            ggml_set_name(b, "b");
+
+            b = ggml_permute(ctx, b, 1, 0, 2, 3);
+            ggml_set_name(b, "permuted_b");
+        } else if (v & 2) {
             auto ne = ne_b; ne[0] *= 3; ne[1] *= 2; ne[2] *= 4;
             b = ggml_new_tensor(ctx, type, 4, ne.data());
             ggml_set_name(b, "b");
@@ -9986,6 +10002,12 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             test_cases.emplace_back(new test_concat(GGML_TYPE_I16, {11, 12, 13, 14}, 7, dim, v));
             test_cases.emplace_back(new test_concat(GGML_TYPE_I32, {11, 12, 13, 14}, 7, dim, v));
             test_cases.emplace_back(new test_concat(GGML_TYPE_I64, {11, 12, 13, 14}, 7, dim, v));
+        }
+    }
+
+    for (int v : { 4, 8, 12 }) {
+        for (int dim : { 0, 1, 2, 3 }) {
+            test_cases.emplace_back(new test_concat(GGML_TYPE_F16, {11, 12, 13, 14}, 7, dim, v));
         }
     }
 


### PR DESCRIPTION
## Summary
- Preserve dimension-0 tensor strides for typed Vulkan `CONCAT` operations.
- Keep byte-oriented addressing for quantized `CONCAT` operations.
- Add regression coverage for F16 `CONCAT` with strided dimension-0 inputs.

## Test plan
- [x] Vulkan `CONCAT`: 144/144 tests passed.
- [x] New strided F16 cases: 12/12 passed; all 12 fail with the old hardcoded stride.
- [x] Q4_0 and Q8_0 `CONCAT`: 8/8 tests passed.
- [x] Qwen3.5-VL elephant inference on Strix completed twice with coherent output and no context overflow.