### PR TITLE
QVAC-22740 infra: bump CodeScan caller to qvac-actions 0.3.0

### DIFF
--- a/.github/workflows/security-baseline.yml
+++ b/.github/workflows/security-baseline.yml
@@ -32,7 +32,7 @@ jobs:
   baseline:
     # Pinned to the qvac-actions 0.2.0 release commit (immutable SHA + version
     # comment, per the org freeze-and-pin convention).
-    uses: tetherto/qvac-actions/.github/workflows/public-reusable-security.yml@be1d22629cc48b6dcc36645acc9e6d89cfaf54d8 # 0.2.0
+    uses: tetherto/qvac-actions/.github/workflows/public-reusable-security.yml@bbb0740e2a16b94371c7439e0e06945c5b68e759 # 0.3.0
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The CodeScan caller is pinned to qvac-actions `0.2.0`, which predates the findings-export feature. Bumping to `0.3.0` gives this repo the downloadable `security-scan-report` artifact (findings.json + findings.md + per-language SARIF) on every run — the coverage/triage route while `codeql-upload: never`.

## 📝 How does it solve it?

- Bumps the reusable-workflow pin `0.2.0` → `0.3.0`. `export-report` defaults on, so no other change is needed.

## 🔐 Action pinning

- `tetherto/qvac-actions/.github/workflows/public-reusable-security.yml`: `be1d22629cc48b6dcc36645acc9e6d89cfaf54d8 # 0.2.0` → `bbb0740e2a16b94371c7439e0e06945c5b68e759 # 0.3.0`.

## 🧪 How was it tested?

- Pinned to the immutable `0.3.0` tag commit. `workflow_dispatch` after merge confirms the `security-scan-report` artifact appears under the run's Artifacts.
