### PR TITLE
RPC: Tensor Parallel 

### DIFF
--- a/ggml/include/ggml-rpc.h
+++ b/ggml/include/ggml-rpc.h
@@ -7,7 +7,7 @@ extern "C" {
 #endif
 
 #define RPC_PROTO_MAJOR_VERSION    6
-#define RPC_PROTO_MINOR_VERSION    1
+#define RPC_PROTO_MINOR_VERSION    0
 #define RPC_PROTO_PATCH_VERSION    0
 
 #ifdef  __cplusplus

--- a/ggml/include/ggml-rpc.h
+++ b/ggml/include/ggml-rpc.h
@@ -6,8 +6,8 @@
 extern "C" {
 #endif
 
-#define RPC_PROTO_MAJOR_VERSION    5
-#define RPC_PROTO_MINOR_VERSION    0
+#define RPC_PROTO_MAJOR_VERSION    6
+#define RPC_PROTO_MINOR_VERSION    1
 #define RPC_PROTO_PATCH_VERSION    0
 
 #ifdef  __cplusplus

--- a/ggml/src/ggml-backend-impl.h
+++ b/ggml/src/ggml-backend-impl.h
@@ -82,6 +82,7 @@ extern "C" {
     // buffer that contains a collection of buffers
     GGML_API ggml_backend_buffer_t ggml_backend_multi_buffer_alloc_buffer(ggml_backend_buffer_t * buffers, size_t n_buffers);
     GGML_API bool                  ggml_backend_buffer_is_multi_buffer(ggml_backend_buffer_t buffer);
+    GGML_API ggml_backend_buffer_t ggml_backend_multi_buffer_get_buffer(ggml_backend_buffer_t buffer, const void * addr);
     GGML_API void                  ggml_backend_multi_buffer_set_usage(ggml_backend_buffer_t buffer, enum ggml_backend_buffer_usage usage);
 
     //

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -2185,6 +2185,14 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
                 cgraph_ij->uid = ggml_graph_next_uid();
             }
         }
+
+        // Aux graph contents are rewritten on every compute but are identical across calls while the subgraphs are reused,
+        // so they can get stable uids on rebuild. Only safe without a comm backend, where the fallback usage is deterministic.
+        if (backend_ctx->comm_ctx == nullptr) {
+            for (ggml_cgraph * cgraph_aux : backend_ctx->cgraphs_aux) {
+                cgraph_aux->uid = ggml_graph_next_uid();
+            }
+        }
     }
 
     size_t iga = 0; // i graph aux

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -771,6 +771,7 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
         const bool kv_mirrored = src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED &&
                 src_ss[2].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED;
         GGML_ASSERT(kv_split || kv_mirrored);
+        GGML_ASSERT(!kv_mirrored || (tensor->src[1]->ne[2] == 1 && tensor->src[2]->ne[2] == 1));
         GGML_ASSERT(tensor->src[4] == nullptr || src_ss[4].axis == GGML_BACKEND_SPLIT_AXIS_0);
         return {GGML_BACKEND_SPLIT_AXIS_1, {0}, {1}, 1};
     };

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -1189,11 +1189,6 @@ static enum ggml_status ggml_backend_meta_buffer_init_tensor_impl(ggml_backend_m
         ggml_context          * simple_ctx = stc.ctxs[j].get();
         ggml_backend_buffer_t   simple_buf = buf_ctx->bufs[j].get();
 
-        if ((simple_buf != nullptr) && ggml_backend_buffer_is_multi_buffer(simple_buf)) {
-            // see https://github.com/ggml-org/llama.cpp/issues/22197
-            GGML_ABORT("multi buffers are not supported by the meta backend");
-        }
-
         if (split_dim >= 0 && split_dim < GGML_MAX_DIMS) {
             // TODO: the following assert fails for llama-parallel even though the results are correct:
             // GGML_ASSERT(ggml_is_contiguously_allocated(tensor));
@@ -1243,9 +1238,19 @@ static enum ggml_status ggml_backend_meta_buffer_init_tensor_impl(ggml_backend_m
         }
         if (t_ij->view_src != nullptr) {
             t_ij->data = (char *) t_ij->view_src->data + t_ij->view_offs;
-        } else if (simple_buf != nullptr) {
+            if (t_ij->view_src->buffer != nullptr) {
+                t_ij->buffer = t_ij->view_src->buffer;
+            }
+        } else if (simple_buf != nullptr && !ggml_backend_buffer_is_multi_buffer(simple_buf)) {
             t_ij->data = (char *) ggml_backend_buffer_get_base(simple_buf)
                 + size_t(tensor->data) - size_t(ggml_backend_buffer_get_base(tensor->buffer));
+        }
+        if (t_ij->buffer != nullptr && t_ij->data != nullptr
+                && ggml_backend_buffer_is_multi_buffer(t_ij->buffer)) {
+            ggml_backend_buffer_t sub = ggml_backend_multi_buffer_get_buffer(t_ij->buffer, t_ij->data);
+            if (sub != nullptr) {
+                t_ij->buffer = sub;
+            }
         }
         t_ij->extra = tensor->extra;
         for (int i = 0; i < GGML_MAX_SRC; i++) {

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -590,7 +590,18 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
             GGML_ASSERT(split_states_equal(src_ss[0], src_ss[1]));
             return {assume_sync ? GGML_BACKEND_SPLIT_AXIS_MIRRORED : GGML_BACKEND_SPLIT_AXIS_PARTIAL, {0}, {1}, 1};
         }
-        GGML_ABORT("fatal error");
+        if (src_ss[0].axis == src_ss[1].axis && src_ss[0].axis >= GGML_BACKEND_SPLIT_AXIS_2 &&
+                src_ss[0].axis < GGML_MAX_DIMS) {
+            GGML_ASSERT(split_states_equal(src_ss[0], src_ss[1]));
+            return src_ss[0];
+        }
+        // batched matmul with the batches split across devices and a replicated activation
+        if (src_ss[0].axis >= GGML_BACKEND_SPLIT_AXIS_2 && src_ss[0].axis < GGML_MAX_DIMS &&
+                src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
+            return src_ss[0];
+        }
+        GGML_ABORT("unsupported mul_mat split states: node=%s src0=%s axis=%d src1=%s axis=%d",
+            tensor->name, tensor->src[0]->name, (int) src_ss[0].axis, tensor->src[1]->name, (int) src_ss[1].axis);
         //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
     };
 
@@ -745,12 +756,31 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
     };
 
     auto handle_flash_attn_ext = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
-        GGML_ASSERT(                             src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_2);
-        GGML_ASSERT(                             src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_2);
-        GGML_ASSERT(                             src_ss[2].axis == GGML_BACKEND_SPLIT_AXIS_2);
-        GGML_ASSERT(tensor->src[4] == nullptr || src_ss[3].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+        GGML_ASSERT(tensor->src[3] == nullptr || src_ss[3].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+
+        if (src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
+            GGML_ASSERT(src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+            GGML_ASSERT(src_ss[2].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+            GGML_ASSERT(tensor->src[4] == nullptr || src_ss[4].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+            return {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}, {1}, 1};
+        }
+
+        GGML_ASSERT(src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_2);
+        const bool kv_split = src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_2 &&
+                src_ss[2].axis == GGML_BACKEND_SPLIT_AXIS_2;
+        const bool kv_mirrored = src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED &&
+                src_ss[2].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED;
+        GGML_ASSERT(kv_split || kv_mirrored);
         GGML_ASSERT(tensor->src[4] == nullptr || src_ss[4].axis == GGML_BACKEND_SPLIT_AXIS_0);
         return {GGML_BACKEND_SPLIT_AXIS_1, {0}, {1}, 1};
+    };
+
+    auto handle_lightning_indexer = [&](
+            const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
+        for (size_t i = 0; i < 4; i++) {
+            GGML_ASSERT(src_ss[i].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+        }
+        return {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}, {1}, 1};
     };
 
     auto handle_ssm_conv = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
@@ -817,7 +847,12 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
         ggml_backend_meta_split_state split_state;
         switch (tensor->op) {
             case GGML_OP_NONE: {
-                split_state = {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}, {1}, 1};
+                if (tensor->view_src != nullptr) {
+                    // full-tensor view created with ggml_view_tensor, transparent for the split state
+                    split_state = ggml_backend_meta_get_split_state(stc, tensor->view_src, assume_sync);
+                } else {
+                    split_state = {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}, {1}, 1};
+                }
             } break;
             case GGML_OP_DUP: {
                 split_state = handle_generic(src_ss, /*scalar_only =*/ true);
@@ -921,7 +956,7 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
                 split_state = handle_rope(src_ss);
             } break;
             case GGML_OP_ROPE_BACK: {
-                split_state = handle_generic(src_ss, /*scalar_only =*/ true);
+                split_state = handle_rope(src_ss);
             } break;
             case GGML_OP_CLAMP: {
                 split_state = handle_generic(src_ss, /*scalar_only =*/ false);
@@ -985,7 +1020,9 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
             case GGML_OP_GATED_DELTA_NET: {
                 split_state = handle_gated_delta_net(src_ss);
             } break;
-            case GGML_OP_LIGHTNING_INDEXER:
+            case GGML_OP_LIGHTNING_INDEXER: {
+                split_state = handle_lightning_indexer(src_ss);
+            } break;
             case GGML_OP_DSV4_HC_COMB:
             case GGML_OP_DSV4_HC_PRE:
             case GGML_OP_DSV4_HC_POST: {
@@ -1070,13 +1107,14 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
         if (buf_ctx->debug > 0) {
             std::string srcs_info;
             for (size_t i = 0; i < GGML_MAX_SRC; i++) {
-                if (tensor->src[i] == nullptr) {
+                if (tensor->src[i] == nullptr || tensor->src[i] == tensor) {
                     continue;
                 }
                 if (!srcs_info.empty()) {
                     srcs_info += ", ";
                 }
-                const ggml_backend_meta_split_state split_state = ggml_backend_meta_get_split_state(tensor->src[0], true);
+                const ggml_backend_meta_split_state split_state =
+                        ggml_backend_meta_get_split_state(tensor->src[i], true);
                 GGML_ASSERT(split_state.n_segments == 1);
                 const char * axis_name = ggml_backend_meta_split_axis_name(split_state.axis);
                 std::string ne_info;
@@ -1253,6 +1291,108 @@ static enum ggml_status ggml_backend_meta_buffer_init_tensor(ggml_backend_buffer
     ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) buffer->context;
     buf_ctx->stc_compute_index = buf_ctx->stc_compute_index_next;
     return ggml_backend_meta_buffer_init_tensor_impl(buf_ctx->get_simple_tensor_container(tensor), tensor);
+}
+
+static void ggml_backend_meta_buffer_memset_tensor(
+        ggml_backend_buffer_t buffer, ggml_tensor * tensor, uint8_t value, size_t offset, size_t size) {
+    const size_t n_bufs = ggml_backend_meta_buffer_n_bufs(buffer);
+    const ggml_backend_meta_split_state split_state =
+            ggml_backend_meta_get_split_state(tensor, /*assume_sync =*/ false);
+    GGML_ASSERT(ggml_is_contiguous(tensor) || split_state.axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+
+    if (split_state.n_segments != 1 || split_state.nr[0] != 1) {
+        GGML_ASSERT(split_state.axis >= 0 && split_state.axis < GGML_MAX_DIMS);
+        GGML_ASSERT(split_state.nr[0] != 0);
+        GGML_ASSERT(tensor->ne[3] == 1);
+
+        std::vector<size_t> simple_offsets(n_bufs, 0);
+        if (split_state.axis == GGML_BACKEND_SPLIT_AXIS_0) {
+            GGML_ASSERT(tensor->ne[2] == 1);
+
+            const size_t row_stride = tensor->nb[1];
+            GGML_ASSERT(offset % row_stride == 0);
+            GGML_ASSERT(size   % row_stride == 0);
+            const int64_t row_start = offset / row_stride;
+            const int64_t row_count = size   / row_stride;
+            GGML_ASSERT(row_start + row_count <= tensor->ne[1]);
+
+            const int64_t blck_size = ggml_blck_size(tensor->type);
+            for (size_t s = 0; s < split_state.n_segments; s++) {
+                for (size_t r = 0; r < split_state.nr[s]; r++) {
+                    for (size_t j = 0; j < n_bufs; j++) {
+                        ggml_tensor * simple_tensor = ggml_backend_meta_buffer_simple_tensor(tensor, j);
+                        GGML_ASSERT(split_state.ne[s*n_bufs + j] % blck_size == 0);
+                        const size_t nbytes = split_state.ne[s*n_bufs + j]/blck_size * tensor->nb[0];
+                        for (int64_t row = 0; row < row_count; row++) {
+                            ggml_backend_tensor_memset(simple_tensor, value,
+                                    simple_offsets[j] + (row_start + row)*simple_tensor->nb[1], nbytes);
+                        }
+                        simple_offsets[j] += nbytes;
+                    }
+                }
+            }
+            return;
+        }
+
+        GGML_ASSERT(split_state.axis == GGML_BACKEND_SPLIT_AXIS_1);
+
+        const size_t row_stride = tensor->nb[2];
+        GGML_ASSERT(offset % row_stride == 0);
+        GGML_ASSERT(size   % row_stride == 0);
+        const int64_t row_start = offset / row_stride;
+        const int64_t row_count = size   / row_stride;
+        GGML_ASSERT(row_start + row_count <= tensor->ne[2]);
+
+        for (size_t s = 0; s < split_state.n_segments; s++) {
+            for (size_t r = 0; r < split_state.nr[s]; r++) {
+                for (size_t j = 0; j < n_bufs; j++) {
+                    ggml_tensor * simple_tensor = ggml_backend_meta_buffer_simple_tensor(tensor, j);
+                    const size_t nbytes = split_state.ne[s*n_bufs + j] * tensor->nb[1];
+                    for (int64_t row = 0; row < row_count; row++) {
+                        ggml_backend_tensor_memset(simple_tensor, value,
+                                simple_offsets[j] + (row_start + row)*simple_tensor->nb[2], nbytes);
+                    }
+                    simple_offsets[j] += nbytes;
+                }
+            }
+        }
+        return;
+    }
+
+    switch (split_state.axis) {
+        case GGML_BACKEND_SPLIT_AXIS_0:
+        case GGML_BACKEND_SPLIT_AXIS_1:
+        case GGML_BACKEND_SPLIT_AXIS_2: {
+            const size_t chunk_size_full = tensor->nb[split_state.axis + 1];
+            GGML_ASSERT(offset % chunk_size_full == 0);
+            GGML_ASSERT(size   % chunk_size_full == 0);
+            const int64_t i_start =  offset        / chunk_size_full;
+            const int64_t i_stop  = (offset + size) / chunk_size_full;
+            for (size_t j = 0; j < n_bufs; j++) {
+                ggml_tensor * simple_tensor = ggml_backend_meta_buffer_simple_tensor(tensor, j);
+                const size_t chunk_size = simple_tensor->nb[split_state.axis + 1];
+                if (chunk_size == 0) {
+                    continue;
+                }
+                for (int64_t i = i_start; i < i_stop; i++) {
+                    ggml_backend_tensor_memset(simple_tensor, value, i*chunk_size, chunk_size);
+                }
+            }
+        } break;
+        case GGML_BACKEND_SPLIT_AXIS_PARTIAL: {
+            GGML_ASSERT(value == 0);
+            [[fallthrough]];
+        }
+        case GGML_BACKEND_SPLIT_AXIS_MIRRORED: {
+            for (size_t j = 0; j < n_bufs; j++) {
+                ggml_tensor * simple_tensor = ggml_backend_meta_buffer_simple_tensor(tensor, j);
+                ggml_backend_tensor_memset(simple_tensor, value, offset, size);
+            }
+        } break;
+        default: {
+            GGML_ABORT("fatal error");
+        }
+    }
 }
 
 static void ggml_backend_meta_buffer_set_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
@@ -1488,7 +1628,7 @@ static const ggml_backend_buffer_i ggml_backend_meta_buffer_iface = {
     /* .free_buffer     = */ ggml_backend_meta_buffer_free_buffer,
     /* .get_base        = */ ggml_backend_meta_buffer_get_base,
     /* .init_tensor     = */ ggml_backend_meta_buffer_init_tensor,
-    /* .memset_tensor   = */ nullptr, // TODO implement
+    /* .memset_tensor   = */ ggml_backend_meta_buffer_memset_tensor,
     /* .set_tensor      = */ ggml_backend_meta_buffer_set_tensor,
     /* .get_tensor      = */ ggml_backend_meta_buffer_get_tensor,
     /* .set_tensor_2d   = */ nullptr,

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -1987,7 +1987,7 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
 
         {
             // For MoE models it may make sense to delay the AllReduce in order to reduce I/O:
-            auto get_i_delayed = [&](const int i) -> int {
+            auto get_i_delayed_branch = [&](const int i) -> int {
                 int id = i; // i_delayed
                 int idr = i; // i_delayed return, last safe return value
 
@@ -2085,6 +2085,62 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
                 }
                 idr = id;
                 return idr;
+            };
+
+            // AllReduce(a) + AllReduce(b) == AllReduce(a + b) for independent partial branches.
+            auto get_i_delayed = [&](const int i) -> int {
+                const int i_delayed = get_i_delayed_branch(i);
+                ggml_tensor * node = cgraph->nodes[i_delayed];
+
+                if (ggml_node_get_use_count(cgraph, i_delayed) != 1) {
+                    return i_delayed;
+                }
+
+                for (int id = i_delayed + 1; id < cgraph->n_nodes; id++) {
+                    ggml_tensor * next = cgraph->nodes[id];
+                    if (next->view_src == node) {
+                        return i_delayed;
+                    }
+                    for (int s = 0; s < GGML_MAX_SRC; s++) {
+                        if (next->src[s] == node) {
+                            return i_delayed;
+                        }
+                    }
+
+                    if (next->view_src != nullptr && next->view_src->op == GGML_OP_NONE && ggml_backend_buffer_is_host(next->view_src->buffer)) {
+                        continue;
+                    }
+                    if (ggml_backend_meta_get_split_state(next, false).axis != GGML_BACKEND_SPLIT_AXIS_PARTIAL) {
+                        continue;
+                    }
+
+                    const int i_other = id;
+                    const int i_other_delayed = get_i_delayed_branch(i_other);
+                    ggml_tensor * other = cgraph->nodes[i_other_delayed];
+                    if (ggml_node_get_use_count(cgraph, i_other_delayed) != 1 || i_other_delayed + 1 >= cgraph->n_nodes) {
+                        return i_delayed;
+                    }
+
+                    ggml_tensor * sum = cgraph->nodes[i_other_delayed + 1];
+                    if (sum->op != GGML_OP_ADD ||
+                            !ggml_are_same_shape(node, other) || node->type != other->type || sum->type != node->type ||
+                            !((sum->src[0] == node && sum->src[1] == other) ||
+                              (sum->src[0] == other && sum->src[1] == node)) ||
+                            ggml_backend_meta_get_split_state(sum, false).axis != GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
+                        return i_delayed;
+                    }
+
+                    for (size_t j = 0; j < n_backends; j++) {
+                        auto & bcj = backend_ctx->backend_configs[j];
+                        const bool compute = bcj.nodes[i]->flags & GGML_TENSOR_FLAG_COMPUTE;
+                        const bool compute_other = bcj.nodes[i_other]->flags & GGML_TENSOR_FLAG_COMPUTE;
+                        if (compute != compute_other) {
+                            return i_delayed;
+                        }
+                    }
+                    return i_other_delayed + 1;
+                }
+                return i_delayed;
             };
 
             int i_start = 0;

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -2190,14 +2190,6 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
                 cgraph_ij->uid = ggml_graph_next_uid();
             }
         }
-
-        // Aux graph contents are rewritten on every compute but are identical across calls while the subgraphs are reused,
-        // so they can get stable uids on rebuild. Only safe without a comm backend, where the fallback usage is deterministic.
-        if (backend_ctx->comm_ctx == nullptr) {
-            for (ggml_cgraph * cgraph_aux : backend_ctx->cgraphs_aux) {
-                cgraph_aux->uid = ggml_graph_next_uid();
-            }
-        }
     }
 
     size_t iga = 0; // i graph aux

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -280,11 +280,29 @@ void ggml_backend_tensor_get_async(ggml_backend_t backend, const struct ggml_ten
     }
 }
 
+static void ggml_backend_tensor_check_2d_bounds(
+        const struct ggml_tensor * tensor, size_t offset, size_t size, size_t n_copies,
+        size_t stride_tensor, size_t stride_data) {
+    const size_t nbytes = ggml_nbytes(tensor);
+    const size_t last   = n_copies - 1;
+
+    GGML_ASSERT(offset <= nbytes && size <= nbytes - offset && "tensor access out of bounds");
+    GGML_ASSERT((stride_tensor == 0 || last <= (nbytes - offset - size) / stride_tensor) &&
+                "tensor access out of bounds");
+    GGML_ASSERT((stride_data == 0 || last <= (SIZE_MAX - size) / stride_data) &&
+                "data access overflows");
+}
+
 void ggml_backend_tensor_set_2d_async(ggml_backend_t backend, struct ggml_tensor * tensor, const void * data, size_t offset, size_t size,
             size_t n_copies, size_t stride_tensor, size_t stride_data) {
     GGML_ASSERT(backend);
     GGML_ASSERT(tensor);
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
+
+    if (n_copies == 0 || size == 0) {
+        return;
+    }
+    ggml_backend_tensor_check_2d_bounds(tensor, offset, size, n_copies, stride_tensor, stride_data);
 
     if (n_copies <= 1 || backend->iface.set_tensor_2d_async == NULL) {
         for (size_t i = 0; i < n_copies; i++) {
@@ -292,12 +310,7 @@ void ggml_backend_tensor_set_2d_async(ggml_backend_t backend, struct ggml_tensor
         }
         return;
     }
-    if (size == 0) {
-        return;
-    }
 
-    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
-    GGML_ASSERT(offset + (n_copies-1)*stride_tensor + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
     backend->iface.set_tensor_2d_async(backend, tensor, data, offset, size, n_copies, stride_tensor, stride_data);
 }
 
@@ -307,18 +320,18 @@ void ggml_backend_tensor_get_2d_async(ggml_backend_t backend, const struct ggml_
     GGML_ASSERT(tensor);
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
 
+    if (n_copies == 0 || size == 0) {
+        return;
+    }
+    ggml_backend_tensor_check_2d_bounds(tensor, offset, size, n_copies, stride_tensor, stride_data);
+
     if (n_copies <= 1 || backend->iface.get_tensor_2d_async == NULL) {
         for (size_t i = 0; i < n_copies; i++) {
             ggml_backend_tensor_get_async(backend, tensor, (char *) data + i*stride_data, offset + i*stride_tensor, size);
         }
         return;
     }
-    if (size == 0) {
-        return;
-    }
 
-    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
-    GGML_ASSERT(offset + (n_copies-1)*stride_tensor + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
     backend->iface.get_tensor_2d_async(backend, tensor, data, offset, size, n_copies, stride_tensor, stride_data);
 }
 
@@ -358,18 +371,18 @@ void ggml_backend_tensor_set_2d(struct ggml_tensor * tensor, const void * data, 
     ggml_backend_buffer_t buf = tensor->view_src ? tensor->view_src->buffer : tensor->buffer;
     GGML_ASSERT(buf != NULL && "tensor buffer not set");
 
+    if (n_copies == 0 || size == 0) {
+        return;
+    }
+    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
+    ggml_backend_tensor_check_2d_bounds(tensor, offset, size, n_copies, stride_tensor, stride_data);
+
     if (n_copies <= 1 || buf->iface.set_tensor_2d == NULL) {
         for (size_t i = 0; i < n_copies; i++) {
             ggml_backend_tensor_set(tensor, (const char *) data + i*stride_data, offset + i*stride_tensor, size);
         }
         return;
     }
-    if (size == 0) {
-        return;
-    }
-
-    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
-    GGML_ASSERT(offset + (n_copies-1)*stride_tensor + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
 
     buf->iface.set_tensor_2d(buf, tensor, data, offset, size, n_copies, stride_tensor, stride_data);
 }
@@ -380,18 +393,18 @@ void ggml_backend_tensor_get_2d(const struct ggml_tensor * tensor, void * data, 
     ggml_backend_buffer_t buf = tensor->view_src ? tensor->view_src->buffer : tensor->buffer;
     GGML_ASSERT(buf != NULL && "tensor buffer not set");
 
+    if (n_copies == 0 || size == 0) {
+        return;
+    }
+    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
+    ggml_backend_tensor_check_2d_bounds(tensor, offset, size, n_copies, stride_tensor, stride_data);
+
     if (n_copies <= 1 || buf->iface.get_tensor_2d == NULL) {
         for (size_t i = 0; i < n_copies; i++) {
             ggml_backend_tensor_get(tensor, (char *) data + i*stride_data, offset + i*stride_tensor, size);
         }
         return;
     }
-    if (size == 0) {
-        return;
-    }
-
-    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
-    GGML_ASSERT(offset + (n_copies-1)*stride_tensor + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
 
     buf->iface.get_tensor_2d(buf, tensor, data, offset, size, n_copies, stride_tensor, stride_data);
 }

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -252,11 +252,18 @@ size_t ggml_backend_get_max_size(ggml_backend_t backend) {
     return ggml_backend_buft_get_max_size(ggml_backend_get_default_buffer_type(backend));
 }
 
+static void ggml_backend_tensor_check_bounds(
+        const struct ggml_tensor * tensor, size_t offset, size_t size) {
+    const size_t nbytes = ggml_nbytes(tensor);
+
+    GGML_ASSERT(offset <= nbytes && size <= nbytes - offset && "tensor access out of bounds");
+}
+
 void ggml_backend_tensor_set_async(ggml_backend_t backend, struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
     GGML_ASSERT(backend);
     GGML_ASSERT(tensor);
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
-    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
+    ggml_backend_tensor_check_bounds(tensor, offset, size);
 
     if (backend->iface.set_tensor_async == NULL) {
         ggml_backend_synchronize(backend);
@@ -270,7 +277,7 @@ void ggml_backend_tensor_get_async(ggml_backend_t backend, const struct ggml_ten
     GGML_ASSERT(backend);
     GGML_ASSERT(tensor);
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
-    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
+    ggml_backend_tensor_check_bounds(tensor, offset, size);
 
     if (backend->iface.get_tensor_async == NULL) {
         ggml_backend_synchronize(backend);
@@ -286,7 +293,7 @@ static void ggml_backend_tensor_check_2d_bounds(
     const size_t nbytes = ggml_nbytes(tensor);
     const size_t last   = n_copies - 1;
 
-    GGML_ASSERT(offset <= nbytes && size <= nbytes - offset && "tensor access out of bounds");
+    ggml_backend_tensor_check_bounds(tensor, offset, size);
     GGML_ASSERT((stride_tensor == 0 || last <= (nbytes - offset - size) / stride_tensor) &&
                 "tensor access out of bounds");
     GGML_ASSERT((stride_data == 0 || last <= (SIZE_MAX - size) / stride_data) &&
@@ -345,7 +352,7 @@ void ggml_backend_tensor_set(struct ggml_tensor * tensor, const void * data, siz
     }
 
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
-    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
+    ggml_backend_tensor_check_bounds(tensor, offset, size);
 
     buf->iface.set_tensor(buf, tensor, data, offset, size);
 }
@@ -360,7 +367,7 @@ void ggml_backend_tensor_get(const struct ggml_tensor * tensor, void * data, siz
     }
 
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
-    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
+    ggml_backend_tensor_check_bounds(tensor, offset, size);
 
     buf->iface.get_tensor(buf, tensor, data, offset, size);
 }
@@ -419,7 +426,7 @@ void ggml_backend_tensor_memset(struct ggml_tensor * tensor, uint8_t value, size
 
     GGML_ASSERT(buf != NULL && "tensor buffer not set");
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
-    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
+    ggml_backend_tensor_check_bounds(tensor, offset, size);
     GGML_ASSERT(buf->iface.memset_tensor != NULL && "memset not implemented by backend buffer");
 
     buf->iface.memset_tensor(buf, tensor, value, offset, size);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -726,6 +726,21 @@ bool ggml_backend_buffer_is_multi_buffer(ggml_backend_buffer_t buffer) {
     return buffer->iface.free_buffer == ggml_backend_multi_buffer_free_buffer;
 }
 
+ggml_backend_buffer_t ggml_backend_multi_buffer_get_buffer(ggml_backend_buffer_t buffer, const void * addr) {
+    GGML_ASSERT(ggml_backend_buffer_is_multi_buffer(buffer));
+    ggml_backend_multi_buffer_context * ctx = (ggml_backend_multi_buffer_context *) buffer->context;
+    const uintptr_t address = (uintptr_t) addr;
+    for (size_t i = 0; i < ctx->n_buffers; i++) {
+        ggml_backend_buffer_t sub  = ctx->buffers[i];
+        const uintptr_t       base = (uintptr_t) ggml_backend_buffer_get_base(sub);
+        const size_t          size = ggml_backend_buffer_get_size(sub);
+        if (address >= base && address - base < size) {
+            return sub;
+        }
+    }
+    return NULL;
+}
+
 void ggml_backend_multi_buffer_set_usage(ggml_backend_buffer_t buffer, enum ggml_backend_buffer_usage usage) {
     GGML_ASSERT(buffer);
     GGML_ASSERT(ggml_backend_buffer_is_multi_buffer(buffer));

--- a/ggml/src/ggml-cuda/gated_delta_net_back.cu
+++ b/ggml/src/ggml-cuda/gated_delta_net_back.cu
@@ -129,14 +129,14 @@ template <
     const uint32_t block_size = gdn_back_threads_per_block(S_v, ggml_cuda_get_physical_warp_size())
 >
 __global__ void __launch_bounds__(block_size)
-gated_delta_net_back_cuda(const float * GGML_CUDA_RESTRICT data_q,
-                          const float * GGML_CUDA_RESTRICT data_k,
-                          const float * GGML_CUDA_RESTRICT data_v,
-                          const float * GGML_CUDA_RESTRICT data_g,
-                          const float * GGML_CUDA_RESTRICT data_beta,
-                          const float * GGML_CUDA_RESTRICT data_state,
-                          const float * GGML_CUDA_RESTRICT data_d,
-                                float * GGML_CUDA_RESTRICT data_dst,
+gated_delta_net_back_cuda(const float * data_q_ptr,
+                          const float * data_k_ptr,
+                          const float * data_v_ptr,
+                          const float * data_g_ptr,
+                          const float * data_beta_ptr,
+                          const float * data_state_ptr,
+                          const float * data_d_ptr,
+                                float * data_dst_ptr,
                           const ggml_cuda_gated_delta_net_back_kargs args) {
 
     constexpr const uint32_t warp_size     = ggml_cuda_get_physical_warp_size();
@@ -184,6 +184,14 @@ gated_delta_net_back_cuda(const float * GGML_CUDA_RESTRICT data_q,
     const uint32_t state_size_per_snap = state_size * H * args.n_seqs;
 
     ggml_cuda_pdl_sync();
+    const float * GGML_CUDA_RESTRICT data_q     = data_q_ptr;
+    const float * GGML_CUDA_RESTRICT data_k     = data_k_ptr;
+    const float * GGML_CUDA_RESTRICT data_v     = data_v_ptr;
+    const float * GGML_CUDA_RESTRICT data_g     = data_g_ptr;
+    const float * GGML_CUDA_RESTRICT data_beta  = data_beta_ptr;
+    const float * GGML_CUDA_RESTRICT data_state = data_state_ptr;
+    const float * GGML_CUDA_RESTRICT data_d     = data_d_ptr;
+          float * GGML_CUDA_RESTRICT data_dst   = data_dst_ptr;
 
     for (uint32_t gi = 0; gi < group; gi++) {
         const uint32_t iv1 = iq1 + gi * neq1;       // v-head (iv1 % neq1 == iq1)

--- a/ggml/src/ggml-cuda/sigmoid-back.cu
+++ b/ggml/src/ggml-cuda/sigmoid-back.cu
@@ -6,16 +6,21 @@
 
 template < typename T >
 __global__ void
-sigmoid_back_cuda(const T * GGML_CUDA_RESTRICT data_grad,
-                  const T * GGML_CUDA_RESTRICT data_src,
-                        T * GGML_CUDA_RESTRICT data_dst,
+sigmoid_back_cuda(const T * data_grad_ptr,
+                  const T * data_src_ptr,
+                        T * data_dst_ptr,
                   const int64_t k) {
 
+    ggml_cuda_pdl_lc();
+    const T * GGML_CUDA_RESTRICT data_grad = data_grad_ptr;
+    const T * GGML_CUDA_RESTRICT data_src  = data_src_ptr;
+          T * GGML_CUDA_RESTRICT data_dst  = data_dst_ptr;
     const int64_t tid = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
     if (tid >= k) {
         return;
     }
 
+    ggml_cuda_pdl_sync();
     constexpr const float one = 1.0f;
     const float dy = static_cast<float>(data_grad[tid]);
     const float x  = static_cast<float>(data_src[tid]);

--- a/ggml/src/ggml-rpc/CMakeLists.txt
+++ b/ggml/src/ggml-rpc/CMakeLists.txt
@@ -6,7 +6,7 @@ ggml_add_backend_library(ggml-rpc
                         )
 
 if (WIN32)
-    target_link_libraries(ggml-rpc PRIVATE ws2_32)
+    target_link_libraries(ggml-rpc PRIVATE bcrypt ws2_32)
 endif()
 
 # RDMA auto-detection (Linux only, requires libibverbs)

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -51,7 +51,7 @@ struct rpc_tensor {
     uint64_t data;
     char name[GGML_MAX_NAME];
 
-    char padding[4];
+    int32_t use_count;
 };
 
 static_assert(sizeof(rpc_tensor) % 8 == 0, "rpc_tensor size must be multiple of 8");
@@ -533,10 +533,10 @@ static rpc_tensor serialize_tensor(const ggml_tensor * tensor) {
     }
     result.view_src = reinterpret_cast<uint64_t>(tensor->view_src);
     result.view_offs = tensor->view_offs;
+    result.use_count = 0;
 
     // Avoid sending uninitialized data over the wire
     memset(result.name, 0, sizeof(result.name));
-    memset(result.padding, 0, sizeof(result.padding));
 
     snprintf(result.name, GGML_MAX_NAME, "%s", tensor->name);
     return result;
@@ -809,7 +809,8 @@ static void ggml_backend_rpc_synchronize(ggml_backend_t backend) {
     RPC_STATUS_ASSERT(status);
 }
 
-static void add_tensor(ggml_tensor * tensor, std::vector<rpc_tensor> & tensors, std::unordered_set<ggml_tensor*> & visited) {
+static void add_tensor(const ggml_cgraph * cgraph, ggml_tensor * tensor, std::vector<rpc_tensor> & tensors,
+                       std::unordered_set<ggml_tensor*> & visited) {
     if (tensor == nullptr) {
         return;
     }
@@ -818,10 +819,15 @@ static void add_tensor(ggml_tensor * tensor, std::vector<rpc_tensor> & tensors, 
     }
     visited.insert(tensor);
     for (int i = 0; i < GGML_MAX_SRC; i++) {
-        add_tensor(tensor->src[i], tensors, visited);
+        add_tensor(cgraph, tensor->src[i], tensors, visited);
     }
-    add_tensor(tensor->view_src, tensors, visited);
-    tensors.push_back(serialize_tensor(tensor));
+    add_tensor(cgraph, tensor->view_src, tensors, visited);
+    rpc_tensor result = serialize_tensor(tensor);
+    const size_t hash_pos = ggml_hash_find(&cgraph->visited_hash_set, tensor);
+    if (hash_pos != GGML_HASHSET_FULL && ggml_bitset_get(cgraph->visited_hash_set.used, hash_pos)) {
+        result.use_count = cgraph->use_counts[hash_pos];
+    }
+    tensors.push_back(result);
 }
 
 static void serialize_graph(uint32_t device, const ggml_cgraph * cgraph, std::vector<uint8_t> & output) {
@@ -829,7 +835,7 @@ static void serialize_graph(uint32_t device, const ggml_cgraph * cgraph, std::ve
     std::vector<rpc_tensor> tensors;
     std::unordered_set<ggml_tensor*> visited;
     for (uint32_t i = 0; i < n_nodes; i++) {
-        add_tensor(cgraph->nodes[i], tensors, visited);
+        add_tensor(cgraph, cgraph->nodes[i], tensors, visited);
     }
     // serialization format:
     // | device (4 bytes) | uid (8 bytes) | n_nodes (4 bytes) | nodes (n_nodes * sizeof(uint64_t) | n_tensors (4 bytes) | tensors (n_tensors * sizeof(rpc_tensor)) |
@@ -1774,6 +1780,10 @@ bool rpc_server::graph_compute(const std::vector<uint8_t> & input) {
         if (graph->nodes[i] == nullptr && id != 0) {
             GGML_LOG_ERROR("[%s] failed to create graph node %d (id=%" PRId64 ")\n", __func__, i, id);
             return false;
+        }
+        if (graph->nodes[i] != nullptr) {
+            const size_t hash_pos = ggml_hash_find_or_insert(&graph->visited_hash_set, graph->nodes[i]);
+            graph->use_counts[hash_pos] = tensor_ptrs.at(nodes[i])->use_count;
         }
     }
     ggml_status status = ggml_backend_graph_compute_async(backends[device], graph);

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -9,7 +9,6 @@
 #include <cinttypes>
 #include <cstdlib>
 #include <optional>
-#include <random>
 #include <string>
 #include <thread>
 #include <vector>
@@ -21,6 +20,15 @@
 #include <fstream>
 #include <filesystem>
 #include <algorithm>
+
+#ifdef _WIN32
+#  define WIN32_LEAN_AND_MEAN
+#  ifndef NOMINMAX
+#    define NOMINMAX
+#  endif
+#  include <windows.h>
+#  include <bcrypt.h>
+#endif
 
 static const char * RPC_DEBUG = std::getenv("GGML_RPC_DEBUG");
 
@@ -339,6 +347,75 @@ static bool checked_add_size(size_t a, size_t b, size_t & result) {
     }
     result = a + b;
     return true;
+}
+
+static bool checked_rpc_tensor_size(const rpc_tensor & tensor, size_t & tensor_size) {
+    const ggml_type type = (ggml_type) tensor.type;
+    const size_t block_size = ggml_blck_size(type);
+    if (tensor.ne[0] % block_size != 0) {
+        return false;
+    }
+
+    int64_t nelements = 1;
+    for (uint32_t i = 0; i < GGML_MAX_DIMS; i++) {
+        if (tensor.ne[i] != 0 && nelements > INT64_MAX / tensor.ne[i]) {
+            return false;
+        }
+        nelements *= tensor.ne[i];
+    }
+
+    size_t data_size;
+    if (!checked_mul_size(ggml_type_size(type), tensor.ne[0] / block_size, data_size)) {
+        return false;
+    }
+    for (uint32_t i = 1; i < GGML_MAX_DIMS; i++) {
+        if (!checked_mul_size(data_size, tensor.ne[i], data_size)) {
+            return false;
+        }
+    }
+
+    for (uint32_t i = 0; i < GGML_MAX_DIMS; i++) {
+        if (tensor.ne[i] == 0) {
+            tensor_size = 0;
+            return true;
+        }
+    }
+
+    if (block_size == 1) {
+        tensor_size = ggml_type_size(type);
+        for (uint32_t i = 0; i < GGML_MAX_DIMS; i++) {
+            size_t extent;
+            if (!checked_mul_size(tensor.ne[i] - 1, tensor.nb[i], extent) ||
+                    !checked_add_size(tensor_size, extent, tensor_size)) {
+                return false;
+            }
+        }
+    } else {
+        if (!checked_mul_size(tensor.ne[0] / block_size, tensor.nb[0], tensor_size)) {
+            return false;
+        }
+        for (uint32_t i = 1; i < GGML_MAX_DIMS; i++) {
+            size_t extent;
+            if (!checked_mul_size(tensor.ne[i] - 1, tensor.nb[i], extent) ||
+                    !checked_add_size(tensor_size, extent, tensor_size)) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+static bool fill_secure_random(uint8_t * data, size_t size) {
+#ifdef _WIN32
+    if (size > UINT32_MAX) {
+        return false;
+    }
+    return BCryptGenRandom(nullptr, data, (ULONG) size, BCRYPT_USE_SYSTEM_PREFERRED_RNG) == 0;
+#else
+    std::ifstream source("/dev/urandom", std::ios::binary);
+    source.read((char *) data, size);
+    return source && source.gcount() == (std::streamsize) size;
+#endif
 }
 
 static bool checked_span_size(size_t size, size_t n_copies, size_t stride) {
@@ -1289,6 +1366,12 @@ ggml_tensor * rpc_server::deserialize_tensor(struct ggml_context * ctx, const rp
         return nullptr;
     }
 
+    size_t tensor_size;
+    if (!checked_rpc_tensor_size(*tensor, tensor_size)) {
+        GGML_LOG_ERROR("[%s] invalid tensor dimensions or strides\n", __func__);
+        return nullptr;
+    }
+
     ggml_tensor * result = ggml_new_tensor_4d(ctx, (ggml_type) tensor->type,
         tensor->ne[0], tensor->ne[1], tensor->ne[2], tensor->ne[3]);
 
@@ -1305,7 +1388,8 @@ ggml_tensor * rpc_server::deserialize_tensor(struct ggml_context * ctx, const rp
     if (result->buffer && buffers.find(result->buffer) == buffers.end()) {
         result->buffer = nullptr;
     }
-    if (result->buffer && ggml_nelements(result) > 0 && ggml_backend_buffer_is_multi_buffer(result->buffer)) {
+    const bool empty_unallocated = tensor_size == 0 && tensor->data == 0;
+    if (result->buffer && !empty_unallocated && ggml_backend_buffer_is_multi_buffer(result->buffer)) {
         ggml_backend_buffer_t sub_buffer =
             ggml_backend_multi_buffer_get_buffer(result->buffer, reinterpret_cast<const void *>(tensor->data));
         if (sub_buffer == nullptr) {
@@ -1316,18 +1400,22 @@ ggml_tensor * rpc_server::deserialize_tensor(struct ggml_context * ctx, const rp
         result->buffer = sub_buffer;
     }
 
-    if (result->buffer && ggml_nelements(result) > 0) {
+    if (result->buffer && !empty_unallocated) {
         // require that the tensor data does not go beyond the buffer end
-        uint64_t tensor_size = (uint64_t) ggml_nbytes(result);
-        uint64_t buffer_start = (uint64_t) ggml_backend_buffer_get_base(result->buffer);
-        uint64_t buffer_size = (uint64_t) ggml_backend_buffer_get_size(result->buffer);
-        if (tensor->data + tensor_size < tensor->data ||
-            tensor->data < buffer_start || tensor->data + tensor_size > buffer_start + buffer_size) {
+        const uint64_t buffer_start = (uint64_t) ggml_backend_buffer_get_base(result->buffer);
+        const uint64_t buffer_size = (uint64_t) ggml_backend_buffer_get_size(result->buffer);
+        if (tensor_size > UINT64_MAX - tensor->data || buffer_size > UINT64_MAX - buffer_start) {
+            GGML_LOG_ERROR("[%s] tensor or buffer range overflows\n", __func__);
+            return nullptr;
+        }
+        const uint64_t tensor_end = tensor->data + tensor_size;
+        const uint64_t buffer_end = buffer_start + buffer_size;
+        if (tensor->data < buffer_start || tensor_end > buffer_end) {
             GGML_LOG_ERROR("[%s] tensor '%s' (op %s, type %s, ne [%" PRId64 ", %" PRId64 ", %" PRId64 ", %" PRId64 "]) "
                            "data [0x%" PRIx64 ", 0x%" PRIx64 ") out of buffer bounds [0x%" PRIx64 ", 0x%" PRIx64 ")\n",
                            __func__, tensor->name, ggml_op_name((ggml_op) tensor->op), ggml_type_name(result->type),
                            result->ne[0], result->ne[1], result->ne[2], result->ne[3],
-                           tensor->data, tensor->data + tensor_size, buffer_start, buffer_start + buffer_size);
+                           tensor->data, tensor_end, buffer_start, buffer_end);
             return nullptr;
         }
     }
@@ -2794,13 +2882,10 @@ static void * ggml_backend_rpc_comm_init(ggml_backend_t * backends, size_t n_bac
         comm_port = (uint32_t) port0 + 1000;
     }
 
-    std::array<uint8_t, RPC_COMM_SESSION_ID_SIZE> session_id = {};
-    std::random_device random;
-    for (size_t offset = 0; offset < session_id.size();) {
-        const auto value = random();
-        const size_t size = std::min(sizeof(value), session_id.size() - offset);
-        memcpy(session_id.data() + offset, &value, size);
-        offset += size;
+    std::array<uint8_t, RPC_COMM_SESSION_ID_SIZE> session_id;
+    if (!fill_secure_random(session_id.data(), session_id.size())) {
+        GGML_LOG_WARN("%s: failed to generate communicator session id\n", __func__);
+        return nullptr;
     }
 
     // Send all init requests before reading any response: rank 0 blocks in accept

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -1559,6 +1559,10 @@ bool rpc_server::get_tensor_2d(const rpc_msg_get_tensor_2d_req & request, std::v
                            __func__, request.offset, span, ggml_nbytes(tensor));
             return false;
         }
+        if (request.size * request.n_copies > ggml_nbytes(tensor)) {
+            GGML_LOG_ERROR("[%s] packed response size exceeds tensor size\n", __func__);
+            return false;
+        }
     }
 
     response.resize(request.size * request.n_copies, 0);
@@ -1875,7 +1879,13 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
     const size_t wire_bytes = wire_bf16 ? (size_t) ne*2 : nbytes;
     const size_t need       = wire_bf16 ? 2*nbytes : nbytes;
     if (state.scratch_size < need) {
-        state.scratch.reset(ggml_backend_alloc_buffer(backend, need));
+        ggml_backend_buffer_ptr scratch { ggml_backend_alloc_buffer(backend, need) };
+        if (scratch == nullptr) {
+            GGML_LOG_ERROR("[%s] failed to allocate %zu bytes of scratch space\n", __func__, need);
+            return false;
+        }
+        ggml_backend_synchronize(backend);
+        state.scratch = std::move(scratch);
         state.scratch_size = need;
     }
     char * scratch_base = (char *) ggml_backend_buffer_get_base(state.scratch.get());
@@ -1961,6 +1971,7 @@ bool rpc_server::comm_free(const rpc_msg_comm_free_req & request) {
     if (request.device >= backends.size()) {
         return false;
     }
+    ggml_backend_synchronize(backends[request.device]);
     comm_states[request.device] = comm_state();
     return true;
 }

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -1388,8 +1388,8 @@ ggml_tensor * rpc_server::deserialize_tensor(struct ggml_context * ctx, const rp
     if (result->buffer && buffers.find(result->buffer) == buffers.end()) {
         result->buffer = nullptr;
     }
-    const bool empty_unallocated = tensor_size == 0 && tensor->data == 0;
-    if (result->buffer && !empty_unallocated && ggml_backend_buffer_is_multi_buffer(result->buffer)) {
+    const bool empty_tensor = tensor_size == 0;
+    if (result->buffer && !empty_tensor && ggml_backend_buffer_is_multi_buffer(result->buffer)) {
         ggml_backend_buffer_t sub_buffer =
             ggml_backend_multi_buffer_get_buffer(result->buffer, reinterpret_cast<const void *>(tensor->data));
         if (sub_buffer == nullptr) {
@@ -1400,7 +1400,7 @@ ggml_tensor * rpc_server::deserialize_tensor(struct ggml_context * ctx, const rp
         result->buffer = sub_buffer;
     }
 
-    if (result->buffer && !empty_unallocated) {
+    if (result->buffer && !empty_tensor) {
         // require that the tensor data does not go beyond the buffer end
         const uint64_t buffer_start = (uint64_t) ggml_backend_buffer_get_base(result->buffer);
         const uint64_t buffer_size = (uint64_t) ggml_backend_buffer_get_size(result->buffer);
@@ -1426,6 +1426,10 @@ ggml_tensor * rpc_server::deserialize_tensor(struct ggml_context * ctx, const rp
     }
     result->flags = tensor->flags;
     result->data = reinterpret_cast<void *>(tensor->data);
+    if (empty_tensor && result->buffer) {
+        // Empty split views have no addressable data and can point outside the local shard.
+        result->data = ggml_backend_buffer_get_base(result->buffer);
+    }
     ggml_set_name(result, tensor->name);
     return result;
 }

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -377,7 +377,7 @@ static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, 
 // Performs HELLO handshake with transport auto-negotiation.
 // Advertises local capabilities via conn_caps; if the server responds with
 // matching capabilities, the socket is upgraded transparently.
-static bool negotiate_hello(const std::shared_ptr<socket_t> & sock, uint8_t * minor = nullptr) {
+static bool negotiate_hello(const std::shared_ptr<socket_t> & sock) {
     rpc_msg_hello_req request = {};
     rpc_msg_hello_rsp response = {};
 
@@ -392,21 +392,8 @@ static bool negotiate_hello(const std::shared_ptr<socket_t> & sock, uint8_t * mi
         return false;
     }
 
-    if (minor != nullptr) {
-        *minor = response.minor;
-    }
     sock->update_caps(response.conn_caps);
     return true;
-}
-
-// minor protocol version of each connected server, used to gate newer commands (comm collectives)
-static std::mutex server_minor_mutex;
-static std::unordered_map<std::string, uint8_t> server_minor_versions;
-
-static uint8_t rpc_server_minor_version(const std::string & endpoint) {
-    std::lock_guard<std::mutex> lock(server_minor_mutex);
-    auto it = server_minor_versions.find(endpoint);
-    return it != server_minor_versions.end() ? it->second : 0;
 }
 
 static std::shared_ptr<socket_t> get_socket(const std::string & endpoint) {
@@ -434,13 +421,8 @@ static std::shared_ptr<socket_t> get_socket(const std::string & endpoint) {
     if (sock == nullptr) {
         return nullptr;
     }
-    uint8_t minor = 0;
-    if (!negotiate_hello(sock, &minor)) {
+    if (!negotiate_hello(sock)) {
         return nullptr;
-    }
-    {
-        std::lock_guard<std::mutex> minor_lock(server_minor_mutex);
-        server_minor_versions[endpoint] = minor;
     }
     LOG_DBG("[%s] connected to %s\n", __func__, endpoint.c_str());
     sockets[endpoint] = sock;
@@ -2549,10 +2531,6 @@ static void * ggml_backend_rpc_comm_init(ggml_backend_t * backends, size_t n_bac
                 GGML_LOG_WARN("%s: multiple ranks on endpoint %s are not supported\n", __func__, rpc_ctx->endpoint.c_str());
                 return nullptr;
             }
-        }
-        if (rpc_server_minor_version(rpc_ctx->endpoint) < 1) {
-            GGML_LOG_WARN("%s: server %s does not support collectives\n", __func__, rpc_ctx->endpoint.c_str());
-            return nullptr;
         }
         ranks.push_back({rpc_ctx->endpoint, rpc_ctx->device});
     }

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -93,6 +93,11 @@ const size_t HASH_THRESHOLD = 10 * 1024 * 1024;
 // so that both sides clear their caches at the same point in the message stream
 const size_t GRAPH_CACHE_MAX = 1024;
 
+static constexpr int RPC_COMM_CONNECT_RETRY_COUNT = 100;
+static constexpr int RPC_COMM_CONNECT_RETRY_MS    = 50;
+static constexpr int RPC_COMM_ACCEPT_TIMEOUT_MS   =
+        RPC_COMM_CONNECT_RETRY_COUNT * RPC_COMM_CONNECT_RETRY_MS + 1000;
+
 struct rpc_msg_hello_req {
     uint8_t conn_caps[RPC_CONN_CAPS_SIZE];
 };
@@ -1791,8 +1796,9 @@ bool rpc_server::comm_init(const rpc_msg_comm_init_req & request, rpc_msg_comm_i
             GGML_LOG_ERROR("[%s] failed to listen on comm port %u\n", __func__, request.port);
             return true;
         }
-        state.peer = srv->accept();
+        state.peer = srv->accept(RPC_COMM_ACCEPT_TIMEOUT_MS);
         if (state.peer == nullptr) {
+            GGML_LOG_ERROR("[%s] timed out waiting for rank 1 on comm port %u\n", __func__, request.port);
             return true;
         }
         if (!state.peer->recv_data(remote_caps, sizeof(remote_caps))) {
@@ -1808,10 +1814,10 @@ bool rpc_server::comm_init(const rpc_msg_comm_init_req & request, rpc_msg_comm_i
     } else {
         const std::string host(request.host, strnlen(request.host, sizeof(request.host)));
         // rank 0 may not be listening yet, retry for a few seconds
-        for (int i = 0; i < 100 && state.peer == nullptr; i++) {
+        for (int i = 0; i < RPC_COMM_CONNECT_RETRY_COUNT && state.peer == nullptr; i++) {
             state.peer = socket_t::connect(host.c_str(), request.port);
             if (state.peer == nullptr) {
-                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                std::this_thread::sleep_for(std::chrono::milliseconds(RPC_COMM_CONNECT_RETRY_MS));
             }
         }
         if (state.peer == nullptr) {
@@ -2599,6 +2605,8 @@ static void * ggml_backend_rpc_comm_init(ggml_backend_t * backends, size_t n_bac
 
     // Send all init requests before reading any response: rank 0 blocks in accept
     // until rank 1 has connected.
+    bool ok = true;
+    std::array<bool, 2> request_sent = {};
     for (size_t i = 0; i < n_backends; i++) {
         rpc_msg_comm_init_req request = {};
         request.device = ranks[i].device;
@@ -2610,11 +2618,17 @@ static void * ggml_backend_rpc_comm_init(ggml_backend_t * backends, size_t n_bac
         }
         auto sock = get_socket(ranks[i].endpoint);
         if (sock == nullptr || !send_rpc_cmd(sock, RPC_CMD_COMM_INIT, &request, sizeof(request))) {
-            return nullptr;
+            GGML_LOG_WARN("%s: failed to send init request to rank %zu (%s)\n",
+                          __func__, i, ranks[i].endpoint.c_str());
+            ok = false;
+            continue;
         }
+        request_sent[i] = true;
     }
-    bool ok = true;
     for (size_t i = 0; i < n_backends; i++) {
+        if (!request_sent[i]) {
+            continue;
+        }
         auto sock = get_socket(ranks[i].endpoint);
         rpc_msg_comm_init_rsp response = {};
         uint64_t rsp_size = 0;

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <chrono>
 #include <cinttypes>
+#include <cstdlib>
 #include <optional>
 #include <string>
 #include <thread>
@@ -79,6 +80,7 @@ enum rpc_cmd {
     RPC_CMD_COMM_INIT,
     RPC_CMD_COMM_ALLREDUCE,
     RPC_CMD_COMM_FREE,
+    RPC_CMD_SYNCHRONIZE,
     RPC_CMD_COUNT,
 };
 
@@ -236,6 +238,10 @@ struct rpc_msg_comm_allreduce_req {
 };
 
 struct rpc_msg_comm_free_req {
+    uint32_t device;
+};
+
+struct rpc_msg_synchronize_req {
     uint32_t device;
 };
 
@@ -758,8 +764,11 @@ static void ggml_backend_rpc_free(ggml_backend_t backend) {
 }
 
 static void ggml_backend_rpc_synchronize(ggml_backend_t backend) {
-    GGML_UNUSED(backend);
-    // this is no-op because we don't have any async operations
+    ggml_backend_rpc_context * rpc_ctx = (ggml_backend_rpc_context *)backend->context;
+    rpc_msg_synchronize_req request = {rpc_ctx->device};
+    auto sock = get_socket(rpc_ctx->endpoint);
+    bool status = send_rpc_cmd(sock, RPC_CMD_SYNCHRONIZE, &request, sizeof(request), nullptr, 0);
+    RPC_STATUS_ASSERT(status);
 }
 
 static void add_tensor(ggml_tensor * tensor, std::vector<rpc_tensor> & tensors, std::unordered_set<ggml_tensor*> & visited) {
@@ -970,6 +979,7 @@ public:
     bool copy_tensor(const rpc_msg_copy_tensor_req & request, rpc_msg_copy_tensor_rsp & response);
     bool graph_compute(const std::vector<uint8_t> & input);
     bool graph_recompute(const rpc_msg_graph_recompute_req & request);
+    bool synchronize(const rpc_msg_synchronize_req & request);
     bool comm_init(const rpc_msg_comm_init_req & request, rpc_msg_comm_init_rsp & response);
     bool comm_allreduce(const rpc_msg_comm_allreduce_req & request);
     bool comm_free(const rpc_msg_comm_free_req & request);
@@ -1746,6 +1756,14 @@ bool rpc_server::graph_recompute(const rpc_msg_graph_recompute_req & request) {
     return true;
 }
 
+bool rpc_server::synchronize(const rpc_msg_synchronize_req & request) {
+    if (request.device >= backends.size()) {
+        return false;
+    }
+    ggml_backend_synchronize(backends[request.device]);
+    return true;
+}
+
 // graph compute is asynchronous; commands that read or write buffer data synchronize first
 void rpc_server::sync_all_backends() {
     for (ggml_backend_t backend : backends) {
@@ -1956,6 +1974,7 @@ bool rpc_server::get_device_memory(const rpc_msg_get_device_memory_req & request
 }
 
 rpc_server::~rpc_server() {
+    sync_all_backends();
     for (auto buffer : buffers) {
         ggml_backend_buffer_free(buffer);
     }
@@ -2243,6 +2262,19 @@ static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const
                 }
                 break;
             }
+            case RPC_CMD_SYNCHRONIZE: {
+                rpc_msg_synchronize_req request;
+                if (!recv_msg(sock, &request, sizeof(request))) {
+                    return;
+                }
+                if (!server.synchronize(request)) {
+                    return;
+                }
+                if (!send_msg(sock, nullptr, 0)) {
+                    return;
+                }
+                break;
+            }
             case RPC_CMD_COMM_INIT: {
                 rpc_msg_comm_init_req request;
                 if (!recv_msg(sock, &request, sizeof(request))) {
@@ -2515,6 +2547,9 @@ static void ggml_backend_rpc_comm_free(void * comm_ctx_v) {
 
 static void * ggml_backend_rpc_comm_init(ggml_backend_t * backends, size_t n_backends) {
     if (n_backends != 2 || std::getenv("GGML_RPC_NO_COMM") != nullptr) {
+        if (n_backends != 2) {
+            GGML_LOG_WARN("RPC all-reduce currently only supports 2 ranks, falling back to slow all-reduce\n");
+        }
         return nullptr;
     }
     std::vector<ggml_backend_rpc_comm_context::rank_info> ranks;
@@ -2542,9 +2577,24 @@ static void * ggml_backend_rpc_comm_init(ggml_backend_t * backends, size_t n_bac
     if (!parse_endpoint(ranks[0].endpoint, host0, port0)) {
         return nullptr;
     }
-    const uint32_t comm_port = (uint32_t) port0 + 1000;
     if (host0.size() >= 64) {
         return nullptr;
+    }
+
+    uint32_t comm_port = 0;
+    if (const char * env = std::getenv("GGML_RPC_COMM_PORT")) {
+        char * end = nullptr;
+        const unsigned long parsed = std::strtoul(env, &end, 10);
+        if (end == env || *end != '\0' || parsed == 0 || parsed > 65535) {
+            GGML_LOG_WARN("%s: invalid GGML_RPC_COMM_PORT '%s'\n", __func__, env);
+            return nullptr;
+        }
+        comm_port = (uint32_t) parsed;
+    } else if (port0 <= 0 || port0 > 65535 - 1000) {
+        GGML_LOG_WARN("%s: RPC port %d + 1000 is out of range; set GGML_RPC_COMM_PORT\n", __func__, port0);
+        return nullptr;
+    } else {
+        comm_port = (uint32_t) port0 + 1000;
     }
 
     // Send all init requests before reading any response: rank 0 blocks in accept
@@ -2594,7 +2644,7 @@ static bool ggml_backend_rpc_comm_allreduce_tensor(void * comm_ctx_v, ggml_tenso
     }
     for (size_t i = 0; i < n_ranks; i++) {
         if (tensors[i] == nullptr || tensors[i]->type != GGML_TYPE_F32 || ggml_nelements(tensors[i]) != ne ||
-                !ggml_is_contiguously_allocated(tensors[i]) ||
+                !ggml_is_contiguous(tensors[i]) ||
                 tensors[i]->buffer == nullptr || !ggml_backend_buffer_is_rpc(tensors[i]->buffer)) {
             return false;
         }

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -5,9 +5,11 @@
 #include "transport.h"
 
 #include <array>
+#include <chrono>
 #include <cinttypes>
 #include <optional>
 #include <string>
+#include <thread>
 #include <vector>
 #include <memory>
 #include <mutex>
@@ -72,6 +74,11 @@ enum rpc_cmd {
     RPC_CMD_DEVICE_COUNT,
     RPC_CMD_GRAPH_RECOMPUTE,
     RPC_CMD_MEMSET_TENSOR,
+    RPC_CMD_SET_TENSOR_2D,
+    RPC_CMD_GET_TENSOR_2D,
+    RPC_CMD_COMM_INIT,
+    RPC_CMD_COMM_ALLREDUCE,
+    RPC_CMD_COMM_FREE,
     RPC_CMD_COUNT,
 };
 
@@ -79,6 +86,10 @@ static_assert(RPC_CMD_HELLO == 14, "RPC_CMD_HELLO must be always 14");
 
 // Try RPC_CMD_SET_TENSOR_HASH first when data size is larger than this threshold
 const size_t HASH_THRESHOLD = 10 * 1024 * 1024;
+
+// Maximum number of graphs cached per device; client and server must use the same value
+// so that both sides clear their caches at the same point in the message stream
+const size_t GRAPH_CACHE_MAX = 1024;
 
 struct rpc_msg_hello_req {
     uint8_t conn_caps[RPC_CONN_CAPS_SIZE];
@@ -196,6 +207,36 @@ struct rpc_msg_get_device_memory_rsp {
 
 struct rpc_msg_graph_recompute_req {
     uint32_t device;
+    uint64_t uid;
+};
+
+struct rpc_msg_get_tensor_2d_req {
+    rpc_tensor tensor;
+    uint64_t offset;
+    uint64_t size;
+    uint64_t n_copies;
+    uint64_t stride;
+};
+
+struct rpc_msg_comm_init_req {
+    uint32_t device;
+    uint32_t rank;
+    uint32_t world;
+    uint32_t port;      // rank 0: port to listen on; rank > 0: rank 0's comm port
+    char     host[64];  // rank > 0: rank 0's host
+};
+
+struct rpc_msg_comm_init_rsp {
+    uint8_t ok;
+};
+
+struct rpc_msg_comm_allreduce_req {
+    uint32_t   device;
+    rpc_tensor tensor;
+};
+
+struct rpc_msg_comm_free_req {
+    uint32_t device;
 };
 
 #pragma pack(pop)
@@ -212,7 +253,8 @@ struct ggml_backend_rpc_device_context {
     uint32_t    device;
     std::string name;
     std::string description;
-    uint64_t    last_graph_uid;
+    // uids of graphs cached by the server for this device
+    std::unordered_set<uint64_t> graph_uids;
 };
 
 struct ggml_backend_rpc_buffer_type_context {
@@ -335,7 +377,7 @@ static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, 
 // Performs HELLO handshake with transport auto-negotiation.
 // Advertises local capabilities via conn_caps; if the server responds with
 // matching capabilities, the socket is upgraded transparently.
-static bool negotiate_hello(const std::shared_ptr<socket_t> & sock) {
+static bool negotiate_hello(const std::shared_ptr<socket_t> & sock, uint8_t * minor = nullptr) {
     rpc_msg_hello_req request = {};
     rpc_msg_hello_rsp response = {};
 
@@ -350,8 +392,21 @@ static bool negotiate_hello(const std::shared_ptr<socket_t> & sock) {
         return false;
     }
 
+    if (minor != nullptr) {
+        *minor = response.minor;
+    }
     sock->update_caps(response.conn_caps);
     return true;
+}
+
+// minor protocol version of each connected server, used to gate newer commands (comm collectives)
+static std::mutex server_minor_mutex;
+static std::unordered_map<std::string, uint8_t> server_minor_versions;
+
+static uint8_t rpc_server_minor_version(const std::string & endpoint) {
+    std::lock_guard<std::mutex> lock(server_minor_mutex);
+    auto it = server_minor_versions.find(endpoint);
+    return it != server_minor_versions.end() ? it->second : 0;
 }
 
 static std::shared_ptr<socket_t> get_socket(const std::string & endpoint) {
@@ -379,8 +434,13 @@ static std::shared_ptr<socket_t> get_socket(const std::string & endpoint) {
     if (sock == nullptr) {
         return nullptr;
     }
-    if (!negotiate_hello(sock)) {
+    uint8_t minor = 0;
+    if (!negotiate_hello(sock, &minor)) {
         return nullptr;
+    }
+    {
+        std::lock_guard<std::mutex> minor_lock(server_minor_mutex);
+        server_minor_versions[endpoint] = minor;
     }
     LOG_DBG("[%s] connected to %s\n", __func__, endpoint.c_str());
     sockets[endpoint] = sock;
@@ -509,6 +569,48 @@ static void ggml_backend_rpc_buffer_set_tensor(ggml_backend_buffer_t buffer, ggm
     RPC_STATUS_ASSERT(status);
 }
 
+static void ggml_backend_rpc_buffer_set_tensor_2d(ggml_backend_buffer_t buffer, ggml_tensor * tensor, const void * data,
+        size_t offset, size_t size, size_t n_copies, size_t stride_tensor, size_t stride_data) {
+    ggml_backend_rpc_buffer_context * ctx = (ggml_backend_rpc_buffer_context *)buffer->context;
+    rpc_tensor rpc_tensor = serialize_tensor(tensor);
+    // input serialization format: | rpc_tensor | offset (8 bytes) | size (8 bytes) | n_copies (8 bytes) | stride (8 bytes) | data (size * n_copies bytes) |
+    size_t input_size = sizeof(rpc_tensor) + 4*sizeof(uint64_t) + size*n_copies;
+    std::vector<uint8_t> input(input_size, 0);
+    uint8_t * dest = input.data();
+    memcpy(dest, &rpc_tensor, sizeof(rpc_tensor));
+    dest += sizeof(rpc_tensor);
+    uint64_t header[4] = { offset, size, n_copies, stride_tensor };
+    memcpy(dest, header, sizeof(header));
+    dest += sizeof(header);
+    for (size_t i = 0; i < n_copies; i++) {
+        memcpy(dest + i*size, (const char *)data + i*stride_data, size);
+    }
+    bool status = send_rpc_cmd(ctx->sock, RPC_CMD_SET_TENSOR_2D, input.data(), input.size());
+    RPC_STATUS_ASSERT(status);
+}
+
+static void ggml_backend_rpc_buffer_get_tensor_2d(ggml_backend_buffer_t buffer, const ggml_tensor * tensor, void * data,
+        size_t offset, size_t size, size_t n_copies, size_t stride_tensor, size_t stride_data) {
+    ggml_backend_rpc_buffer_context * ctx = (ggml_backend_rpc_buffer_context *)buffer->context;
+    rpc_msg_get_tensor_2d_req request;
+    request.tensor   = serialize_tensor(tensor);
+    request.offset   = offset;
+    request.size     = size;
+    request.n_copies = n_copies;
+    request.stride   = stride_tensor;
+    if (stride_data == size) {
+        bool status = send_rpc_cmd(ctx->sock, RPC_CMD_GET_TENSOR_2D, &request, sizeof(request), data, size*n_copies);
+        RPC_STATUS_ASSERT(status);
+    } else {
+        std::vector<uint8_t> packed(size*n_copies);
+        bool status = send_rpc_cmd(ctx->sock, RPC_CMD_GET_TENSOR_2D, &request, sizeof(request), packed.data(), packed.size());
+        RPC_STATUS_ASSERT(status);
+        for (size_t i = 0; i < n_copies; i++) {
+            memcpy((char *)data + i*stride_data, packed.data() + i*size, size);
+        }
+    }
+}
+
 static void ggml_backend_rpc_buffer_get_tensor(ggml_backend_buffer_t buffer, const ggml_tensor * tensor, void * data, size_t offset, size_t size) {
     ggml_backend_rpc_buffer_context * ctx = (ggml_backend_rpc_buffer_context *)buffer->context;
     rpc_msg_get_tensor_req request;
@@ -555,8 +657,8 @@ static ggml_backend_buffer_i ggml_backend_rpc_buffer_interface = {
     /* .memset_tensor   = */ ggml_backend_rpc_buffer_memset_tensor,
     /* .set_tensor      = */ ggml_backend_rpc_buffer_set_tensor,
     /* .get_tensor      = */ ggml_backend_rpc_buffer_get_tensor,
-    /* .set_tensor_2d   = */ NULL,
-    /* .get_tensor_2d   = */ NULL,
+    /* .set_tensor_2d   = */ ggml_backend_rpc_buffer_set_tensor_2d,
+    /* .get_tensor_2d   = */ ggml_backend_rpc_buffer_get_tensor_2d,
     /* .cpy_tensor      = */ ggml_backend_rpc_buffer_cpy_tensor,
     /* .clear           = */ ggml_backend_rpc_buffer_clear,
     /* .reset           = */ NULL,
@@ -698,13 +800,15 @@ static void serialize_graph(uint32_t device, const ggml_cgraph * cgraph, std::ve
         add_tensor(cgraph->nodes[i], tensors, visited);
     }
     // serialization format:
-    // | device (4 bytes) | n_nodes (4 bytes) | nodes (n_nodes * sizeof(uint64_t) | n_tensors (4 bytes) | tensors (n_tensors * sizeof(rpc_tensor)) |
+    // | device (4 bytes) | uid (8 bytes) | n_nodes (4 bytes) | nodes (n_nodes * sizeof(uint64_t) | n_tensors (4 bytes) | tensors (n_tensors * sizeof(rpc_tensor)) |
     uint32_t n_tensors = tensors.size();
-    int output_size = 2*sizeof(uint32_t) + n_nodes * sizeof(uint64_t) + sizeof(uint32_t) + n_tensors * sizeof(rpc_tensor);
+    int output_size = 2*sizeof(uint32_t) + sizeof(uint64_t) + n_nodes * sizeof(uint64_t) + sizeof(uint32_t) + n_tensors * sizeof(rpc_tensor);
     output.resize(output_size, 0);
     uint8_t * dest = output.data();
     memcpy(dest, &device, sizeof(device));
     dest += sizeof(device);
+    memcpy(dest, &cgraph->uid, sizeof(cgraph->uid));
+    dest += sizeof(cgraph->uid);
     memcpy(dest, &n_nodes, sizeof(n_nodes));
     dest += sizeof(n_nodes);
     for (uint32_t i = 0; i < n_nodes; i++) {
@@ -723,15 +827,22 @@ static enum ggml_status ggml_backend_rpc_graph_compute(ggml_backend_t backend, g
     ggml_backend_rpc_device_context * rpc_dev_ctx = (ggml_backend_rpc_device_context *)rpc_dev->context;
 
     GGML_ASSERT(cgraph->n_nodes > 0);
-    bool reuse = cgraph->uid != 0 && rpc_dev_ctx->last_graph_uid == cgraph->uid;
+    auto & graph_uids = rpc_dev_ctx->graph_uids;
+    bool reuse = cgraph->uid != 0 && graph_uids.count(cgraph->uid) > 0;
     if (reuse) {
         rpc_msg_graph_recompute_req request;
         request.device = rpc_ctx->device;
+        request.uid    = cgraph->uid;
         auto sock = get_socket(rpc_ctx->endpoint);
         bool status = send_rpc_cmd(sock, RPC_CMD_GRAPH_RECOMPUTE, &request, sizeof(request));
         RPC_STATUS_ASSERT(status);
     } else {
-        rpc_dev_ctx->last_graph_uid = cgraph->uid;
+        if (cgraph->uid != 0) {
+            if (graph_uids.size() >= GRAPH_CACHE_MAX) {
+                graph_uids.clear();
+            }
+            graph_uids.insert(cgraph->uid);
+        }
         std::vector<uint8_t> input;
         serialize_graph(rpc_ctx->device, cgraph, input);
         auto sock = get_socket(rpc_ctx->endpoint);
@@ -741,13 +852,25 @@ static enum ggml_status ggml_backend_rpc_graph_compute(ggml_backend_t backend, g
     return GGML_STATUS_SUCCESS;
 }
 
+static void ggml_backend_rpc_set_tensor_2d_async(ggml_backend_t backend, ggml_tensor * tensor, const void * data,
+        size_t offset, size_t size, size_t n_copies, size_t stride_tensor, size_t stride_data) {
+    ggml_backend_tensor_set_2d(tensor, data, offset, size, n_copies, stride_tensor, stride_data);
+    GGML_UNUSED(backend);
+}
+
+static void ggml_backend_rpc_get_tensor_2d_async(ggml_backend_t backend, const ggml_tensor * tensor, void * data,
+        size_t offset, size_t size, size_t n_copies, size_t stride_tensor, size_t stride_data) {
+    ggml_backend_tensor_get_2d(tensor, data, offset, size, n_copies, stride_tensor, stride_data);
+    GGML_UNUSED(backend);
+}
+
 static ggml_backend_i ggml_backend_rpc_interface = {
     /* .get_name                = */ ggml_backend_rpc_name,
     /* .free                    = */ ggml_backend_rpc_free,
     /* .set_tensor_async        = */ NULL,
     /* .get_tensor_async        = */ NULL,
-    /* .set_tensor_2d_async     = */ NULL,
-    /* .get_tensor_2d_async     = */ NULL,
+    /* .set_tensor_2d_async     = */ ggml_backend_rpc_set_tensor_2d_async,
+    /* .get_tensor_2d_async     = */ ggml_backend_rpc_get_tensor_2d_async,
     /* .cpy_tensor_async        = */ NULL,
     /* .synchronize             = */ ggml_backend_rpc_synchronize,
     /* .graph_plan_create       = */ NULL,
@@ -842,6 +965,7 @@ public:
     rpc_server(std::vector<ggml_backend_t> all_backends, const char * cache_dir)
         : backends(std::move(all_backends)), cache_dir(cache_dir) {
         stored_graphs.resize(backends.size());
+        comm_states.resize(backends.size());
     }
     ~rpc_server();
 
@@ -854,11 +978,16 @@ public:
     bool buffer_clear(const rpc_msg_buffer_clear_req & request);
     bool memset_tensor(const rpc_msg_memset_tensor_req & request);
     bool set_tensor(const std::vector<uint8_t> & input);
+    bool set_tensor_2d(const std::vector<uint8_t> & input);
     bool set_tensor_hash(const rpc_msg_set_tensor_hash_req & request, rpc_msg_set_tensor_hash_rsp & response);
     bool get_tensor(const rpc_msg_get_tensor_req & request, std::vector<uint8_t> & response);
+    bool get_tensor_2d(const rpc_msg_get_tensor_2d_req & request, std::vector<uint8_t> & response);
     bool copy_tensor(const rpc_msg_copy_tensor_req & request, rpc_msg_copy_tensor_rsp & response);
     bool graph_compute(const std::vector<uint8_t> & input);
     bool graph_recompute(const rpc_msg_graph_recompute_req & request);
+    bool comm_init(const rpc_msg_comm_init_req & request, rpc_msg_comm_init_rsp & response);
+    bool comm_allreduce(const rpc_msg_comm_allreduce_req & request);
+    bool comm_free(const rpc_msg_comm_free_req & request);
     bool init_tensor(const rpc_msg_init_tensor_req & request);
     bool get_alloc_size(const rpc_msg_get_alloc_size_req & request, rpc_msg_get_alloc_size_rsp & response);
     bool get_device_memory(const rpc_msg_get_device_memory_req & request, rpc_msg_get_device_memory_rsp & response);
@@ -869,6 +998,7 @@ public:
     };
 
 private:
+    void sync_all_backends();
     bool get_cached_file(uint64_t hash, std::vector<uint8_t> & data);
     ggml_tensor * deserialize_tensor(struct ggml_context * ctx, const rpc_tensor * tensor);
     ggml_tensor * create_node(uint64_t id,
@@ -877,11 +1007,23 @@ private:
                               std::unordered_map<uint64_t, struct ggml_tensor*> & tensor_map);
 
 
+    // pairwise allreduce over a direct connection to the peer server
+    struct comm_state {
+        socket_ptr              peer;
+        uint32_t                rank = 0;
+        uint32_t                world = 0;
+        ggml_backend_buffer_ptr scratch;
+        size_t                  scratch_size = 0;
+        std::vector<uint8_t>    send_buf;
+        std::vector<uint8_t>    recv_buf;
+    };
+
     std::vector<ggml_backend_t> backends;
     const char * cache_dir;
     std::unordered_set<ggml_backend_buffer_t> buffers;
-    // store the last computed graph for each backend
-    std::vector<stored_graph> stored_graphs;
+    // computed graphs cached per backend, keyed by uid
+    std::vector<std::unordered_map<uint64_t, stored_graph>> stored_graphs;
+    std::vector<comm_state> comm_states;
 };
 
 void rpc_server::hello(rpc_msg_hello_rsp & response) {
@@ -989,6 +1131,7 @@ bool rpc_server::buffer_get_base(const rpc_msg_buffer_get_base_req & request, rp
 }
 
 bool rpc_server::free_buffer(const rpc_msg_free_buffer_req & request) {
+    sync_all_backends();
     LOG_DBG("[%s] remote_ptr: %" PRIx64 "\n", __func__, request.remote_ptr);
     ggml_backend_buffer_t buffer = reinterpret_cast<ggml_backend_buffer_t>(request.remote_ptr);
     if (buffers.find(buffer) == buffers.end()) {
@@ -1001,6 +1144,7 @@ bool rpc_server::free_buffer(const rpc_msg_free_buffer_req & request) {
 }
 
 bool rpc_server::buffer_clear(const rpc_msg_buffer_clear_req & request) {
+    sync_all_backends();
     LOG_DBG("[%s] remote_ptr: %" PRIx64 ", value: %u\n", __func__, request.remote_ptr, request.value);
     ggml_backend_buffer_t buffer = reinterpret_cast<ggml_backend_buffer_t>(request.remote_ptr);
     if (buffers.find(buffer) == buffers.end()) {
@@ -1012,6 +1156,7 @@ bool rpc_server::buffer_clear(const rpc_msg_buffer_clear_req & request) {
 }
 
 bool rpc_server::memset_tensor(const rpc_msg_memset_tensor_req & request) {
+    sync_all_backends();
     struct ggml_init_params params {
         /*.mem_size   =*/ ggml_tensor_overhead(),
         /*.mem_buffer =*/ NULL,
@@ -1087,13 +1232,20 @@ ggml_tensor * rpc_server::deserialize_tensor(struct ggml_context * ctx, const rp
         result->buffer = nullptr;
     }
 
-    if (result->buffer) {
+    if (result->buffer && ggml_nelements(result) > 0) {
         // require that the tensor data does not go beyond the buffer end
         uint64_t tensor_size = (uint64_t) ggml_nbytes(result);
         uint64_t buffer_start = (uint64_t) ggml_backend_buffer_get_base(result->buffer);
         uint64_t buffer_size = (uint64_t) ggml_backend_buffer_get_size(result->buffer);
-        GGML_ASSERT(tensor->data + tensor_size >= tensor->data); // check for overflow
-        GGML_ASSERT(tensor->data >= buffer_start && tensor->data + tensor_size <= buffer_start + buffer_size);
+        if (tensor->data + tensor_size < tensor->data ||
+            tensor->data < buffer_start || tensor->data + tensor_size > buffer_start + buffer_size) {
+            GGML_LOG_ERROR("[%s] tensor '%s' (op %s, type %s, ne [%" PRId64 ", %" PRId64 ", %" PRId64 ", %" PRId64 "]) "
+                           "data [0x%" PRIx64 ", 0x%" PRIx64 ") out of buffer bounds [0x%" PRIx64 ", 0x%" PRIx64 ")\n",
+                           __func__, tensor->name, ggml_op_name((ggml_op) tensor->op), ggml_type_name(result->type),
+                           result->ne[0], result->ne[1], result->ne[2], result->ne[3],
+                           tensor->data, tensor->data + tensor_size, buffer_start, buffer_start + buffer_size);
+            return nullptr;
+        }
     }
 
     result->op = (ggml_op) tensor->op;
@@ -1108,6 +1260,7 @@ ggml_tensor * rpc_server::deserialize_tensor(struct ggml_context * ctx, const rp
 
 
 bool rpc_server::set_tensor(const std::vector<uint8_t> & input) {
+    sync_all_backends();
     // serialization format: | rpc_tensor | offset (8 bytes) | data (size bytes) |
     if (input.size() < sizeof(rpc_tensor) + sizeof(uint64_t)) {
         return false;
@@ -1159,6 +1312,67 @@ bool rpc_server::set_tensor(const std::vector<uint8_t> & input) {
     return true;
 }
 
+bool rpc_server::set_tensor_2d(const std::vector<uint8_t> & input) {
+    sync_all_backends();
+    // serialization format: | rpc_tensor | offset (8 bytes) | size (8 bytes) | n_copies (8 bytes) | stride (8 bytes) | data (size * n_copies bytes) |
+    if (input.size() < sizeof(rpc_tensor) + 4*sizeof(uint64_t)) {
+        return false;
+    }
+    const rpc_tensor * in_tensor = (const rpc_tensor *)input.data();
+    uint64_t header[4];
+    memcpy(header, input.data() + sizeof(rpc_tensor), sizeof(header));
+    const uint64_t offset   = header[0];
+    const uint64_t size     = header[1];
+    const uint64_t n_copies = header[2];
+    const uint64_t stride   = header[3];
+
+    const uint64_t data_size = input.size() - sizeof(rpc_tensor) - 4*sizeof(uint64_t);
+    if (n_copies == 0 || size == 0 || size > data_size / n_copies || size * n_copies != data_size) {
+        return false;
+    }
+
+    struct ggml_init_params params {
+        /*.mem_size   =*/ ggml_tensor_overhead(),
+        /*.mem_buffer =*/ NULL,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context_ptr ctx_ptr { ggml_init(params) };
+    GGML_ASSERT(ctx_ptr != nullptr);
+    ggml_context * ctx = ctx_ptr.get();
+    ggml_tensor * tensor = deserialize_tensor(ctx, in_tensor);
+    if (tensor == nullptr || tensor->buffer == nullptr) {
+        GGML_LOG_ERROR("[%s] error deserializing tensor\n", __func__);
+        return false;
+    }
+    LOG_DBG("[%s] buffer: %p, data: %p, offset: %" PRIu64 ", size: %" PRIu64 ", n_copies: %" PRIu64 ", stride: %" PRIu64 "\n",
+            __func__, (void*)tensor->buffer, tensor->data, offset, size, n_copies, stride);
+
+    // sanitize tensor->data
+    {
+        if (stride != 0 && n_copies - 1 > (UINT64_MAX - size) / stride) {
+            return false;
+        }
+        const uint64_t span = (n_copies - 1)*stride + size;
+        const uint64_t p0 = (uint64_t) ggml_backend_buffer_get_base(tensor->buffer);
+        const uint64_t p1 = p0 + ggml_backend_buffer_get_size(tensor->buffer);
+
+        if (in_tensor->data < p0 || in_tensor->data > p1 || offset > p1 - in_tensor->data || span > p1 - in_tensor->data - offset) {
+            GGML_LOG_ERROR("[%s] tensor data region (data=0x%" PRIx64 ", offset=%" PRIu64 ", span=%" PRIu64 ") out of buffer bounds [0x%" PRIx64 ", 0x%" PRIx64 ")\n",
+                           __func__, in_tensor->data, offset, span, p0, p1);
+            return false;
+        }
+        if (offset > ggml_nbytes(tensor) || span > ggml_nbytes(tensor) - offset) {
+            GGML_LOG_ERROR("[%s] tensor write region (offset=%" PRIu64 ", span=%" PRIu64 ") out of tensor bounds (%zu)\n",
+                           __func__, offset, span, ggml_nbytes(tensor));
+            return false;
+        }
+    }
+
+    const void * data = input.data() + sizeof(rpc_tensor) + 4*sizeof(uint64_t);
+    ggml_backend_tensor_set_2d(tensor, data, offset, size, n_copies, stride, size);
+    return true;
+}
+
 bool rpc_server::get_cached_file(uint64_t hash, std::vector<uint8_t> & data) {
     if (!cache_dir) {
         return false;
@@ -1181,6 +1395,7 @@ bool rpc_server::get_cached_file(uint64_t hash, std::vector<uint8_t> & data) {
 
 bool rpc_server::set_tensor_hash(const rpc_msg_set_tensor_hash_req & request, rpc_msg_set_tensor_hash_rsp & response)
 {
+    sync_all_backends();
     std::vector<uint8_t> cached_file;
     if (!get_cached_file(request.hash, cached_file)) {
         response.result = 0;
@@ -1222,6 +1437,7 @@ bool rpc_server::set_tensor_hash(const rpc_msg_set_tensor_hash_req & request, rp
 }
 
 bool rpc_server::init_tensor(const rpc_msg_init_tensor_req & request) {
+    sync_all_backends();
     struct ggml_init_params params {
         /*.mem_size   =*/ ggml_tensor_overhead(),
         /*.mem_buffer =*/ NULL,
@@ -1257,6 +1473,7 @@ bool rpc_server::init_tensor(const rpc_msg_init_tensor_req & request) {
 }
 
 bool rpc_server::get_tensor(const rpc_msg_get_tensor_req & request, std::vector<uint8_t> & response) {
+    sync_all_backends();
     struct ggml_init_params params {
         /*.mem_size   =*/ ggml_tensor_overhead(),
         /*.mem_buffer =*/ NULL,
@@ -1291,7 +1508,56 @@ bool rpc_server::get_tensor(const rpc_msg_get_tensor_req & request, std::vector<
     return true;
 }
 
+bool rpc_server::get_tensor_2d(const rpc_msg_get_tensor_2d_req & request, std::vector<uint8_t> & response) {
+    sync_all_backends();
+    struct ggml_init_params params {
+        /*.mem_size   =*/ ggml_tensor_overhead(),
+        /*.mem_buffer =*/ NULL,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context_ptr ctx_ptr { ggml_init(params) };
+    GGML_ASSERT(ctx_ptr != nullptr);
+    ggml_context * ctx = ctx_ptr.get();
+    ggml_tensor * tensor = deserialize_tensor(ctx, &request.tensor);
+    if (tensor == nullptr || tensor->buffer == nullptr) {
+        GGML_LOG_ERROR("[%s] error deserializing tensor\n", __func__);
+        return false;
+    }
+    LOG_DBG("[%s] buffer: %p, data: %p, offset: %" PRIu64 ", size: %" PRIu64 ", n_copies: %" PRIu64 ", stride: %" PRIu64 "\n",
+            __func__, (void*)tensor->buffer, tensor->data, request.offset, request.size, request.n_copies, request.stride);
+
+    // sanitize tensor->data
+    {
+        if (request.n_copies == 0 || request.size == 0 || request.size > UINT64_MAX / request.n_copies) {
+            return false;
+        }
+        if (request.stride != 0 && request.n_copies - 1 > (UINT64_MAX - request.size) / request.stride) {
+            return false;
+        }
+        const uint64_t span = (request.n_copies - 1)*request.stride + request.size;
+        const uint64_t p0 = (uint64_t) ggml_backend_buffer_get_base(tensor->buffer);
+        const uint64_t p1 = p0 + ggml_backend_buffer_get_size(tensor->buffer);
+
+        if (request.tensor.data < p0 || request.tensor.data > p1 || request.offset > p1 - request.tensor.data ||
+                span > p1 - request.tensor.data - request.offset) {
+            GGML_LOG_ERROR("[%s] tensor data region (data=0x%" PRIx64 ", offset=%" PRIu64 ", span=%" PRIu64 ") out of buffer bounds [0x%" PRIx64 ", 0x%" PRIx64 ")\n",
+                           __func__, request.tensor.data, request.offset, span, p0, p1);
+            return false;
+        }
+        if (request.offset > ggml_nbytes(tensor) || span > ggml_nbytes(tensor) - request.offset) {
+            GGML_LOG_ERROR("[%s] tensor read region (offset=%" PRIu64 ", span=%" PRIu64 ") out of tensor bounds (%zu)\n",
+                           __func__, request.offset, span, ggml_nbytes(tensor));
+            return false;
+        }
+    }
+
+    response.resize(request.size * request.n_copies, 0);
+    ggml_backend_tensor_get_2d(tensor, response.data(), request.offset, request.size, request.n_copies, request.stride, request.size);
+    return true;
+}
+
 bool rpc_server::copy_tensor(const rpc_msg_copy_tensor_req & request, rpc_msg_copy_tensor_rsp & response) {
+    sync_all_backends();
     struct ggml_init_params params {
         /*.mem_size   =*/ 2*ggml_tensor_overhead(),
         /*.mem_buffer =*/ NULL,
@@ -1390,8 +1656,8 @@ ggml_tensor * rpc_server::create_node(uint64_t id,
 
 bool rpc_server::graph_compute(const std::vector<uint8_t> & input) {
     // serialization format:
-    // | device (4 bytes) | n_nodes (4 bytes) | nodes (n_nodes * sizeof(uint64_t) | n_tensors (4 bytes) | tensors (n_tensors * sizeof(rpc_tensor)) |
-    if (input.size() < 2*sizeof(uint32_t)) {
+    // | device (4 bytes) | uid (8 bytes) | n_nodes (4 bytes) | nodes (n_nodes * sizeof(uint64_t) | n_tensors (4 bytes) | tensors (n_tensors * sizeof(rpc_tensor)) |
+    if (input.size() < 2*sizeof(uint32_t) + sizeof(uint64_t)) {
         return false;
     }
     const uint8_t * src = input.data();
@@ -1401,10 +1667,13 @@ bool rpc_server::graph_compute(const std::vector<uint8_t> & input) {
     if (device >= backends.size()) {
         return false;
     }
+    uint64_t uid;
+    memcpy(&uid, src, sizeof(uid));
+    src += sizeof(uid);
     uint32_t n_nodes;
     memcpy(&n_nodes, src, sizeof(n_nodes));
     src += sizeof(n_nodes);
-    if (input.size() < 2*sizeof(uint32_t) + n_nodes*sizeof(uint64_t) + sizeof(uint32_t)) {
+    if (input.size() < 2*sizeof(uint32_t) + sizeof(uint64_t) + n_nodes*sizeof(uint64_t) + sizeof(uint32_t)) {
         return false;
     }
     const uint64_t * nodes = (const uint64_t *)src;
@@ -1412,19 +1681,26 @@ bool rpc_server::graph_compute(const std::vector<uint8_t> & input) {
     uint32_t n_tensors;
     memcpy(&n_tensors, src, sizeof(n_tensors));
     src += sizeof(n_tensors);
-    if (input.size() < 2*sizeof(uint32_t) + n_nodes*sizeof(uint64_t) + sizeof(uint32_t) + n_tensors*sizeof(rpc_tensor)) {
+    if (input.size() < 2*sizeof(uint32_t) + sizeof(uint64_t) + n_nodes*sizeof(uint64_t) + sizeof(uint32_t) + n_tensors*sizeof(rpc_tensor)) {
         return false;
     }
     const rpc_tensor * tensors = (const rpc_tensor *)src;
-    LOG_DBG("[%s] device: %u, n_nodes: %u, n_tensors: %u\n", __func__, device, n_nodes, n_tensors);
+    LOG_DBG("[%s] device: %u, uid: %" PRIu64 ", n_nodes: %u, n_tensors: %u\n", __func__, device, uid, n_nodes, n_tensors);
+
+    // graphs with uid == 0 are not cached, see GRAPH_CACHE_MAX for the eviction policy
+    if (uid != 0 && stored_graphs[device].size() >= GRAPH_CACHE_MAX) {
+        stored_graphs[device].clear();
+    }
+    stored_graph sg_tmp;
+    stored_graph & sg = uid != 0 ? stored_graphs[device][uid] : sg_tmp;
 
     size_t buf_size = ggml_tensor_overhead()*(n_nodes + n_tensors) + ggml_graph_overhead_custom(n_nodes, false);
-    if (stored_graphs[device].buffer.size() < buf_size) {
-        stored_graphs[device].buffer.resize(buf_size);
+    if (sg.buffer.size() < buf_size) {
+        sg.buffer.resize(buf_size);
     }
     struct ggml_init_params params = {
         /*.mem_size   =*/ buf_size,
-        /*.mem_buffer =*/ stored_graphs[device].buffer.data(),
+        /*.mem_buffer =*/ sg.buffer.data(),
         /*.no_alloc   =*/ true,
     };
     ggml_context_ptr ctx_ptr { ggml_init(params) };
@@ -1452,9 +1728,9 @@ bool rpc_server::graph_compute(const std::vector<uint8_t> & input) {
             return false;
         }
     }
-    ggml_status status = ggml_backend_graph_compute(backends[device], graph);
+    ggml_status status = ggml_backend_graph_compute_async(backends[device], graph);
     GGML_ASSERT(status == GGML_STATUS_SUCCESS && "Unsuccessful graph computations are not supported with RPC");
-    stored_graphs[device].graph = graph;
+    sg.graph = graph;
     return true;
 }
 
@@ -1463,13 +1739,213 @@ bool rpc_server::graph_recompute(const rpc_msg_graph_recompute_req & request) {
     if (device >= backends.size()) {
         return false;
     }
-    if (stored_graphs[device].graph == nullptr) {
+    auto it = stored_graphs[device].find(request.uid);
+    if (it == stored_graphs[device].end() || it->second.graph == nullptr) {
+        GGML_LOG_ERROR("[%s] device: %u, graph with uid %" PRIu64 " not found\n", __func__, device, request.uid);
         return false;
     }
-    ggml_cgraph * graph = stored_graphs[device].graph;
-    LOG_DBG("[%s] device: %u\n", __func__, device);
-    ggml_status status = ggml_backend_graph_compute(backends[device], graph);
+    ggml_cgraph * graph = it->second.graph;
+    LOG_DBG("[%s] device: %u, uid: %" PRIu64 "\n", __func__, device, request.uid);
+    ggml_status status = ggml_backend_graph_compute_async(backends[device], graph);
     GGML_ASSERT(status == GGML_STATUS_SUCCESS && "Unsuccessful graph computations are not supported with RPC");
+    return true;
+}
+
+// graph compute is asynchronous; commands that read or write buffer data synchronize first
+void rpc_server::sync_all_backends() {
+    for (ggml_backend_t backend : backends) {
+        ggml_backend_synchronize(backend);
+    }
+}
+
+// The comm link between two servers uses the same caps negotiation as the client HELLO,
+// so it gets the same transport upgrades (e.g. RDMA).
+bool rpc_server::comm_init(const rpc_msg_comm_init_req & request, rpc_msg_comm_init_rsp & response) {
+    response.ok = 0;
+    if (request.device >= backends.size() || request.world != 2 || request.rank >= request.world) {
+        return true;
+    }
+    comm_state & state = comm_states[request.device];
+    if (state.peer != nullptr) {
+        response.ok = 1;
+        return true;
+    }
+    uint8_t local_caps[RPC_CONN_CAPS_SIZE] = {};
+    uint8_t remote_caps[RPC_CONN_CAPS_SIZE] = {};
+    if (request.rank == 0) {
+        socket_ptr srv = socket_t::create_server("0.0.0.0", request.port);
+        if (srv == nullptr) {
+            GGML_LOG_ERROR("[%s] failed to listen on comm port %u\n", __func__, request.port);
+            return true;
+        }
+        state.peer = srv->accept();
+        if (state.peer == nullptr) {
+            return true;
+        }
+        if (!state.peer->recv_data(remote_caps, sizeof(remote_caps))) {
+            state.peer = nullptr;
+            return true;
+        }
+        state.peer->get_caps(local_caps);
+        if (!state.peer->send_data(local_caps, sizeof(local_caps))) {
+            state.peer = nullptr;
+            return true;
+        }
+        state.peer->update_caps(remote_caps);
+    } else {
+        const std::string host(request.host, strnlen(request.host, sizeof(request.host)));
+        // rank 0 may not be listening yet, retry for a few seconds
+        for (int i = 0; i < 100 && state.peer == nullptr; i++) {
+            state.peer = socket_t::connect(host.c_str(), request.port);
+            if (state.peer == nullptr) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            }
+        }
+        if (state.peer == nullptr) {
+            GGML_LOG_ERROR("[%s] failed to connect to peer %s:%u\n", __func__, host.c_str(), request.port);
+            return true;
+        }
+        state.peer->get_caps(local_caps);
+        if (!state.peer->send_data(local_caps, sizeof(local_caps)) ||
+            !state.peer->recv_data(remote_caps, sizeof(remote_caps))) {
+            state.peer = nullptr;
+            return true;
+        }
+        state.peer->update_caps(remote_caps);
+    }
+    state.rank  = request.rank;
+    state.world = request.world;
+    GGML_LOG_INFO("[%s] device %u joined pairwise comm as rank %u\n", __func__, request.device, request.rank);
+    response.ok = 1;
+    return true;
+}
+
+bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
+    if (request.device >= backends.size()) {
+        return false;
+    }
+    comm_state & state = comm_states[request.device];
+    if (state.peer == nullptr) {
+        GGML_LOG_ERROR("[%s] no communicator for device %u\n", __func__, request.device);
+        return false;
+    }
+    ggml_backend_t backend = backends[request.device];
+
+    size_t ctx_size = 16*ggml_tensor_overhead() + 2*ggml_graph_overhead_custom(8, false);
+    struct ggml_init_params params = {
+        /*.mem_size   =*/ ctx_size,
+        /*.mem_buffer =*/ NULL,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context_ptr ctx_ptr { ggml_init(params) };
+    GGML_ASSERT(ctx_ptr != nullptr);
+    ggml_context * ctx = ctx_ptr.get();
+    ggml_tensor * t_dst = deserialize_tensor(ctx, &request.tensor);
+    if (t_dst == nullptr || t_dst->buffer == nullptr) {
+        GGML_LOG_ERROR("[%s] error deserializing tensor\n", __func__);
+        return false;
+    }
+    const size_t  nbytes = ggml_nbytes(t_dst);
+    const int64_t ne     = ggml_nelements(t_dst);
+    if (nbytes == 0) {
+        return true;
+    }
+    // reduce large partials in bf16 to halve the wire bytes; small (decode-sized) ones
+    // stay f32 since the extra casts and sync cost more than the bytes saved
+    const bool   wire_bf16  = t_dst->type == GGML_TYPE_F32 && ne >= 32768;
+    const size_t wire_bytes = wire_bf16 ? (size_t) ne*2 : nbytes;
+    const size_t need       = wire_bf16 ? 2*nbytes : nbytes;
+    if (state.scratch_size < need) {
+        state.scratch.reset(ggml_backend_alloc_buffer(backend, need));
+        state.scratch_size = need;
+    }
+    char * scratch_base = (char *) ggml_backend_buffer_get_base(state.scratch.get());
+    state.send_buf.resize(wire_bytes);
+    state.recv_buf.resize(wire_bytes);
+
+    auto new_scratch_tensor = [&](ggml_type type, size_t offset) {
+        ggml_tensor * t = ggml_new_tensor_4d(ctx, type, t_dst->ne[0], t_dst->ne[1], t_dst->ne[2], t_dst->ne[3]);
+        t->buffer = state.scratch.get();
+        t->data   = scratch_base + offset;
+        return t;
+    };
+    auto new_cpy_node = [&](ggml_tensor * src, ggml_tensor * dst) {
+        ggml_tensor * t = ggml_new_tensor_4d(ctx, dst->type, dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
+        t->op     = GGML_OP_CPY;
+        t->src[0] = src;
+        t->src[1] = dst;
+        t->buffer = dst->buffer;
+        t->data   = dst->data;
+        t->flags |= GGML_TENSOR_FLAG_COMPUTE;
+        return t;
+    };
+    auto compute_nodes = [&](ggml_tensor * n0, ggml_tensor * n1) {
+        ggml_cgraph * graph = ggml_new_graph_custom(ctx, 2, false);
+        graph->nodes[0] = n0;
+        graph->nodes[1] = n1;
+        graph->n_nodes  = n1 != nullptr ? 2 : 1;
+        ggml_status status = ggml_backend_graph_compute_async(backend, graph);
+        GGML_ASSERT(status == GGML_STATUS_SUCCESS && "Unsuccessful graph computations are not supported with RPC");
+    };
+
+    // wait for the pending subgraph that produced this partial
+    ggml_backend_synchronize(backend);
+
+    ggml_tensor * t_wire_send = nullptr;
+    ggml_tensor * t_wire_recv = nullptr;
+    if (wire_bf16) {
+        t_wire_send = new_scratch_tensor(GGML_TYPE_BF16, 0);
+        t_wire_recv = new_scratch_tensor(GGML_TYPE_BF16, ne*2);
+        compute_nodes(new_cpy_node(t_dst, t_wire_send), nullptr);
+        ggml_backend_synchronize(backend);
+        ggml_backend_tensor_get(t_wire_send, state.send_buf.data(), 0, wire_bytes);
+    } else {
+        ggml_backend_tensor_get(t_dst, state.send_buf.data(), 0, wire_bytes);
+    }
+
+    // rank 0 sends first, rank 1 receives first, so large payloads cannot deadlock
+    if (state.rank == 0) {
+        if (!state.peer->send_data(state.send_buf.data(), wire_bytes) ||
+            !state.peer->recv_data(state.recv_buf.data(), wire_bytes)) {
+            return false;
+        }
+    } else {
+        if (!state.peer->recv_data(state.recv_buf.data(), wire_bytes) ||
+            !state.peer->send_data(state.send_buf.data(), wire_bytes)) {
+            return false;
+        }
+    }
+
+    ggml_tensor * t_peer = new_scratch_tensor(t_dst->type, wire_bf16 ? (size_t) ne*4 : 0);
+    ggml_tensor * t_cast = nullptr;
+    if (wire_bf16) {
+        ggml_backend_tensor_set(t_wire_recv, state.recv_buf.data(), 0, wire_bytes);
+        t_cast = new_cpy_node(t_wire_recv, t_peer);
+    } else {
+        ggml_backend_tensor_set(t_peer, state.recv_buf.data(), 0, wire_bytes);
+    }
+
+    ggml_tensor * t_red = ggml_new_tensor_4d(ctx, t_dst->type, t_dst->ne[0], t_dst->ne[1], t_dst->ne[2], t_dst->ne[3]);
+    t_red->op     = GGML_OP_ADD;
+    t_red->src[0] = t_dst;
+    t_red->src[1] = t_peer;
+    t_red->buffer = t_dst->buffer;
+    t_red->data   = t_dst->data;
+    t_red->flags |= GGML_TENSOR_FLAG_COMPUTE;
+
+    if (t_cast != nullptr) {
+        compute_nodes(t_cast, t_red);
+    } else {
+        compute_nodes(t_red, nullptr);
+    }
+    return true;
+}
+
+bool rpc_server::comm_free(const rpc_msg_comm_free_req & request) {
+    if (request.device >= backends.size()) {
+        return false;
+    }
+    comm_states[request.device] = comm_state();
     return true;
 }
 
@@ -1676,6 +2152,30 @@ static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const
                 }
                 break;
             }
+            case RPC_CMD_SET_TENSOR_2D: {
+                std::vector<uint8_t> input;
+                if (!recv_msg(sock, input)) {
+                    return;
+                }
+                if (!server.set_tensor_2d(input)) {
+                    return;
+                }
+                break;
+            }
+            case RPC_CMD_GET_TENSOR_2D: {
+                rpc_msg_get_tensor_2d_req request;
+                if (!recv_msg(sock, &request, sizeof(request))) {
+                    return;
+                }
+                std::vector<uint8_t> response;
+                if (!server.get_tensor_2d(request, response)) {
+                    return;
+                }
+                if (!send_msg(sock, response.data(), response.size())) {
+                    return;
+                }
+                break;
+            }
             case RPC_CMD_SET_TENSOR_HASH: {
                 rpc_msg_set_tensor_hash_req request;
                 if (!recv_msg(sock, &request, sizeof(request))) {
@@ -1747,6 +2247,40 @@ static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const
                     return;
                 }
                 if (!server.graph_recompute(request)) {
+                    return;
+                }
+                break;
+            }
+            case RPC_CMD_COMM_INIT: {
+                rpc_msg_comm_init_req request;
+                if (!recv_msg(sock, &request, sizeof(request))) {
+                    return;
+                }
+                rpc_msg_comm_init_rsp response;
+                if (!server.comm_init(request, response)) {
+                    return;
+                }
+                if (!send_msg(sock, &response, sizeof(response))) {
+                    return;
+                }
+                break;
+            }
+            case RPC_CMD_COMM_ALLREDUCE: {
+                rpc_msg_comm_allreduce_req request;
+                if (!recv_msg(sock, &request, sizeof(request))) {
+                    return;
+                }
+                if (!server.comm_allreduce(request)) {
+                    return;
+                }
+                break;
+            }
+            case RPC_CMD_COMM_FREE: {
+                rpc_msg_comm_free_req request;
+                if (!recv_msg(sock, &request, sizeof(request))) {
+                    return;
+                }
+                if (!server.comm_free(request)) {
                     return;
                 }
                 break;
@@ -1961,12 +2495,154 @@ static ggml_backend_dev_t ggml_backend_rpc_reg_get_device(ggml_backend_reg_t reg
     }
 }
 
+// Pairwise allreduce between two RPC servers over a direct server-to-server connection.
+// The client only sends fire-and-forget COMM_ALLREDUCE commands; the tensor data is
+// exchanged between the servers and never passes through the client.
+struct ggml_backend_rpc_comm_context {
+    struct rank_info {
+        std::string endpoint;
+        uint32_t    device;
+    };
+    std::vector<rank_info> ranks;
+};
+
+static void ggml_backend_rpc_comm_free(void * comm_ctx_v) {
+    ggml_backend_rpc_comm_context * comm_ctx = (ggml_backend_rpc_comm_context *) comm_ctx_v;
+    if (comm_ctx == nullptr) {
+        return;
+    }
+    for (const auto & rank : comm_ctx->ranks) {
+        rpc_msg_comm_free_req request = {rank.device};
+        auto sock = get_socket(rank.endpoint);
+        if (sock != nullptr) {
+            send_rpc_cmd(sock, RPC_CMD_COMM_FREE, &request, sizeof(request));
+        }
+    }
+    delete comm_ctx;
+}
+
+static void * ggml_backend_rpc_comm_init(ggml_backend_t * backends, size_t n_backends) {
+    if (n_backends != 2 || std::getenv("GGML_RPC_NO_COMM") != nullptr) {
+        return nullptr;
+    }
+    std::vector<ggml_backend_rpc_comm_context::rank_info> ranks;
+    ranks.reserve(n_backends);
+    for (size_t i = 0; i < n_backends; i++) {
+        if (!ggml_backend_is_rpc(backends[i])) {
+            return nullptr;
+        }
+        ggml_backend_rpc_context * rpc_ctx = (ggml_backend_rpc_context *) backends[i]->context;
+        // one rank per endpoint: a server processes its socket sequentially, so a second
+        // COMM_INIT on the same connection would deadlock behind the first
+        for (const auto & rank : ranks) {
+            if (rank.endpoint == rpc_ctx->endpoint) {
+                GGML_LOG_WARN("%s: multiple ranks on endpoint %s are not supported\n", __func__, rpc_ctx->endpoint.c_str());
+                return nullptr;
+            }
+        }
+        if (rpc_server_minor_version(rpc_ctx->endpoint) < 1) {
+            GGML_LOG_WARN("%s: server %s does not support collectives\n", __func__, rpc_ctx->endpoint.c_str());
+            return nullptr;
+        }
+        ranks.push_back({rpc_ctx->endpoint, rpc_ctx->device});
+    }
+
+    // rank 1 connects to rank 0 on its serving host; endpoints must be mutually reachable
+    // (e.g. do not bind the servers to 127.0.0.1 when they run on different machines)
+    std::string host0;
+    int port0;
+    if (!parse_endpoint(ranks[0].endpoint, host0, port0)) {
+        return nullptr;
+    }
+    const uint32_t comm_port = (uint32_t) port0 + 1000;
+    if (host0.size() >= 64) {
+        return nullptr;
+    }
+
+    // Send all init requests before reading any response: rank 0 blocks in accept
+    // until rank 1 has connected.
+    for (size_t i = 0; i < n_backends; i++) {
+        rpc_msg_comm_init_req request = {};
+        request.device = ranks[i].device;
+        request.rank   = (uint32_t) i;
+        request.world  = (uint32_t) n_backends;
+        request.port   = comm_port;
+        if (i > 0) {
+            memcpy(request.host, host0.c_str(), host0.size());
+        }
+        auto sock = get_socket(ranks[i].endpoint);
+        if (sock == nullptr || !send_rpc_cmd(sock, RPC_CMD_COMM_INIT, &request, sizeof(request))) {
+            return nullptr;
+        }
+    }
+    bool ok = true;
+    for (size_t i = 0; i < n_backends; i++) {
+        auto sock = get_socket(ranks[i].endpoint);
+        rpc_msg_comm_init_rsp response = {};
+        uint64_t rsp_size = 0;
+        if (sock == nullptr || !sock->recv_data(&rsp_size, sizeof(rsp_size)) || rsp_size != sizeof(response) ||
+                !sock->recv_data(&response, sizeof(response)) || !response.ok) {
+            GGML_LOG_WARN("%s: rank %zu (%s) failed to initialize\n", __func__, i, ranks[i].endpoint.c_str());
+            ok = false;
+        }
+    }
+    if (!ok) {
+        return nullptr;
+    }
+    GGML_LOG_INFO("%s: pairwise communicator initialized (%s <-> %s)\n", __func__,
+                  ranks[0].endpoint.c_str(), ranks[1].endpoint.c_str());
+    return new ggml_backend_rpc_comm_context{std::move(ranks)};
+}
+
+static bool ggml_backend_rpc_comm_allreduce_tensor(void * comm_ctx_v, ggml_tensor ** tensors) {
+    ggml_backend_rpc_comm_context * comm_ctx = (ggml_backend_rpc_comm_context *) comm_ctx_v;
+    if (comm_ctx == nullptr) {
+        return false;
+    }
+    const size_t n_ranks = comm_ctx->ranks.size();
+    const int64_t ne = ggml_nelements(tensors[0]);
+    if (ne == 0) {
+        return true;
+    }
+    for (size_t i = 0; i < n_ranks; i++) {
+        if (tensors[i] == nullptr || tensors[i]->type != GGML_TYPE_F32 || ggml_nelements(tensors[i]) != ne ||
+                !ggml_is_contiguously_allocated(tensors[i]) ||
+                tensors[i]->buffer == nullptr || !ggml_backend_buffer_is_rpc(tensors[i]->buffer)) {
+            return false;
+        }
+        // a rank with a disabled node has garbage in its partial and must contribute zeros,
+        // which only the fallback path handles
+        if ((tensors[i]->flags & GGML_TENSOR_FLAG_COMPUTE) == 0) {
+            return false;
+        }
+    }
+    for (size_t i = 0; i < n_ranks; i++) {
+        rpc_msg_comm_allreduce_req request;
+        request.device = comm_ctx->ranks[i].device;
+        request.tensor = serialize_tensor(tensors[i]);
+        auto sock = get_socket(comm_ctx->ranks[i].endpoint);
+        if (sock == nullptr || !send_rpc_cmd(sock, RPC_CMD_COMM_ALLREDUCE, &request, sizeof(request))) {
+            return false;
+        }
+    }
+    return true;
+}
+
 static void * ggml_backend_rpc_get_proc_address(ggml_backend_reg_t reg, const char * name) {
     if (std::strcmp(name, "ggml_backend_rpc_add_server") == 0) {
         return (void *)ggml_backend_rpc_add_server;
     }
     if (std::strcmp(name, "ggml_backend_rpc_start_server") == 0) {
         return (void *)ggml_backend_rpc_start_server;
+    }
+    if (std::strcmp(name, "ggml_backend_comm_init") == 0) {
+        return (void *)ggml_backend_rpc_comm_init;
+    }
+    if (std::strcmp(name, "ggml_backend_comm_free") == 0) {
+        return (void *)ggml_backend_rpc_comm_free;
+    }
+    if (std::strcmp(name, "ggml_backend_comm_allreduce_tensor") == 0) {
+        return (void *)ggml_backend_rpc_comm_allreduce_tensor;
     }
     return NULL;
 
@@ -2031,7 +2707,7 @@ ggml_backend_reg_t ggml_backend_rpc_add_server(const char * endpoint) {
             /* .device      = */    ind,
             /* .name        = */    dev_name,
             /* .description = */    dev_desc,
-            /* .last_graph_uid = */ 0,
+            /* .graph_uids  = */    {},
         };
 
         ggml_backend_dev_t dev = new ggml_backend_device {

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -237,6 +237,7 @@ struct rpc_msg_comm_init_req {
     uint32_t port;      // rank 0: port to listen on; rank > 0: rank 0's comm port
     char     host[64];  // rank > 0: rank 0's host
     uint8_t  session_id[RPC_COMM_SESSION_ID_SIZE];
+    uint8_t  wire_bf16;
 };
 
 struct rpc_msg_comm_init_rsp {
@@ -1082,6 +1083,7 @@ private:
         socket_ptr              peer;
         uint32_t                rank = 0;
         uint32_t                world = 0;
+        bool                    wire_bf16 = true;
         uint64_t                next_op_id = 0;
         ggml_backend_buffer_ptr scratch;
         size_t                  scratch_size = 0;
@@ -1861,7 +1863,7 @@ void rpc_server::sync_all_backends() {
 bool rpc_server::comm_init(const rpc_msg_comm_init_req & request, rpc_msg_comm_init_rsp & response) {
     response.ok = 0;
     if (request.device >= backends.size() || request.world != 2 || request.rank >= request.world ||
-            request.port == 0 || request.port > UINT16_MAX) {
+            request.port == 0 || request.port > UINT16_MAX || request.wire_bf16 > 1) {
         return true;
     }
     comm_state & state = comm_states[request.device];
@@ -1962,8 +1964,9 @@ bool rpc_server::comm_init(const rpc_msg_comm_init_req & request, rpc_msg_comm_i
         }
         state.peer->update_caps(remote_caps);
     }
-    state.rank  = request.rank;
-    state.world = request.world;
+    state.rank        = request.rank;
+    state.world       = request.world;
+    state.wire_bf16   = request.wire_bf16 != 0;
     GGML_LOG_INFO("[%s] device %u joined pairwise comm as rank %u\n", __func__, request.device, request.rank);
     response.ok = 1;
     return true;
@@ -2012,7 +2015,7 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
     }
     // reduce large partials in bf16 to halve the wire bytes; small (decode-sized) ones
     // stay f32 since the extra casts and sync cost more than the bytes saved
-    const bool wire_bf16 = t_dst->type == GGML_TYPE_F32 && ne >= 32768;
+    const bool wire_bf16 = state.wire_bf16 && t_dst->type == GGML_TYPE_F32 && ne >= 32768;
     size_t wire_bytes = nbytes;
     size_t need       = nbytes;
     size_t local_offset = 0;
@@ -2805,12 +2808,14 @@ static void * ggml_backend_rpc_comm_init(ggml_backend_t * backends, size_t n_bac
     bool ok = true;
     std::array<bool, 2> request_sent = {};
     std::array<bool, 2> initialized = {};
+    const bool wire_bf16 = std::getenv("GGML_RPC_NO_WIRE_BF16") == nullptr;
     for (size_t i = 0; i < n_backends; i++) {
         rpc_msg_comm_init_req request = {};
-        request.device = ranks[i].device;
-        request.rank   = (uint32_t) i;
-        request.world  = (uint32_t) n_backends;
-        request.port   = comm_port;
+        request.device    = ranks[i].device;
+        request.rank      = (uint32_t) i;
+        request.world     = (uint32_t) n_backends;
+        request.port      = comm_port;
+        request.wire_bf16 = wire_bf16;
         memcpy(request.session_id, session_id.data(), session_id.size());
         if (i > 0) {
             memcpy(request.host, host0.c_str(), host0.size());

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -9,6 +9,7 @@
 #include <cinttypes>
 #include <cstdlib>
 #include <optional>
+#include <random>
 #include <string>
 #include <thread>
 #include <vector>
@@ -93,10 +94,14 @@ const size_t HASH_THRESHOLD = 10 * 1024 * 1024;
 // so that both sides clear their caches at the same point in the message stream
 const size_t GRAPH_CACHE_MAX = 1024;
 
-static constexpr int RPC_COMM_CONNECT_RETRY_COUNT = 100;
-static constexpr int RPC_COMM_CONNECT_RETRY_MS    = 50;
-static constexpr int RPC_COMM_ACCEPT_TIMEOUT_MS   =
-        RPC_COMM_CONNECT_RETRY_COUNT * RPC_COMM_CONNECT_RETRY_MS + 1000;
+static constexpr int RPC_COMM_CONNECT_TIMEOUT_MS         = 5000;
+static constexpr int RPC_COMM_CONNECT_ATTEMPT_TIMEOUT_MS = 250;
+static constexpr int RPC_COMM_CONNECT_RETRY_MS           = 50;
+static constexpr int RPC_COMM_ACCEPT_TIMEOUT_MS          = RPC_COMM_CONNECT_TIMEOUT_MS + 1000;
+static constexpr int RPC_COMM_HANDSHAKE_TIMEOUT_MS       = 1000;
+static constexpr int RPC_COMM_IO_TIMEOUT_MS              = 30000;
+static constexpr size_t RPC_COMM_FULL_DUPLEX_THRESHOLD   = 64 * 1024;
+static constexpr size_t RPC_COMM_SESSION_ID_SIZE         = 16;
 
 struct rpc_msg_hello_req {
     uint8_t conn_caps[RPC_CONN_CAPS_SIZE];
@@ -231,10 +236,19 @@ struct rpc_msg_comm_init_req {
     uint32_t world;
     uint32_t port;      // rank 0: port to listen on; rank > 0: rank 0's comm port
     char     host[64];  // rank > 0: rank 0's host
+    uint8_t  session_id[RPC_COMM_SESSION_ID_SIZE];
 };
 
 struct rpc_msg_comm_init_rsp {
     uint8_t ok;
+};
+
+struct rpc_msg_comm_peer_hello {
+    uint8_t major;
+    uint8_t minor;
+    uint8_t patch;
+    uint8_t padding;
+    uint8_t session_id[RPC_COMM_SESSION_ID_SIZE];
 };
 
 struct rpc_msg_comm_allreduce_req {
@@ -251,6 +265,25 @@ struct rpc_msg_synchronize_req {
 };
 
 #pragma pack(pop)
+
+static rpc_msg_comm_peer_hello make_comm_peer_hello(const uint8_t * session_id) {
+    rpc_msg_comm_peer_hello hello = {
+        /*.major   =*/ RPC_PROTO_MAJOR_VERSION,
+        /*.minor   =*/ RPC_PROTO_MINOR_VERSION,
+        /*.patch   =*/ RPC_PROTO_PATCH_VERSION,
+        /*.padding =*/ 0,
+        /*.session_id =*/ {},
+    };
+    memcpy(hello.session_id, session_id, sizeof(hello.session_id));
+    return hello;
+}
+
+static bool validate_comm_peer_hello(
+        const rpc_msg_comm_peer_hello & hello, const uint8_t * session_id) {
+    return hello.major == RPC_PROTO_MAJOR_VERSION &&
+           hello.minor <= RPC_PROTO_MINOR_VERSION &&
+           memcmp(hello.session_id, session_id, sizeof(hello.session_id)) == 0;
+}
 
 // RPC data structures
 
@@ -961,8 +994,8 @@ void ggml_backend_rpc_get_device_memory(const char * endpoint, uint32_t device, 
 
 class rpc_server {
 public:
-    rpc_server(std::vector<ggml_backend_t> all_backends, const char * cache_dir)
-        : backends(std::move(all_backends)), cache_dir(cache_dir) {
+    rpc_server(std::vector<ggml_backend_t> all_backends, const char * cache_dir, std::string bind_host)
+        : backends(std::move(all_backends)), bind_host(std::move(bind_host)), cache_dir(cache_dir) {
         stored_graphs.resize(backends.size());
         comm_states.resize(backends.size());
     }
@@ -1019,6 +1052,7 @@ private:
     };
 
     std::vector<ggml_backend_t> backends;
+    std::string bind_host;
     const char * cache_dir;
     std::unordered_set<ggml_backend_buffer_t> buffers;
     // computed graphs cached per backend, keyed by uid
@@ -1780,27 +1814,53 @@ void rpc_server::sync_all_backends() {
     }
 }
 
-// The comm link between two servers uses the same caps negotiation as the client HELLO,
-// so it gets the same transport upgrades (e.g. RDMA).
+// The comm link authenticates the peer session before using the same caps negotiation
+// as the client HELLO, so it gets the same transport upgrades (e.g. RDMA).
 bool rpc_server::comm_init(const rpc_msg_comm_init_req & request, rpc_msg_comm_init_rsp & response) {
     response.ok = 0;
-    if (request.device >= backends.size() || request.world != 2 || request.rank >= request.world) {
+    if (request.device >= backends.size() || request.world != 2 || request.rank >= request.world ||
+            request.port == 0 || request.port > UINT16_MAX) {
         return true;
     }
     comm_state & state = comm_states[request.device];
     if (state.peer != nullptr) {
-        response.ok = 1;
+        GGML_LOG_WARN("[%s] communicator already initialized for device %u\n", __func__, request.device);
         return true;
     }
     uint8_t local_caps[RPC_CONN_CAPS_SIZE] = {};
     uint8_t remote_caps[RPC_CONN_CAPS_SIZE] = {};
     if (request.rank == 0) {
-        socket_ptr srv = socket_t::create_server("0.0.0.0", request.port);
+        socket_ptr srv = socket_t::create_server(bind_host.c_str(), request.port);
         if (srv == nullptr) {
             GGML_LOG_ERROR("[%s] failed to listen on comm port %u\n", __func__, request.port);
             return true;
         }
-        state.peer = srv->accept(RPC_COMM_ACCEPT_TIMEOUT_MS);
+        const auto deadline = std::chrono::steady_clock::now() +
+                std::chrono::milliseconds(RPC_COMM_ACCEPT_TIMEOUT_MS);
+        while (state.peer == nullptr) {
+            const int remaining_ms = (int) std::chrono::duration_cast<std::chrono::milliseconds>(
+                    deadline - std::chrono::steady_clock::now()).count();
+            if (remaining_ms <= 0) {
+                break;
+            }
+            socket_ptr peer = srv->accept(remaining_ms);
+            if (peer == nullptr) {
+                break;
+            }
+            rpc_msg_comm_peer_hello peer_hello = {};
+            if (!peer->set_timeout(RPC_COMM_HANDSHAKE_TIMEOUT_MS) ||
+                    !peer->recv_data(&peer_hello, sizeof(peer_hello)) ||
+                    !validate_comm_peer_hello(peer_hello, request.session_id)) {
+                GGML_LOG_WARN("[%s] rejected communicator peer\n", __func__);
+                continue;
+            }
+            const rpc_msg_comm_peer_hello local_hello = make_comm_peer_hello(request.session_id);
+            if (!peer->send_data(&local_hello, sizeof(local_hello)) ||
+                    !peer->set_timeout(RPC_COMM_IO_TIMEOUT_MS)) {
+                continue;
+            }
+            state.peer = std::move(peer);
+        }
         if (state.peer == nullptr) {
             GGML_LOG_ERROR("[%s] timed out waiting for rank 1 on comm port %u\n", __func__, request.port);
             return true;
@@ -1817,11 +1877,35 @@ bool rpc_server::comm_init(const rpc_msg_comm_init_req & request, rpc_msg_comm_i
         state.peer->update_caps(remote_caps);
     } else {
         const std::string host(request.host, strnlen(request.host, sizeof(request.host)));
-        // rank 0 may not be listening yet, retry for a few seconds
-        for (int i = 0; i < RPC_COMM_CONNECT_RETRY_COUNT && state.peer == nullptr; i++) {
-            state.peer = socket_t::connect(host.c_str(), request.port);
+        const auto deadline = std::chrono::steady_clock::now() +
+                std::chrono::milliseconds(RPC_COMM_CONNECT_TIMEOUT_MS);
+        while (state.peer == nullptr) {
+            const auto now = std::chrono::steady_clock::now();
+            if (now >= deadline) {
+                break;
+            }
+            const int remaining_ms = (int) std::chrono::duration_cast<std::chrono::milliseconds>(
+                    deadline - now).count();
+            socket_ptr peer = socket_t::connect(host.c_str(), request.port,
+                    std::min(remaining_ms, RPC_COMM_CONNECT_ATTEMPT_TIMEOUT_MS));
+            if (peer != nullptr) {
+                const rpc_msg_comm_peer_hello local_hello = make_comm_peer_hello(request.session_id);
+                rpc_msg_comm_peer_hello remote_hello = {};
+                if (peer->set_timeout(RPC_COMM_HANDSHAKE_TIMEOUT_MS) &&
+                        peer->send_data(&local_hello, sizeof(local_hello)) &&
+                        peer->recv_data(&remote_hello, sizeof(remote_hello)) &&
+                        validate_comm_peer_hello(remote_hello, request.session_id) &&
+                        peer->set_timeout(RPC_COMM_IO_TIMEOUT_MS)) {
+                    state.peer = std::move(peer);
+                }
+            }
             if (state.peer == nullptr) {
-                std::this_thread::sleep_for(std::chrono::milliseconds(RPC_COMM_CONNECT_RETRY_MS));
+                const int retry_ms = std::min(RPC_COMM_CONNECT_RETRY_MS, (int)
+                        std::chrono::duration_cast<std::chrono::milliseconds>(
+                            deadline - std::chrono::steady_clock::now()).count());
+                if (retry_ms > 0) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(retry_ms));
+                }
             }
         }
         if (state.peer == nullptr) {
@@ -1873,6 +1957,11 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
     if (nbytes == 0) {
         return true;
     }
+    if (t_dst->type != GGML_TYPE_F32 || !ggml_is_contiguous(t_dst) || ne <= 0 ||
+            (uint64_t) ne > SIZE_MAX / sizeof(float) || nbytes != (size_t) ne * sizeof(float)) {
+        GGML_LOG_ERROR("[%s] all-reduce tensor must be contiguous F32\n", __func__);
+        return false;
+    }
     // reduce large partials in bf16 to halve the wire bytes; small (decode-sized) ones
     // stay f32 since the extra casts and sync cost more than the bytes saved
     const bool   wire_bf16  = t_dst->type == GGML_TYPE_F32 && ne >= 32768;
@@ -1923,14 +2012,19 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
     if (wire_bf16) {
         t_wire_send = new_scratch_tensor(GGML_TYPE_BF16, 0);
         t_wire_recv = new_scratch_tensor(GGML_TYPE_BF16, ne*2);
-        compute_nodes(new_cpy_node(t_dst, t_wire_send), nullptr);
+        ggml_tensor * t_to_wire  = new_cpy_node(t_dst, t_wire_send);
+        ggml_tensor * t_to_local = new_cpy_node(t_to_wire, t_dst);
+        compute_nodes(t_to_wire, t_to_local);
         t_send = t_wire_send;
     }
     ggml_backend_tensor_get_async(backend, t_send, state.send_buf.data(), 0, wire_bytes);
     ggml_backend_synchronize(backend);
 
-    // rank 0 sends first, rank 1 receives first, so large payloads cannot deadlock
-    if (state.rank == 0) {
+    if (wire_bytes >= RPC_COMM_FULL_DUPLEX_THRESHOLD) {
+        if (!state.peer->exchange_data(state.send_buf.data(), state.recv_buf.data(), wire_bytes)) {
+            return false;
+        }
+    } else if (state.rank == 0) {
         if (!state.peer->send_data(state.send_buf.data(), wire_bytes) ||
             !state.peer->recv_data(state.recv_buf.data(), wire_bytes)) {
             return false;
@@ -1954,7 +2048,7 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
     ggml_tensor * t_red = ggml_new_tensor_4d(ctx, t_dst->type, t_dst->ne[0], t_dst->ne[1], t_dst->ne[2], t_dst->ne[3]);
     t_red->op     = GGML_OP_ADD;
     t_red->src[0] = t_dst;
-    t_red->src[1] = t_peer;
+    t_red->src[1] = t_cast != nullptr ? t_cast : t_peer;
     t_red->buffer = t_dst->buffer;
     t_red->data   = t_dst->data;
     t_red->flags |= GGML_TENSOR_FLAG_COMPUTE;
@@ -1998,8 +2092,8 @@ rpc_server::~rpc_server() {
 }
 
 static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const char * cache_dir,
-                             socket_ptr sock) {
-    rpc_server server(backends, cache_dir);
+                             const std::string & bind_host, socket_ptr sock) {
+    rpc_server server(backends, cache_dir, bind_host);
     uint8_t cmd;
     if (!sock->recv_data(&cmd, 1)) {
         return;
@@ -2411,7 +2505,7 @@ void ggml_backend_rpc_start_server(const char * endpoint, const char * cache_dir
         }
         printf("Accepted client connection\n");
         fflush(stdout);
-        rpc_serve_client(backends, cache_dir, client_socket);
+        rpc_serve_client(backends, cache_dir, host, client_socket);
         printf("Client connection closed\n");
         fflush(stdout);
     }
@@ -2614,16 +2708,27 @@ static void * ggml_backend_rpc_comm_init(ggml_backend_t * backends, size_t n_bac
         comm_port = (uint32_t) port0 + 1000;
     }
 
+    std::array<uint8_t, RPC_COMM_SESSION_ID_SIZE> session_id = {};
+    std::random_device random;
+    for (size_t offset = 0; offset < session_id.size();) {
+        const auto value = random();
+        const size_t size = std::min(sizeof(value), session_id.size() - offset);
+        memcpy(session_id.data() + offset, &value, size);
+        offset += size;
+    }
+
     // Send all init requests before reading any response: rank 0 blocks in accept
     // until rank 1 has connected.
     bool ok = true;
     std::array<bool, 2> request_sent = {};
+    std::array<bool, 2> initialized = {};
     for (size_t i = 0; i < n_backends; i++) {
         rpc_msg_comm_init_req request = {};
         request.device = ranks[i].device;
         request.rank   = (uint32_t) i;
         request.world  = (uint32_t) n_backends;
         request.port   = comm_port;
+        memcpy(request.session_id, session_id.data(), session_id.size());
         if (i > 0) {
             memcpy(request.host, host0.c_str(), host0.size());
         }
@@ -2647,9 +2752,21 @@ static void * ggml_backend_rpc_comm_init(ggml_backend_t * backends, size_t n_bac
                 !sock->recv_data(&response, sizeof(response)) || !response.ok) {
             GGML_LOG_WARN("%s: rank %zu (%s) failed to initialize\n", __func__, i, ranks[i].endpoint.c_str());
             ok = false;
+        } else {
+            initialized[i] = true;
         }
     }
     if (!ok) {
+        for (size_t i = 0; i < n_backends; i++) {
+            if (!initialized[i]) {
+                continue;
+            }
+            rpc_msg_comm_free_req request = {ranks[i].device};
+            auto sock = get_socket(ranks[i].endpoint);
+            if (sock != nullptr) {
+                send_rpc_cmd(sock, RPC_CMD_COMM_FREE, &request, sizeof(request));
+            }
+        }
         return nullptr;
     }
     GGML_LOG_INFO("%s: pairwise communicator initialized (%s <-> %s)\n", __func__,
@@ -2684,8 +2801,14 @@ static bool ggml_backend_rpc_comm_allreduce_tensor(void * comm_ctx_v, ggml_tenso
         request.device = comm_ctx->ranks[i].device;
         request.tensor = serialize_tensor(tensors[i]);
         auto sock = get_socket(comm_ctx->ranks[i].endpoint);
-        if (sock == nullptr || !send_rpc_cmd(sock, RPC_CMD_COMM_ALLREDUCE, &request, sizeof(request))) {
-            return false;
+        if (sock == nullptr) {
+            if (i == 0) {
+                return false;
+            }
+            GGML_ABORT("RPC all-reduce lost a rank after dispatch started");
+        }
+        if (!send_rpc_cmd(sock, RPC_CMD_COMM_ALLREDUCE, &request, sizeof(request))) {
+            GGML_ABORT("RPC all-reduce dispatch failed");
         }
     }
     return true;

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -253,6 +253,7 @@ struct rpc_msg_comm_peer_hello {
 
 struct rpc_msg_comm_allreduce_req {
     uint32_t   device;
+    uint64_t   op_id;
     rpc_tensor tensor;
 };
 
@@ -322,6 +323,26 @@ struct ggml_backend_rpc_buffer_context {
 };
 
 // RPC helper functions
+
+static bool checked_mul_size(size_t a, size_t b, size_t & result) {
+    if (a != 0 && b > SIZE_MAX / a) {
+        return false;
+    }
+    result = a*b;
+    return true;
+}
+
+static bool checked_add_size(size_t a, size_t b, size_t & result) {
+    if (a > SIZE_MAX - b) {
+        return false;
+    }
+    result = a + b;
+    return true;
+}
+
+static bool checked_span_size(size_t size, size_t n_copies, size_t stride) {
+    return n_copies == 0 || stride == 0 || n_copies - 1 <= (SIZE_MAX - size) / stride;
+}
 
 // Computes FNV-1a hash of the data
 static uint64_t fnv_hash(const uint8_t * data, size_t len) {
@@ -603,7 +624,13 @@ static void ggml_backend_rpc_buffer_set_tensor_2d(ggml_backend_buffer_t buffer, 
     ggml_backend_rpc_buffer_context * ctx = (ggml_backend_rpc_buffer_context *)buffer->context;
     rpc_tensor rpc_tensor = serialize_tensor(tensor);
     // input serialization format: | rpc_tensor | offset (8 bytes) | size (8 bytes) | n_copies (8 bytes) | stride (8 bytes) | data (size * n_copies bytes) |
-    size_t input_size = sizeof(rpc_tensor) + 4*sizeof(uint64_t) + size*n_copies;
+    const size_t header_size = sizeof(rpc_tensor) + 4*sizeof(uint64_t);
+    size_t data_size;
+    size_t input_size;
+    GGML_ASSERT(checked_mul_size(size, n_copies, data_size));
+    GGML_ASSERT(checked_add_size(header_size, data_size, input_size));
+    GGML_ASSERT(checked_span_size(size, n_copies, stride_tensor));
+    GGML_ASSERT(checked_span_size(size, n_copies, stride_data));
     std::vector<uint8_t> input(input_size, 0);
     uint8_t * dest = input.data();
     memcpy(dest, &rpc_tensor, sizeof(rpc_tensor));
@@ -627,11 +654,15 @@ static void ggml_backend_rpc_buffer_get_tensor_2d(ggml_backend_buffer_t buffer, 
     request.size     = size;
     request.n_copies = n_copies;
     request.stride   = stride_tensor;
+    size_t output_size;
+    GGML_ASSERT(checked_mul_size(size, n_copies, output_size));
+    GGML_ASSERT(checked_span_size(size, n_copies, stride_tensor));
+    GGML_ASSERT(checked_span_size(size, n_copies, stride_data));
     if (stride_data == size) {
-        bool status = send_rpc_cmd(ctx->sock, RPC_CMD_GET_TENSOR_2D, &request, sizeof(request), data, size*n_copies);
+        bool status = send_rpc_cmd(ctx->sock, RPC_CMD_GET_TENSOR_2D, &request, sizeof(request), data, output_size);
         RPC_STATUS_ASSERT(status);
     } else {
-        std::vector<uint8_t> packed(size*n_copies);
+        std::vector<uint8_t> packed(output_size);
         bool status = send_rpc_cmd(ctx->sock, RPC_CMD_GET_TENSOR_2D, &request, sizeof(request), packed.data(), packed.size());
         RPC_STATUS_ASSERT(status);
         for (size_t i = 0; i < n_copies; i++) {
@@ -1051,6 +1082,7 @@ private:
         socket_ptr              peer;
         uint32_t                rank = 0;
         uint32_t                world = 0;
+        uint64_t                next_op_id = 0;
         ggml_backend_buffer_ptr scratch;
         size_t                  scratch_size = 0;
         std::vector<uint8_t>    send_buf;
@@ -1946,6 +1978,11 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
         GGML_LOG_ERROR("[%s] no communicator for device %u\n", __func__, request.device);
         return false;
     }
+    if (request.op_id != state.next_op_id) {
+        GGML_LOG_ERROR("[%s] unexpected operation id %" PRIu64 ", expected %" PRIu64 "\n",
+                       __func__, request.op_id, state.next_op_id);
+        return false;
+    }
     ggml_backend_t backend = backends[request.device];
 
     size_t ctx_size = 16*ggml_tensor_overhead() + 2*ggml_graph_overhead_custom(8, false);
@@ -1965,6 +2002,7 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
     const size_t  nbytes = ggml_nbytes(t_dst);
     const int64_t ne     = ggml_nelements(t_dst);
     if (nbytes == 0) {
+        state.next_op_id++;
         return true;
     }
     if (t_dst->type != GGML_TYPE_F32 || !ggml_is_contiguous(t_dst) || ne <= 0 ||
@@ -1974,9 +2012,30 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
     }
     // reduce large partials in bf16 to halve the wire bytes; small (decode-sized) ones
     // stay f32 since the extra casts and sync cost more than the bytes saved
-    const bool   wire_bf16  = t_dst->type == GGML_TYPE_F32 && ne >= 32768;
-    const size_t wire_bytes = wire_bf16 ? (size_t) ne*2 : nbytes;
-    const size_t need       = wire_bf16 ? 2*nbytes : nbytes;
+    const bool wire_bf16 = t_dst->type == GGML_TYPE_F32 && ne >= 32768;
+    size_t wire_bytes = nbytes;
+    size_t need       = nbytes;
+    size_t local_offset = 0;
+    size_t peer_offset  = 0;
+    if (wire_bf16) {
+        size_t aligned_wire_end;
+        if (!checked_mul_size((size_t) ne, 2, wire_bytes) ||
+                !checked_add_size(wire_bytes, alignof(float) - 1, aligned_wire_end)) {
+            GGML_LOG_ERROR("[%s] all-reduce scratch size overflows\n", __func__);
+            return false;
+        }
+        local_offset = aligned_wire_end & ~(alignof(float) - 1);
+        if (!checked_add_size(local_offset, nbytes, peer_offset) ||
+                !checked_add_size(peer_offset, nbytes, need)) {
+            GGML_LOG_ERROR("[%s] all-reduce scratch size overflows\n", __func__);
+            return false;
+        }
+    }
+    size_t frame_bytes;
+    if (!checked_add_size(sizeof(request.op_id), wire_bytes, frame_bytes)) {
+        GGML_LOG_ERROR("[%s] all-reduce frame size overflows\n", __func__);
+        return false;
+    }
     if (state.scratch_size < need) {
         ggml_backend_buffer_ptr scratch { ggml_backend_alloc_buffer(backend, need) };
         if (scratch == nullptr) {
@@ -1988,8 +2047,11 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
         state.scratch_size = need;
     }
     char * scratch_base = (char *) ggml_backend_buffer_get_base(state.scratch.get());
-    state.send_buf.resize(wire_bytes);
-    state.recv_buf.resize(wire_bytes);
+    state.send_buf.resize(frame_bytes);
+    state.recv_buf.resize(frame_bytes);
+    memcpy(state.send_buf.data(), &request.op_id, sizeof(request.op_id));
+    uint8_t * send_data = state.send_buf.data() + sizeof(request.op_id);
+    uint8_t * recv_data = state.recv_buf.data() + sizeof(request.op_id);
 
     auto new_scratch_tensor = [&](ggml_type type, size_t offset) {
         ggml_tensor * t = ggml_new_tensor_4d(ctx, type, t_dst->ne[0], t_dst->ne[1], t_dst->ne[2], t_dst->ne[3]);
@@ -2018,46 +2080,55 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
 
     ggml_tensor * t_wire_send = nullptr;
     ggml_tensor * t_wire_recv = nullptr;
+    ggml_tensor * t_local     = t_dst;
     ggml_tensor * t_send      = t_dst;
     if (wire_bf16) {
         t_wire_send = new_scratch_tensor(GGML_TYPE_BF16, 0);
-        t_wire_recv = new_scratch_tensor(GGML_TYPE_BF16, ne*2);
+        t_wire_recv = new_scratch_tensor(GGML_TYPE_BF16, 0);
+        t_local     = new_scratch_tensor(GGML_TYPE_F32, local_offset);
         ggml_tensor * t_to_wire  = new_cpy_node(t_dst, t_wire_send);
-        ggml_tensor * t_to_local = new_cpy_node(t_to_wire, t_dst);
+        ggml_tensor * t_to_local = new_cpy_node(t_to_wire, t_local);
         compute_nodes(t_to_wire, t_to_local);
         t_send = t_wire_send;
     }
-    ggml_backend_tensor_get_async(backend, t_send, state.send_buf.data(), 0, wire_bytes);
+    ggml_backend_tensor_get_async(backend, t_send, send_data, 0, wire_bytes);
     ggml_backend_synchronize(backend);
 
+    bool exchange_ok;
     if (wire_bytes >= RPC_COMM_FULL_DUPLEX_THRESHOLD) {
-        if (!state.peer->exchange_data(state.send_buf.data(), state.recv_buf.data(), wire_bytes)) {
-            return false;
-        }
+        exchange_ok = state.peer->exchange_data(state.send_buf.data(), state.recv_buf.data(), frame_bytes);
     } else if (state.rank == 0) {
-        if (!state.peer->send_data(state.send_buf.data(), wire_bytes) ||
-            !state.peer->recv_data(state.recv_buf.data(), wire_bytes)) {
-            return false;
-        }
+        exchange_ok = state.peer->send_data(state.send_buf.data(), frame_bytes) &&
+                      state.peer->recv_data(state.recv_buf.data(), frame_bytes);
     } else {
-        if (!state.peer->recv_data(state.recv_buf.data(), wire_bytes) ||
-            !state.peer->send_data(state.send_buf.data(), wire_bytes)) {
-            return false;
-        }
+        exchange_ok = state.peer->recv_data(state.recv_buf.data(), frame_bytes) &&
+                      state.peer->send_data(state.send_buf.data(), frame_bytes);
+    }
+    if (!exchange_ok) {
+        GGML_LOG_ERROR("[%s] peer exchange failed for operation %" PRIu64 "\n", __func__, request.op_id);
+        return false;
     }
 
-    ggml_tensor * t_peer = new_scratch_tensor(t_dst->type, wire_bf16 ? (size_t) ne*4 : 0);
+    uint64_t peer_op_id;
+    memcpy(&peer_op_id, state.recv_buf.data(), sizeof(peer_op_id));
+    if (peer_op_id != request.op_id) {
+        GGML_LOG_ERROR("[%s] peer operation id %" PRIu64 " does not match %" PRIu64 "\n",
+                       __func__, peer_op_id, request.op_id);
+        return false;
+    }
+
+    ggml_tensor * t_peer = new_scratch_tensor(t_dst->type, peer_offset);
     ggml_tensor * t_cast = nullptr;
     if (wire_bf16) {
-        ggml_backend_tensor_set(t_wire_recv, state.recv_buf.data(), 0, wire_bytes);
+        ggml_backend_tensor_set(t_wire_recv, recv_data, 0, wire_bytes);
         t_cast = new_cpy_node(t_wire_recv, t_peer);
     } else {
-        ggml_backend_tensor_set(t_peer, state.recv_buf.data(), 0, wire_bytes);
+        ggml_backend_tensor_set(t_peer, recv_data, 0, wire_bytes);
     }
 
     ggml_tensor * t_red = ggml_new_tensor_4d(ctx, t_dst->type, t_dst->ne[0], t_dst->ne[1], t_dst->ne[2], t_dst->ne[3]);
     t_red->op     = GGML_OP_ADD;
-    t_red->src[0] = t_dst;
+    t_red->src[0] = t_local;
     t_red->src[1] = t_cast != nullptr ? t_cast : t_peer;
     t_red->buffer = t_dst->buffer;
     t_red->data   = t_dst->data;
@@ -2068,6 +2139,7 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
     } else {
         compute_nodes(t_red, nullptr);
     }
+    state.next_op_id++;
     return true;
 }
 
@@ -2649,6 +2721,7 @@ struct ggml_backend_rpc_comm_context {
         uint32_t    device;
     };
     std::vector<rank_info> ranks;
+    uint64_t next_op_id = 0;
 };
 
 static void ggml_backend_rpc_comm_free(void * comm_ctx_v) {
@@ -2806,9 +2879,11 @@ static bool ggml_backend_rpc_comm_allreduce_tensor(void * comm_ctx_v, ggml_tenso
             return false;
         }
     }
+    const uint64_t op_id = comm_ctx->next_op_id;
     for (size_t i = 0; i < n_ranks; i++) {
-        rpc_msg_comm_allreduce_req request;
+        rpc_msg_comm_allreduce_req request = {};
         request.device = comm_ctx->ranks[i].device;
+        request.op_id   = op_id;
         request.tensor = serialize_tensor(tensors[i]);
         auto sock = get_socket(comm_ctx->ranks[i].endpoint);
         if (sock == nullptr) {
@@ -2821,6 +2896,7 @@ static bool ggml_backend_rpc_comm_allreduce_tensor(void * comm_ctx_v, ggml_tenso
             GGML_ABORT("RPC all-reduce dispatch failed");
         }
     }
+    comm_ctx->next_op_id++;
     return true;
 }
 

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -481,8 +481,11 @@ static rpc_tensor serialize_tensor(const ggml_tensor * tensor) {
 
     result.id = reinterpret_cast<uint64_t>(tensor);
     result.type = tensor->type;
-    if (tensor->buffer && ggml_backend_buffer_is_rpc(tensor->buffer)) {
-        ggml_backend_buffer_t buffer = tensor->buffer;
+    ggml_backend_buffer_t buffer = tensor->buffer;
+    if (buffer && tensor->data && ggml_backend_buffer_is_multi_buffer(buffer)) {
+        buffer = ggml_backend_multi_buffer_get_buffer(buffer, tensor->data);
+    }
+    if (buffer && ggml_backend_buffer_is_rpc(buffer)) {
         ggml_backend_rpc_buffer_context * ctx = (ggml_backend_rpc_buffer_context *)buffer->context;
         result.buffer = ctx != nullptr ? ctx->remote_ptr : 0;
         result.data = reinterpret_cast<uint64_t>(tensor->data);
@@ -1231,6 +1234,16 @@ ggml_tensor * rpc_server::deserialize_tensor(struct ggml_context * ctx, const rp
     if (result->buffer && buffers.find(result->buffer) == buffers.end()) {
         result->buffer = nullptr;
     }
+    if (result->buffer && ggml_nelements(result) > 0 && ggml_backend_buffer_is_multi_buffer(result->buffer)) {
+        ggml_backend_buffer_t sub_buffer =
+            ggml_backend_multi_buffer_get_buffer(result->buffer, reinterpret_cast<const void *>(tensor->data));
+        if (sub_buffer == nullptr) {
+            GGML_LOG_ERROR("[%s] tensor '%s' data 0x%" PRIx64 " is not in the multi-buffer\n",
+                           __func__, tensor->name, tensor->data);
+            return nullptr;
+        }
+        result->buffer = sub_buffer;
+    }
 
     if (result->buffer && ggml_nelements(result) > 0) {
         // require that the tensor data does not go beyond the buffer end
@@ -1888,20 +1901,17 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
         GGML_ASSERT(status == GGML_STATUS_SUCCESS && "Unsuccessful graph computations are not supported with RPC");
     };
 
-    // wait for the pending subgraph that produced this partial
-    ggml_backend_synchronize(backend);
-
     ggml_tensor * t_wire_send = nullptr;
     ggml_tensor * t_wire_recv = nullptr;
+    ggml_tensor * t_send      = t_dst;
     if (wire_bf16) {
         t_wire_send = new_scratch_tensor(GGML_TYPE_BF16, 0);
         t_wire_recv = new_scratch_tensor(GGML_TYPE_BF16, ne*2);
         compute_nodes(new_cpy_node(t_dst, t_wire_send), nullptr);
-        ggml_backend_synchronize(backend);
-        ggml_backend_tensor_get(t_wire_send, state.send_buf.data(), 0, wire_bytes);
-    } else {
-        ggml_backend_tensor_get(t_dst, state.send_buf.data(), 0, wire_bytes);
+        t_send = t_wire_send;
     }
+    ggml_backend_tensor_get_async(backend, t_send, state.send_buf.data(), 0, wire_bytes);
+    ggml_backend_synchronize(backend);
 
     // rank 0 sends first, rank 1 receives first, so large payloads cannot deadlock
     if (state.rank == 0) {

--- a/ggml/src/ggml-rpc/transport.cpp
+++ b/ggml/src/ggml-rpc/transport.cpp
@@ -10,6 +10,8 @@
 #  include <winsock2.h>
 #else
 #  include <arpa/inet.h>
+#  include <errno.h>
+#  include <fcntl.h>
 #  include <sys/select.h>
 #  include <sys/socket.h>
 #  include <sys/types.h>
@@ -18,9 +20,11 @@
 #  include <netdb.h>
 #  include <unistd.h>
 #endif
+#include <chrono>
 #include <cstdlib>
 #include <mutex>
 #include <optional>
+#include <thread>
 
 #ifdef GGML_RPC_RDMA
 #  include <infiniband/verbs.h>
@@ -119,6 +123,8 @@ struct socket_t::impl {
     ~impl();
     bool send_data(const void * data, size_t size);
     bool recv_data(void * data, size_t size);
+    bool exchange_data(const void * send_data, void * recv_data, size_t size);
+    bool set_timeout(int timeout_ms);
     void get_caps(uint8_t * local_caps);
     void update_caps(const uint8_t * remote_caps);
 
@@ -136,6 +142,7 @@ struct socket_t::impl {
 #endif // GGML_RPC_RDMA
     bool     use_rdma;
     sockfd_t fd;
+    int      timeout_ms = -1;
 };
 
 socket_t::impl::~impl() {
@@ -385,6 +392,9 @@ bool socket_t::impl::rdma_activate(uint32_t remote_qpn, uint32_t remote_psn, con
 }
 
 bool socket_t::impl::rdma_poll(struct ibv_cq * cq, struct ibv_wc * wc) {
+    const auto deadline = timeout_ms >= 0
+            ? std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms)
+            : std::chrono::steady_clock::time_point::max();
     for (uint64_t s = 0; ; s++) {
         int n = ibv_poll_cq(cq, 1, wc);
         if (n > 0) {
@@ -395,8 +405,12 @@ bool socket_t::impl::rdma_poll(struct ibv_cq * cq, struct ibv_wc * wc) {
             return wc->status == IBV_WC_SUCCESS;
         }
         if (n < 0) return false;
-        if ((s & 0xFFFFF) == 0 && s > 0) {
+        if ((s & 0xFFF) == 0 && s > 0) {
             if (tcp_peer_closed()) {
+                return false;
+            }
+            if (std::chrono::steady_clock::now() >= deadline) {
+                GGML_LOG_ERROR("RDMA operation timed out\n");
                 return false;
             }
         }
@@ -504,6 +518,40 @@ bool socket_t::impl::recv_data(void * data, size_t size) {
     return true;
 }
 
+bool socket_t::impl::exchange_data(const void * send_buf, void * recv_buf, size_t size) {
+    bool send_ok = false;
+    std::thread sender([&]() {
+        send_ok = send_data(send_buf, size);
+    });
+    const bool recv_ok = recv_data(recv_buf, size);
+    sender.join();
+    return send_ok && recv_ok;
+}
+
+bool socket_t::impl::set_timeout(int timeout) {
+    if (timeout < 0) {
+        return false;
+    }
+#ifdef _WIN32
+    const DWORD value = (DWORD) timeout;
+    if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (const char *) &value, sizeof(value)) != 0 ||
+            setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, (const char *) &value, sizeof(value)) != 0) {
+        return false;
+    }
+#else
+    const struct timeval value = {
+        /*.tv_sec  =*/ timeout / 1000,
+        /*.tv_usec =*/ (timeout % 1000) * 1000,
+    };
+    if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &value, sizeof(value)) != 0 ||
+            setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &value, sizeof(value)) != 0) {
+        return false;
+    }
+#endif
+    timeout_ms = timeout;
+    return true;
+}
+
 void socket_t::impl::get_caps(uint8_t * local_caps) {
     memset(local_caps, 0, RPC_CONN_CAPS_SIZE);
 #ifdef GGML_RPC_RDMA
@@ -557,6 +605,14 @@ bool socket_t::recv_data(void * data, size_t size) {
     return pimpl->recv_data(data, size);
 }
 
+bool socket_t::exchange_data(const void * send_data, void * recv_data, size_t size) {
+    return pimpl->exchange_data(send_data, recv_data, size);
+}
+
+bool socket_t::set_timeout(int timeout_ms) {
+    return pimpl->set_timeout(timeout_ms);
+}
+
 void socket_t::get_caps(uint8_t * local_caps) {
     return pimpl->get_caps(local_caps);
 }
@@ -573,11 +629,32 @@ static bool is_valid_fd(sockfd_t sockfd) {
 #endif
 }
 
+static void close_socket(sockfd_t sockfd) {
+#ifdef _WIN32
+    closesocket(sockfd);
+#else
+    close(sockfd);
+#endif
+}
+
 static bool set_no_delay(sockfd_t sockfd) {
     int flag = 1;
     // set TCP_NODELAY to disable Nagle's algorithm
     int ret = setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (char *)&flag, sizeof(int));
     return ret == 0;
+}
+
+static bool set_non_blocking(sockfd_t sockfd, bool enabled) {
+#ifdef _WIN32
+    u_long mode = enabled ? 1 : 0;
+    return ioctlsocket(sockfd, FIONBIO, &mode) == 0;
+#else
+    const int flags = fcntl(sockfd, F_GETFL, 0);
+    if (flags < 0) {
+        return false;
+    }
+    return fcntl(sockfd, F_SETFL, enabled ? flags | O_NONBLOCK : flags & ~O_NONBLOCK) == 0;
+#endif
 }
 
 static bool set_reuse_addr(sockfd_t sockfd) {
@@ -647,26 +724,74 @@ socket_ptr socket_t::create_server(const char * host, int port) {
     return socket_ptr(new socket_t(std::make_unique<impl>(sockfd)));
 }
 
-socket_ptr socket_t::connect(const char * host, int port) {
+socket_ptr socket_t::connect(const char * host, int port, int timeout_ms) {
     auto sockfd = socket(AF_INET, SOCK_STREAM, 0);
     if (!is_valid_fd(sockfd)) {
         return nullptr;
     }
-    if (!set_no_delay(sockfd)) {
-        GGML_LOG_ERROR("Failed to set TCP_NODELAY\n");
+    auto fail = [&]() -> socket_ptr {
+        close_socket(sockfd);
         return nullptr;
-    }
+    };
     struct sockaddr_in addr;
     addr.sin_family = AF_INET;
     addr.sin_port = htons(port);
     struct hostent * server = gethostbyname(host);
     if (server == NULL) {
         GGML_LOG_ERROR("Cannot resolve host '%s'\n", host);
-        return nullptr;
+        return fail();
     }
     memcpy(&addr.sin_addr.s_addr, server->h_addr, server->h_length);
-    if (::connect(sockfd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-        return nullptr;
+    if (timeout_ms >= 0) {
+        if (!set_non_blocking(sockfd, true)) {
+            return fail();
+        }
+        if (::connect(sockfd, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
+#ifdef _WIN32
+            const int error = WSAGetLastError();
+            if (error != WSAEWOULDBLOCK && error != WSAEINPROGRESS) {
+                return fail();
+            }
+#else
+            if (errno != EINPROGRESS) {
+                return fail();
+            }
+#endif
+            fd_set writefds;
+            FD_ZERO(&writefds);
+            FD_SET(sockfd, &writefds);
+            struct timeval timeout = {
+                /*.tv_sec  =*/ timeout_ms / 1000,
+                /*.tv_usec =*/ (timeout_ms % 1000) * 1000,
+            };
+#ifdef _WIN32
+            const int ready = select(0, NULL, &writefds, NULL, &timeout);
+#else
+            const int ready = select(sockfd + 1, NULL, &writefds, NULL, &timeout);
+#endif
+            if (ready <= 0) {
+                return fail();
+            }
+            int socket_error = 0;
+#ifdef _WIN32
+            int error_size = sizeof(socket_error);
+#else
+            socklen_t error_size = sizeof(socket_error);
+#endif
+            if (getsockopt(sockfd, SOL_SOCKET, SO_ERROR, (char *) &socket_error, &error_size) != 0 ||
+                    socket_error != 0) {
+                return fail();
+            }
+        }
+        if (!set_non_blocking(sockfd, false)) {
+            return fail();
+        }
+    } else if (::connect(sockfd, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
+        return fail();
+    }
+    if (!set_no_delay(sockfd)) {
+        GGML_LOG_ERROR("Failed to set TCP_NODELAY\n");
+        return fail();
     }
     return socket_ptr(new socket_t(std::make_unique<impl>(sockfd)));
 }

--- a/ggml/src/ggml-rpc/transport.cpp
+++ b/ggml/src/ggml-rpc/transport.cpp
@@ -10,6 +10,7 @@
 #  include <winsock2.h>
 #else
 #  include <arpa/inet.h>
+#  include <sys/select.h>
 #  include <sys/socket.h>
 #  include <sys/types.h>
 #  include <netinet/in.h>
@@ -585,7 +586,29 @@ static bool set_reuse_addr(sockfd_t sockfd) {
     return ret == 0;
 }
 
-socket_ptr socket_t::accept() {
+socket_ptr socket_t::accept(int timeout_ms) {
+    if (timeout_ms >= 0) {
+        fd_set readfds;
+        FD_ZERO(&readfds);
+        FD_SET(pimpl->fd, &readfds);
+
+        struct timeval timeout = {
+            /*.tv_sec  =*/ timeout_ms / 1000,
+            /*.tv_usec =*/ (timeout_ms % 1000) * 1000,
+        };
+#ifdef _WIN32
+        const int ready = select(0, &readfds, NULL, NULL, &timeout);
+#else
+        const int ready = select(pimpl->fd + 1, &readfds, NULL, NULL, &timeout);
+#endif
+        if (ready <= 0) {
+            if (ready < 0) {
+                GGML_LOG_ERROR("Failed to wait for incoming connection\n");
+            }
+            return nullptr;
+        }
+    }
+
     auto client_socket_fd = ::accept(pimpl->fd, NULL, NULL);
     if (!is_valid_fd(client_socket_fd)) {
         return nullptr;

--- a/ggml/src/ggml-rpc/transport.h
+++ b/ggml/src/ggml-rpc/transport.h
@@ -15,6 +15,8 @@ struct socket_t {
 
     bool send_data(const void * data, size_t size);
     bool recv_data(void * data, size_t size);
+    bool exchange_data(const void * send_data, void * recv_data, size_t size);
+    bool set_timeout(int timeout_ms);
 
     socket_ptr accept(int timeout_ms = -1);
 
@@ -22,7 +24,7 @@ struct socket_t {
     void update_caps(const uint8_t * remote_caps);
 
     static socket_ptr create_server(const char * host, int port);
-    static socket_ptr connect(const char * host, int port);
+    static socket_ptr connect(const char * host, int port, int timeout_ms = -1);
 
 private:
     struct impl;

--- a/ggml/src/ggml-rpc/transport.h
+++ b/ggml/src/ggml-rpc/transport.h
@@ -16,7 +16,7 @@ struct socket_t {
     bool send_data(const void * data, size_t size);
     bool recv_data(void * data, size_t size);
 
-    socket_ptr accept();
+    socket_ptr accept(int timeout_ms = -1);
 
     void get_caps(uint8_t * local_caps);
     void update_caps(const uint8_t * remote_caps);

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2851,9 +2851,15 @@ struct ggml_backend_vk_context {
     // If false, then it's contiguous.
     bool prealloc_y_last_decode_vector_staging {};
 
-    // Track which nodes have been used since the last sync, and whether they were written to
-    std::vector<const ggml_tensor *> unsynced_nodes_written;
-    std::vector<const ggml_tensor *> unsynced_nodes_read;
+    struct buffer_range {
+        vk_buffer buffer;
+        size_t base;
+        size_t size;
+    };
+
+    // Track which buffer ranges have been used since the last sync, and whether they were written to.
+    std::vector<buffer_range> unsynced_nodes_written;
+    std::vector<buffer_range> unsynced_nodes_read;
     // Track which prealloc buffers have pending reads that need to be synchronized.
     // These are checked before writing to the buffer (and call ggml_vk_sync_buffers if set),
     // and set to true after the buffer contents are consumed.
@@ -17824,23 +17830,23 @@ static bool ggml_vk_build_graph(ggml_backend_vk_context * ctx, ggml_cgraph * cgr
         // Destination nodes are checked against both the written/read lists. Source nodes are only
         // checked against the written list. Two nodes overlap in memory if they come from the same
         // buffer and the tensor or view ranges overlap.
-        auto const &overlaps_unsynced = [&](const ggml_tensor *node, const std::vector<const ggml_tensor *> &unsynced_nodes) -> bool {
+        auto const &get_buffer_range = [](const ggml_tensor * node) {
+            ggml_backend_vk_buffer_context * buf_ctx = (ggml_backend_vk_buffer_context *) node->buffer->context;
+            return ggml_backend_vk_context::buffer_range {
+                buf_ctx->dev_buffer,
+                vk_tensor_offset(node) + node->view_offs,
+                ggml_nbytes(node),
+            };
+        };
+        auto const &overlaps_unsynced = [&](const ggml_tensor * node, const std::vector<ggml_backend_vk_context::buffer_range> & unsynced_nodes) {
             if (unsynced_nodes.size() == 0) {
                 return false;
             }
-            auto n_base = vk_tensor_offset(node) + node->view_offs;
-            auto n_size = ggml_nbytes(node);
-            ggml_backend_vk_buffer_context * a_buf_ctx = (ggml_backend_vk_buffer_context *)node->buffer->context;
-            vk_buffer a_buf = a_buf_ctx->dev_buffer;
-            for (auto &other : unsynced_nodes) {
-                ggml_backend_vk_buffer_context * o_buf_ctx = (ggml_backend_vk_buffer_context *)other->buffer->context;
-                vk_buffer o_buf = o_buf_ctx->dev_buffer;
-                if (a_buf == o_buf) {
-                    auto o_base = vk_tensor_offset(other) + other->view_offs;
-                    auto o_size = ggml_nbytes(other);
-
-                    if ((o_base <= n_base && n_base < o_base + o_size) ||
-                        (n_base <= o_base && o_base < n_base + n_size)) {
+            const auto range = get_buffer_range(node);
+            for (const auto & other : unsynced_nodes) {
+                if (range.buffer == other.buffer) {
+                    if ((other.base <= range.base && range.base < other.base + other.size) ||
+                        (range.base <= other.base && other.base < range.base + range.size)) {
                         return true;
                     }
                 }
@@ -17889,13 +17895,13 @@ static bool ggml_vk_build_graph(ggml_backend_vk_context * ctx, ggml_cgraph * cgr
             const ggml_tensor *cur_node = cgraph->nodes[node_idx + i];
             // Multiple outputs could be written, e.g. in topk_moe. Add them all to the list.
             if (ctx->fused_ops_write_mask & (1 << i)) {
-                ctx->unsynced_nodes_written.push_back(cur_node);
+                ctx->unsynced_nodes_written.push_back(get_buffer_range(cur_node));
             }
             for (uint32_t j = 0; j < GGML_MAX_SRC; ++j) {
                 if (!cur_node->src[j]) {
                     continue;
                 }
-                ctx->unsynced_nodes_read.push_back(cur_node->src[j]);
+                ctx->unsynced_nodes_read.push_back(get_buffer_range(cur_node->src[j]));
             }
         }
     }
@@ -18880,11 +18886,36 @@ static void ggml_backend_vk_get_tensor_2d_async(ggml_backend_t backend, const gg
 
     ggml_backend_vk_buffer_context * buf_ctx = (ggml_backend_vk_buffer_context *)tensor->buffer->context;
 
+    ggml_vk_submit_transfer_ctx(ctx);
     vk_context compute_ctx = ggml_vk_get_compute_ctx(ctx);
 
     vk_buffer buf = buf_ctx->dev_buffer;
 
     auto src_offset = vk_tensor_offset(tensor) + tensor->view_offs + offset;
+    if (buf->memory_property_flags & vk::MemoryPropertyFlagBits::eHostVisible && buf->device->uma) {
+        GGML_ASSERT(buf->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent);
+
+        compute_ctx->s->buffer->buf.pipelineBarrier(
+            vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eTransfer,
+            vk::PipelineStageFlagBits::eHost,
+            {},
+            { { vk::AccessFlagBits::eShaderWrite | vk::AccessFlagBits::eTransferWrite,
+                vk::AccessFlagBits::eHostRead } },
+            {}, {});
+
+        if (size == stride_tensor && size == stride_data) {
+            deferred_memcpy(data, (const uint8_t *) buf->info.pMappedData + src_offset, size * n_copies,
+                            &compute_ctx->out_memcpys);
+        } else {
+            for (size_t i = 0; i < n_copies; i++) {
+                deferred_memcpy((uint8_t *) data + i * stride_data,
+                                (const uint8_t *) buf->info.pMappedData + src_offset + i * stride_tensor,
+                                size, &compute_ctx->out_memcpys);
+            }
+        }
+        return;
+    }
+
     bool ret = ggml_vk_buffer_read_2d_async(compute_ctx, buf, src_offset, data, stride_tensor, stride_data, size, n_copies);
 
     if (!ret) {

--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -1028,8 +1028,6 @@ bool llm_arch_supports_sm_tensor(const llm_arch & arch) {
         case LLM_ARCH_KIMI_LINEAR:
         case LLM_ARCH_QWEN3TTS:
         case LLM_ARCH_QWEN3NEXT:
-        case LLM_ARCH_QWEN35:
-        case LLM_ARCH_QWEN35MOE:
             return false;
         default:
             return true;

--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -1014,7 +1014,6 @@ bool llm_arch_supports_sm_tensor(const llm_arch & arch) {
         case LLM_ARCH_OLMOE:
         case LLM_ARCH_DEEPSEEK2:
         case LLM_ARCH_DEEPSEEK32:
-        case LLM_ARCH_DEEPSEEK4:
         case LLM_ARCH_GLM_DSA:
         case LLM_ARCH_BITNET:
         case LLM_ARCH_T5:

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -355,9 +355,13 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
     static const std::regex pattern_qkv_bias        ("blk\\.\\d*\\.attn_qkv.bias");
     static const std::regex pattern_qk_norm         ("blk\\.\\d*\\.attn_(q|k)_norm\\.weight");
     static const std::regex pattern_kv_cache        ("cache_(k|v)_l\\d*");
+    static const std::regex pattern_dsv4_state      ("dsv4_(csa|hca|lid)_state_(kv|score)_l\\d*");
     static const std::regex pattern_attn_sinks      ("blk\\.\\d*\\.attn_sinks.weight");
     static const std::regex pattern_attn_out_weight ("blk\\.\\d*\\.attn_output.weight");
     static const std::regex pattern_attn_out_bias   ("blk\\.\\d*\\.attn_output.bias");
+    static const std::regex pattern_attn_out_a_weight("blk\\.\\d*\\.attn_output_a\\.weight");
+    static const std::regex pattern_attn_out_b_weight("blk\\.\\d*\\.attn_output_b\\.weight");
+    static const std::regex pattern_attn_q_b_weight ("blk\\.\\d*\\.attn_q_b\\.weight");
     static const std::regex pattern_attn_gate_weight("blk\\.\\d*\\.attn_gate.weight");
 
     static const std::regex pattern_ssm_dt          ("blk\\.\\d*\\.ssm_dt.bias");
@@ -376,8 +380,11 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
     static const std::regex pattern_ffn_gate_bias     ("blk\\.\\d*\\.ffn_gate(_exps)?.bias");
     static const std::regex pattern_ffn_gate_up_weight("blk\\.\\d*\\.ffn_gate_up(_exps)?.weight");
     static const std::regex pattern_ffn_down_weight   ("blk\\.\\d*\\.ffn_down(_exps)?.weight");
-    static const std::regex pattern_ffn_down_bias     ("blk\\.\\d*\\.ffn_down.bias");
-    static const std::regex pattern_ffn_down_exps_bias("blk\\.\\d*\\.ffn_down_exps.bias");
+    static const std::regex pattern_ffn_down_bias         ("blk\\.\\d*\\.ffn_down.bias");
+    static const std::regex pattern_ffn_down_exps_bias    ("blk\\.\\d*\\.ffn_down_exps.bias");
+    static const std::regex pattern_ffn_up_shexp_weight   ("blk\\.\\d*\\.ffn_up_shexp.weight");
+    static const std::regex pattern_ffn_gate_shexp_weight ("blk\\.\\d*\\.ffn_gate_shexp.weight");
+    static const std::regex pattern_ffn_down_shexp_weight ("blk\\.\\d*\\.ffn_down_shexp.weight");
 
     static const std::regex pattern_output_weight("output\\.weight");
     static const std::regex pattern_output_bias  ("output\\.bias");
@@ -434,6 +441,32 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
     };
 
     auto get_tensor_config = [&]() -> tensor_config {
+        if (ud->model->arch == LLM_ARCH_DEEPSEEK4) {
+            if (std::regex_match(tensor_name, pattern_kv_cache) ||
+                    std::regex_match(tensor_name, pattern_dsv4_state)) {
+                return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+            }
+            if (std::regex_match(tensor_name, pattern_attn_sinks)) {
+                return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_0, "attn_output_a.weight");
+            }
+            if (std::regex_match(tensor_name, pattern_attn_q_b_weight)) {
+                return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_1, "attn_output_a.weight");
+            }
+            if (std::regex_match(tensor_name, pattern_attn_out_a_weight)) {
+                return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_1, "attn_output_b.weight");
+            }
+            if (std::regex_match(tensor_name, pattern_attn_out_b_weight)) {
+                return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_0);
+            }
+            if (std::regex_match(tensor_name, pattern_ffn_up_shexp_weight) ||
+                    std::regex_match(tensor_name, pattern_ffn_gate_shexp_weight)) {
+                return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_1, "ffn_down_shexp.weight");
+            }
+            if (std::regex_match(tensor_name, pattern_ffn_down_shexp_weight)) {
+                return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_0, "ffn_down_shexp.weight");
+            }
+        }
+
         // standard attention
         if (std::regex_match(tensor_name, pattern_q_weight) || std::regex_match(tensor_name, pattern_kv_weight)) {
             return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_1, "attn_output.weight", "ssm_out.weight");
@@ -621,7 +654,22 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
 
             if (std::regex_match(tensor_name, pattern_attn_sinks)) {
                 GGML_ASSERT(segments.size() == 1);
+                if (ud->model->arch == LLM_ARCH_DEEPSEEK4) {
+                    return {1};
+                }
                 return {std::lcm(n_embd_q, blck_size_perf)/n_embd_q * n_gqa};
+            }
+
+            if (ud->model->arch == LLM_ARCH_DEEPSEEK4) {
+                if (std::regex_match(tensor_name, pattern_attn_q_b_weight)) {
+                    GGML_ASSERT(segments.size() == 1);
+                    return {hparams.n_embd_head_k(il)};
+                }
+                if (std::regex_match(tensor_name, pattern_attn_out_a_weight) ||
+                        std::regex_match(tensor_name, pattern_attn_out_b_weight)) {
+                    GGML_ASSERT(segments.size() == 1);
+                    return {std::lcm<int64_t>(hparams.dsv4_o_lora_rank, blck_size)};
+                }
             }
 
             const int64_t granularity_q = std::lcm(n_embd_q, blck_size_perf);
@@ -654,7 +702,11 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
         // FFN
         if (std::regex_match(tensor_name, pattern_ffn_up_weight) || std::regex_match(tensor_name, pattern_ffn_up_bias) ||
                 std::regex_match(tensor_name, pattern_ffn_gate_weight) || std::regex_match(tensor_name, pattern_ffn_gate_bias) ||
-                std::regex_match(tensor_name, pattern_ffn_gate_up_weight) || std::regex_match(tensor_name, pattern_ffn_down_weight)) {
+                std::regex_match(tensor_name, pattern_ffn_gate_up_weight) ||
+                std::regex_match(tensor_name, pattern_ffn_down_weight) ||
+                std::regex_match(tensor_name, pattern_ffn_up_shexp_weight) ||
+                std::regex_match(tensor_name, pattern_ffn_gate_shexp_weight) ||
+                std::regex_match(tensor_name, pattern_ffn_down_shexp_weight)) {
             const int64_t blck_size_perf = std::lcm(blck_size, 128);
             GGML_ASSERT(segments.size() == 1);
             return {blck_size_perf};

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -441,6 +441,11 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
     };
 
     auto get_tensor_config = [&]() -> tensor_config {
+        // dflash drafters are small, mirror them on every device: no reduction boundaries,
+        // and the target hidden-state handoff stays within the same backends
+        if (ud->model->arch == LLM_ARCH_DFLASH) {
+            return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+        }
         if (ud->model->arch == LLM_ARCH_DEEPSEEK4) {
             if (std::regex_match(tensor_name, pattern_kv_cache) ||
                     std::regex_match(tensor_name, pattern_dsv4_state)) {

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -458,7 +458,7 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
                 return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_1, "attn_output_a.weight");
             }
             if (std::regex_match(tensor_name, pattern_attn_out_a_weight)) {
-                return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_2, "attn_output_b.weight");
+                return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_1, "attn_output_b.weight");
             }
             if (std::regex_match(tensor_name, pattern_attn_out_b_weight)) {
                 return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_0);
@@ -672,11 +672,8 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
                     const int64_t n_head_group = hparams.n_head(il) / hparams.dsv4_o_group_count;
                     return {n_head_group * hparams.n_embd_head_k(il)};
                 }
-                if (std::regex_match(tensor_name, pattern_attn_out_a_weight)) {
-                    GGML_ASSERT(segments.size() == 1);
-                    return {1};
-                }
-                if (std::regex_match(tensor_name, pattern_attn_out_b_weight)) {
+                if (std::regex_match(tensor_name, pattern_attn_out_a_weight) ||
+                        std::regex_match(tensor_name, pattern_attn_out_b_weight)) {
                     GGML_ASSERT(segments.size() == 1);
                     return {std::lcm<int64_t>(hparams.dsv4_o_lora_rank, blck_size)};
                 }

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -458,7 +458,7 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
                 return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_1, "attn_output_a.weight");
             }
             if (std::regex_match(tensor_name, pattern_attn_out_a_weight)) {
-                return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_1, "attn_output_b.weight");
+                return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_2);
             }
             if (std::regex_match(tensor_name, pattern_attn_out_b_weight)) {
                 return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_0);
@@ -540,6 +540,9 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
 
         // output
         if (std::regex_match(tensor_name, pattern_output_weight)) {
+            if (ud->model->arch == LLM_ARCH_DEEPSEEK4) {
+                return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+            }
             return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_1);
         }
         if (std::regex_match(tensor_name, pattern_output_bias)) {
@@ -672,10 +675,15 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
                     const int64_t n_head_group = hparams.n_head(il) / hparams.dsv4_o_group_count;
                     return {n_head_group * hparams.n_embd_head_k(il)};
                 }
-                if (std::regex_match(tensor_name, pattern_attn_out_a_weight) ||
-                        std::regex_match(tensor_name, pattern_attn_out_b_weight)) {
+                if (std::regex_match(tensor_name, pattern_attn_out_a_weight)) {
                     GGML_ASSERT(segments.size() == 1);
-                    return {std::lcm<int64_t>(hparams.dsv4_o_lora_rank, blck_size)};
+                    return {1};
+                }
+                if (std::regex_match(tensor_name, pattern_attn_out_b_weight)) {
+                    GGML_ASSERT(segments.size() == 1);
+                    // the boundaries must align with wo_a's per-group split, so quant blocks must not straddle groups
+                    GGML_ASSERT(hparams.dsv4_o_lora_rank % blck_size == 0);
+                    return {hparams.dsv4_o_lora_rank};
                 }
             }
 

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -458,7 +458,7 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
                 return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_1, "attn_output_a.weight");
             }
             if (std::regex_match(tensor_name, pattern_attn_out_a_weight)) {
-                return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_1, "attn_output_b.weight");
+                return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_2, "attn_output_b.weight");
             }
             if (std::regex_match(tensor_name, pattern_attn_out_b_weight)) {
                 return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_0);
@@ -672,8 +672,11 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
                     const int64_t n_head_group = hparams.n_head(il) / hparams.dsv4_o_group_count;
                     return {n_head_group * hparams.n_embd_head_k(il)};
                 }
-                if (std::regex_match(tensor_name, pattern_attn_out_a_weight) ||
-                        std::regex_match(tensor_name, pattern_attn_out_b_weight)) {
+                if (std::regex_match(tensor_name, pattern_attn_out_a_weight)) {
+                    GGML_ASSERT(segments.size() == 1);
+                    return {1};
+                }
+                if (std::regex_match(tensor_name, pattern_attn_out_b_weight)) {
                     GGML_ASSERT(segments.size() == 1);
                     return {std::lcm<int64_t>(hparams.dsv4_o_lora_rank, blck_size)};
                 }

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -655,7 +655,7 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
             if (std::regex_match(tensor_name, pattern_attn_sinks)) {
                 GGML_ASSERT(segments.size() == 1);
                 if (ud->model->arch == LLM_ARCH_DEEPSEEK4) {
-                    return {1};
+                    return {hparams.n_head(il) / hparams.dsv4_o_group_count};
                 }
                 return {std::lcm(n_embd_q, blck_size_perf)/n_embd_q * n_gqa};
             }
@@ -663,7 +663,9 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
             if (ud->model->arch == LLM_ARCH_DEEPSEEK4) {
                 if (std::regex_match(tensor_name, pattern_attn_q_b_weight)) {
                     GGML_ASSERT(segments.size() == 1);
-                    return {hparams.n_embd_head_k(il)};
+                    // the grouped output projection requires each device to hold whole groups of heads
+                    const int64_t n_head_group = hparams.n_head(il) / hparams.dsv4_o_group_count;
+                    return {n_head_group * hparams.n_embd_head_k(il)};
                 }
                 if (std::regex_match(tensor_name, pattern_attn_out_a_weight) ||
                         std::regex_match(tensor_name, pattern_attn_out_b_weight)) {

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -213,13 +213,9 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
         ms.add_kv(LLM_KV_ATTENTION_SLIDING_WINDOW_PATTERN, uint32_t(2));
     }
 
-    // MSA requires one indexer head per GQA (KV) head, unlike the DSA archs where the
-    // indexer head count is independent of the main attention head count.
-    ms.add_kv(LLM_KV_ATTENTION_INDEXER_HEAD_COUNT,   arch == LLM_ARCH_MINIMAX_M3 || arch == LLM_ARCH_DEEPSEEK4 ? n_head : uint32_t(1));
-    ms.add_kv(LLM_KV_ATTENTION_INDEXER_KEY_LENGTH,   uint32_t(64));
-    ms.add_kv(LLM_KV_ATTENTION_INDEXER_TOP_K,        uint32_t(8));
-    ms.add_kv(LLM_KV_ATTENTION_INDEXER_BLOCK_SIZE,   uint32_t(4));
-    ms.add_kv(LLM_KV_ATTENTION_INDEXER_LOCAL_BLOCKS, uint32_t(1));
+    ms.add_kv(LLM_KV_ATTENTION_INDEXER_HEAD_COUNT, arch == LLM_ARCH_DEEPSEEK4 ? n_head : uint32_t(1));
+    ms.add_kv(LLM_KV_ATTENTION_INDEXER_KEY_LENGTH, uint32_t(64));
+    ms.add_kv(LLM_KV_ATTENTION_INDEXER_TOP_K,      uint32_t(8));
     ms.add_kv(LLM_KV_ROPE_DIMENSION_SECTIONS, std::vector<uint32_t>({n_embd_head/4, n_embd_head/4, n_embd_head/4, n_embd_head/4}));
 
     if (arch == LLM_ARCH_DEEPSEEK4) {

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -453,7 +453,7 @@ static bool arch_supported(const llm_arch arch) {
     }
     // FIXME: these hit scheduler/view-backed-output issues with WebGPU on CI.
 #ifdef GGML_USE_WEBGPU
-    if (arch == LLM_ARCH_DEEPSEEK32 || arch == LLM_ARCH_GLM_DSA) {
+    if (arch == LLM_ARCH_DEEPSEEK32 || arch == LLM_ARCH_DEEPSEEK4 || arch == LLM_ARCH_GLM_DSA) {
         return false;
     }
 #endif // GGML_USE_WEBGPU

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -213,9 +213,13 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
         ms.add_kv(LLM_KV_ATTENTION_SLIDING_WINDOW_PATTERN, uint32_t(2));
     }
 
-    ms.add_kv(LLM_KV_ATTENTION_INDEXER_HEAD_COUNT, arch == LLM_ARCH_DEEPSEEK4 ? n_head : uint32_t(1));
-    ms.add_kv(LLM_KV_ATTENTION_INDEXER_KEY_LENGTH, uint32_t(64));
-    ms.add_kv(LLM_KV_ATTENTION_INDEXER_TOP_K,      uint32_t(8));
+    // MSA requires one indexer head per GQA (KV) head, unlike the DSA archs where the
+    // indexer head count is independent of the main attention head count.
+    ms.add_kv(LLM_KV_ATTENTION_INDEXER_HEAD_COUNT,   (arch == LLM_ARCH_MINIMAX_M3 || arch == LLM_ARCH_DEEPSEEK4) ? n_head : uint32_t(1));
+    ms.add_kv(LLM_KV_ATTENTION_INDEXER_KEY_LENGTH,   uint32_t(64));
+    ms.add_kv(LLM_KV_ATTENTION_INDEXER_TOP_K,        uint32_t(8));
+    ms.add_kv(LLM_KV_ATTENTION_INDEXER_BLOCK_SIZE,   uint32_t(4));
+    ms.add_kv(LLM_KV_ATTENTION_INDEXER_LOCAL_BLOCKS, uint32_t(1));
     ms.add_kv(LLM_KV_ROPE_DIMENSION_SECTIONS, std::vector<uint32_t>({n_embd_head/4, n_embd_head/4, n_embd_head/4, n_embd_head/4}));
 
     if (arch == LLM_ARCH_DEEPSEEK4) {

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -101,6 +101,12 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
         n_head = 1;
         n_ff   = 96;
         n_layer = 22; // hparams.n_layer_kv_from_start = 20 is hardcoded
+    } else if (arch == LLM_ARCH_DEEPSEEK4) {
+        // head size 64 so that GPU flash attention kernels support the model
+        n_embd  = 512;
+        n_head  = 8;
+        n_ff    = 1024;
+        n_layer = 4;
     } else if (arch == LLM_ARCH_DEEPSEEK2
             || arch == LLM_ARCH_DEEPSEEK32
             || arch == LLM_ARCH_GLM_DSA
@@ -156,11 +162,15 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
         ms.add_kv(LLM_KV_ATTENTION_HEAD_COUNT_KV, n_head_per_layer);
     } else {
         ms.add_kv(LLM_KV_ATTENTION_HEAD_COUNT, n_head);
-        ms.add_kv(LLM_KV_ATTENTION_HEAD_COUNT_KV, n_head);
+        ms.add_kv(LLM_KV_ATTENTION_HEAD_COUNT_KV, arch == LLM_ARCH_DEEPSEEK4 ? uint32_t(1) : n_head);
     }
 
     ms.add_kv(LLM_KV_ATTENTION_MAX_ALIBI_BIAS, 8.0f);
-    if (arch == LLM_ARCH_DEEPSEEK2
+    if (arch == LLM_ARCH_DEEPSEEK4) {
+        ms.add_kv(LLM_KV_ATTENTION_KEY_LENGTH,   n_embd_head);
+        ms.add_kv(LLM_KV_ATTENTION_VALUE_LENGTH, n_embd_head);
+        ms.add_kv(LLM_KV_ROPE_DIMENSION_COUNT,   n_embd_head/2);
+    } else if (arch == LLM_ARCH_DEEPSEEK2
             || arch == LLM_ARCH_DEEPSEEK32
             || arch == LLM_ARCH_GLM_DSA
             || arch == LLM_ARCH_KIMI_LINEAR
@@ -179,7 +189,7 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
     ms.add_kv(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS,      1e-5f);
     ms.add_kv(LLM_KV_ATTENTION_GROUPNORM_EPS,          1e-5f);
     ms.add_kv(LLM_KV_ATTENTION_GROUPNORM_GROUPS,       uint32_t(8));
-    ms.add_kv(LLM_KV_ATTENTION_Q_LORA_RANK,            uint32_t(512));
+    ms.add_kv(LLM_KV_ATTENTION_Q_LORA_RANK,            arch == LLM_ARCH_DEEPSEEK4 ? uint32_t(64) : uint32_t(512));
     ms.add_kv(LLM_KV_ATTENTION_KV_LORA_RANK,           uint32_t(512));
     ms.add_kv(LLM_KV_ATTENTION_RELATIVE_BUCKETS_COUNT, uint32_t(8));
     ms.add_kv(LLM_KV_ATTENTION_SLIDING_WINDOW,         n_ctx/8);
@@ -205,12 +215,26 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
 
     // MSA requires one indexer head per GQA (KV) head, unlike the DSA archs where the
     // indexer head count is independent of the main attention head count.
-    ms.add_kv(LLM_KV_ATTENTION_INDEXER_HEAD_COUNT,   arch == LLM_ARCH_MINIMAX_M3 ? n_head : uint32_t(1));
+    ms.add_kv(LLM_KV_ATTENTION_INDEXER_HEAD_COUNT,   arch == LLM_ARCH_MINIMAX_M3 || arch == LLM_ARCH_DEEPSEEK4 ? n_head : uint32_t(1));
     ms.add_kv(LLM_KV_ATTENTION_INDEXER_KEY_LENGTH,   uint32_t(64));
     ms.add_kv(LLM_KV_ATTENTION_INDEXER_TOP_K,        uint32_t(8));
     ms.add_kv(LLM_KV_ATTENTION_INDEXER_BLOCK_SIZE,   uint32_t(4));
     ms.add_kv(LLM_KV_ATTENTION_INDEXER_LOCAL_BLOCKS, uint32_t(1));
     ms.add_kv(LLM_KV_ROPE_DIMENSION_SECTIONS, std::vector<uint32_t>({n_embd_head/4, n_embd_head/4, n_embd_head/4, n_embd_head/4}));
+
+    if (arch == LLM_ARCH_DEEPSEEK4) {
+        ms.add_kv(LLM_KV_ATTENTION_OUTPUT_GROUP_COUNT,         uint32_t(8));
+        ms.add_kv(LLM_KV_ATTENTION_OUTPUT_LORA_RANK,           uint32_t(32));
+        ms.add_kv(LLM_KV_ATTENTION_COMPRESS_RATIOS,            std::vector<uint32_t>({0, 0, 4, 128}));
+        ms.add_kv(LLM_KV_ATTENTION_COMPRESS_ROPE_FREQ_BASE,    160000.0f);
+        ms.add_kv(LLM_KV_HYPER_CONNECTION_COUNT,               uint32_t(4));
+        ms.add_kv(LLM_KV_HYPER_CONNECTION_SINKHORN_ITERATIONS, uint32_t(2));
+        ms.add_kv(LLM_KV_HYPER_CONNECTION_EPSILON,             1.0e-6f);
+        ms.add_kv(LLM_KV_HASH_LAYER_COUNT,                      uint32_t(0));
+        ms.add_kv(LLM_KV_SWIGLU_CLAMP_EXP,                      10.0f);
+        ms.add_kv(LLM_KV_EXPERT_WEIGHTS_SCALE,                  1.0f);
+        ms.add_kv(LLM_KV_EXPERT_WEIGHTS_NORM,                   true);
+    }
     ms.add_kv(LLM_KV_TOKENIZER_MODEL,         "no_vocab");
     // ms.add_kv(LLM_KV_DENSE_2_FEAT_OUT,     n_embd);
     // ms.add_kv(LLM_KV_DENSE_3_FEAT_IN,      n_embd);
@@ -221,7 +245,7 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
         ms.add_kv(LLM_KV_EXPERT_COUNT,               uint32_t(2));
         ms.add_kv(LLM_KV_EXPERT_USED_COUNT,          uint32_t(1));
         ms.add_kv(LLM_KV_EXPERT_SHARED_COUNT,        uint32_t(1));
-        ms.add_kv(LLM_KV_EXPERT_GATING_FUNC,         uint32_t(2)); // sigmoid
+        ms.add_kv(LLM_KV_EXPERT_GATING_FUNC,         arch == LLM_ARCH_DEEPSEEK4 ? uint32_t(4) : uint32_t(2));
         ms.add_kv(LLM_KV_EXPERT_GROUP_SCALE,         1.0f);
         ms.add_kv(LLM_KV_EXPERTS_PER_GROUP,          uint32_t(1));
     }
@@ -347,6 +371,7 @@ static bool moe_mandatory(const llm_arch arch) {
         case LLM_ARCH_DEEPSEEK:
         case LLM_ARCH_DEEPSEEK2:
         case LLM_ARCH_DEEPSEEK32:
+        case LLM_ARCH_DEEPSEEK4:
         case LLM_ARCH_GLM4_MOE:
         case LLM_ARCH_GLM_DSA:
         case LLM_ARCH_EXAONE_MOE:
@@ -426,10 +451,6 @@ static bool arch_supported(const llm_arch arch) {
     if (arch == LLM_ARCH_DEEPSEEK2OCR) {
         return false;
     }
-    if (arch == LLM_ARCH_DEEPSEEK4) {
-        return false;
-    }
-
     // FIXME: these hit scheduler/view-backed-output issues with WebGPU on CI.
 #ifdef GGML_USE_WEBGPU
     if (arch == LLM_ARCH_DEEPSEEK32 || arch == LLM_ARCH_GLM_DSA) {
@@ -614,10 +635,18 @@ static int test_backends(const llm_arch target_arch, const size_t seed, const gg
                     if (logits_cpu.empty()) {
                         model_and_ctx_cpu = get_model_and_ctx(gguf_ctx.get(), nullptr, seed, {}, LLAMA_SPLIT_MODE_LAYER, encode);
                         logits_cpu = get_logits(model_and_ctx_cpu.first.get(), model_and_ctx_cpu.second.get(), tokens, encode);
+                        if (arch == LLM_ARCH_DEEPSEEK4) {
+                            GGML_ASSERT(llama_memory_seq_rm(
+                                    llama_get_memory(model_and_ctx_cpu.second.get()), 0, -1, -1));
+                        }
                     }
                     if (dc.split_mode != LLAMA_SPLIT_MODE_TENSOR || llm_arch_supports_sm_tensor(arch)) {
                         model_and_ctx_dev = get_model_and_ctx(gguf_ctx.get(), nullptr, seed, dc.devs, dc.split_mode, encode);
                         logits_dev = get_logits(model_and_ctx_dev.first.get(), model_and_ctx_dev.second.get(), tokens, encode);
+                        if (arch == LLM_ARCH_DEEPSEEK4) {
+                            GGML_ASSERT(llama_memory_seq_rm(
+                                    llama_get_memory(model_and_ctx_dev.second.get()), 0, -1, -1));
+                        }
                         const double nmse_val = nmse(logits_cpu, logits_dev);
                         snprintf(nmse_str, sizeof(nmse_str), "(%.2e)", nmse_val);
                         status_nmse = "\033[1;32mOK\033[0m";
@@ -630,7 +659,9 @@ static int test_backends(const llm_arch target_arch, const size_t seed, const gg
                     FILE * file = tmpfile(); // Can be null on Windows without administrator privileges.
                     // FIXME: when adding a tensor to a gguf_context a copy is made, this changes the pointer which the meta backend
                     //     in turn uses to map the tensors to their simple equivalents - this is fundamentally incompatible
-                    if (file != nullptr && llama_model_saver_supports_arch(arch) && dc.split_mode != LLAMA_SPLIT_MODE_TENSOR) {
+                    // FIXME: DSV4 metadata is not implemented by llama_model_saver.
+                    const bool can_roundtrip = llama_model_saver_supports_arch(arch) && arch != LLM_ARCH_DEEPSEEK4;
+                    if (file != nullptr && can_roundtrip && dc.split_mode != LLAMA_SPLIT_MODE_TENSOR) {
                         GGML_ASSERT(model_and_ctx_dev.first && model_and_ctx_dev.second);
                         llama_model_saver ms = llama_model_saver(model_and_ctx_dev.first.get());
                         ms.add_kv_from_model();

--- a/tools/rpc/README.md
+++ b/tools/rpc/README.md
@@ -101,6 +101,12 @@ On Linux systems with RoCEv2-capable NICs (e.g. Mellanox ConnectX), the RPC back
 
 RDMA is enabled by default when `libibverbs` is found at build time.
 
+### Direct all-reduce
+
+Tensor split with exactly two RPC devices uses a direct server-to-server connection for all-reduce. The first server listens on its RPC port plus 1000, and the second server connects to it. Set `GGML_RPC_COMM_PORT` on the main host to use a different port.
+
+Allow the communication port through the firewall and ensure that the servers can connect to each other. Use this only on a trusted private network because the connection does not provide transport authentication or encryption. Set `GGML_RPC_NO_COMM=1` on the main host to disable direct all-reduce.
+
 ### Troubleshooting
 
 Use the `GGML_RPC_DEBUG` environment variable to enable debug messages from `ggml-rpc-server`:

--- a/tools/rpc/README.md
+++ b/tools/rpc/README.md
@@ -108,3 +108,5 @@ Use the `GGML_RPC_DEBUG` environment variable to enable debug messages from `ggm
 $ GGML_RPC_DEBUG=1 bin/ggml-rpc-server
 ```
 
+Set `GGML_RPC_NO_WIRE_BF16=1` on the main host to keep direct all-reduce transfers in F32. By default, large F32 all-reduce tensors use BF16 on the wire to reduce peer traffic.
+


### PR DESCRIPTION
## Summary

Adds tensor parallel over RPC. Also adds minimal changes to the Vulkan + Meta backend to make TP work. This also contains changes to make `-sm tensor` work for DeepseekV4 Flash

## How to run

e.g. on 2 strix halos 

```
  Machine 1

 ./ggml-rpc-server -H 10.55.0.1 -p 50052 -d Vulkan0

 Machine 2

 ./ggml-rpc-server -H 10.55.0.2 -p 50052 -d Vulkan0

 Run from Machine 1

 Verify both servers:

 ./llama-bench \
   -rpc 10.55.0.1:50052,10.55.0.2:50052 \
   --list-devices

 Run tensor parallelism:

 ./llama-bench \
   -m /path/to/model.gguf \
   -rpc 10.55.0.1:50052,10.55.0.2:50052 \
   -dev RPC0/RPC1 \
   -sm tensor \
   -ts 1/1 \
   -ngl 99 \
   -fa 1 \
   -p 2048 -n 128 \
   -b 2048 -ub 512 \
   -r 5
   ```

 Notes:
 • Use matching client/server binaries.
 • The model is only needed on the client machine.
 • Allow TCP ports 50052 and 51052 between the machines.
 • Use a trusted private network; RPC is unauthenticated.
 • Ensure GGML_RPC_NO_COMM is not set.


## Test Plan 

Tested perplexity over wikitext-raw using `-ub 1` and `-ub 512` over 2x Sparks and 2x Strix halos. Everything matches with the single machine baseline on Vulkan and CUDA. 2x MACs over RDMA connected via ThunderBolt would be nice to test too

## Performance 

### Qwen-27B
Opt-in via `-sm tensor`. For Qwen3.6-27B over 2x Sparks over RDMA

| Depth | Backend | 1x PP | 2x PP | 1x TG | 2x TG |
|---:|---|---:|---:|---:|---:|
| 0 | CUDA | 871.93 | 784.80 | 7.25 | 11.95 |
| 0 | Vulkan | 405.92 | 539.13 | 6.95 | 10.03 |
| 10000 | CUDA | 768.15 | 743.35 | 6.67 | 11.68 |
| 10000 | Vulkan | 335.11 | 468.20 | 6.45 | 9.26 |
| 20000 | CUDA | 735.21 | 677.68 | 6.50 | 11.32 |
| 20000 | Vulkan | 265.44 | 414.84 | 6.54 | 9.60 |


For 2x Strix halos over TCP. Over RDMA should be measurably better in transferring large activations for prefill.

| Depth | 1x PP | 2x RPC PP | 1x TG | 2x RPC TG |
|---:|---:|---:|---:|---:|
| 0 | 209.73 | 117.12 | 7.84 | 10.08 |
| 10000 | 171.21 | 106.19 | 7.63 | 11.16 |
| 20000 | 119.37 | 106.10 | 7.46 | 10.38 |

## Further info

