### PR TITLE
QVAC-23195: (opencl : fix) Adreno E031.47 nibble-packing miscompile corrupting MoE expert weights

### DIFF
--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -7421,11 +7421,8 @@ static bool adreno_e17_compiler_quirks(const ggml_backend_opencl_context *backen
 }
 
 inline bool use_adreno_moe_kernels(const ggml_backend_opencl_context *backend_ctx, const ggml_tensor *tensor) {
-    // The moe weight repack kernels *_trans4_ns alias a private ushort8 through a uchar*.
-    // Certain compilers (found with some A7x and A6x) miscompiles this, corrupting the weights.
-    // So, exclude A6x and A7x from using Adreno MoE kernels for now.
-    // The quants that have a general mul_mat_id kernel fallback to the general version; the
-    // rest fallback to CPU.
+    // Keep A6x and A7x on their existing fallbacks until the optimized kernels
+    // are validated on those generations. Unknown Adreno devices also fall back.
     if (backend_ctx && (backend_ctx->adreno_gen == ADRENO_GPU_GEN::A6X ||
                         backend_ctx->adreno_gen == ADRENO_GPU_GEN::A7X ||
                         backend_ctx->adreno_gen == ADRENO_GPU_GEN::ADRENO_UNKNOWN)) {

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -7573,34 +7573,6 @@ static bool use_cpu_q4_k_moe_repack() {
     return env && atoi(env) != 0;
 }
 
-// The optimized MoE MUL_MAT_ID kernels return corrupted results on Adreno 8xx
-// with the E031.47 shader compiler (observed on Adreno 830 / Snapdragon 8 Elite,
-// compiler E031.47.18.51). Both Q4_K kernel families are affected - the F32
-// kernels and the dp4a ones - and repacking the weights on the host reproduces
-// the corruption bit for bit, so the defect is in the matmul kernels rather than
-// in the weight layout.
-//
-// The guard covers every quantization that reaches these kernels, not just the
-// one observed failing: a Q4_K_M model also carries Q6_K and Q5_0 experts, and
-// leaving those on the GPU still produced garbage. Types with general
-// MUL_MAT_ID support (Q4_0, Q8_0, MXFP4) are handled earlier and keep the GPU.
-//
-// Decline the op so it runs on the CPU backend, which is the only configuration
-// that produces correct output on this driver. Newer compilers keep the
-// optimized kernels and must be re-validated before being trusted. Set
-// GGML_OPENCL_ADRENO_MOE_KERNELS=1 to re-enable the kernels for that validation.
-static bool adreno_moe_mul_mat_id_broken(const ggml_backend_opencl_context * backend_ctx) {
-    if (!backend_ctx || backend_ctx->gpu_family != GPU_FAMILY::ADRENO ||
-        backend_ctx->adreno_gen != ADRENO_GPU_GEN::A8X ||
-        backend_ctx->adreno_cl_compiler_version.type != ADRENO_CL_COMPILER_TYPE::E031 ||
-        backend_ctx->adreno_cl_compiler_version.major > 47) {
-        return false;
-    }
-
-    const char * env = getenv("GGML_OPENCL_ADRENO_MOE_KERNELS");
-    return !(env && atoi(env) != 0);
-}
-
 inline bool enable_adreno_trans_weight(const ggml_backend_opencl_context *backend_ctx, const ggml_tensor *tensor) {
 
     bool adreno_kernel = use_adreno_kernels(backend_ctx, tensor);
@@ -7900,9 +7872,6 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
                 op->src[0]->type == GGML_TYPE_Q6_K) {
 #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
                 if (op->src[1]->type == GGML_TYPE_F32) {
-                    if (adreno_moe_mul_mat_id_broken(backend_ctx)) {
-                        return false;
-                    }
                     return use_adreno_moe_kernels(backend_ctx, op->src[0])
                         && ggml_is_contiguous(op->src[0])
                         && ggml_is_contiguous(op->src[1]);

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -7566,22 +7566,27 @@ inline bool use_adreno_moe_kernels(const ggml_backend_opencl_context *backend_ct
     return (((strstr(tensor->name, "ffn") != NULL) && (strstr(tensor->name, "exps") != NULL)) || (strstr(tensor->name, "as") != NULL)) && (ne01 % 32 == 0);
 }
 
-static bool use_cpu_q4_k_moe_repack(const ggml_backend_opencl_context * backend_ctx) {
+// Opt-in host-side equivalent of kernel_convert_block_q4_k_trans4_ns, used to
+// tell weight-layout defects apart from matmul defects on a given driver.
+static bool use_cpu_q4_k_moe_repack() {
     const char * env = getenv("GGML_OPENCL_Q4K_MOE_CPU_REPACK");
-    if (env) {
-        return atoi(env) != 0;
-    }
+    return env && atoi(env) != 0;
+}
 
-    if (!backend_ctx || backend_ctx->gpu_family != GPU_FAMILY::ADRENO) {
+// The optimized Q4_K MoE MUL_MAT_ID kernels return corrupted results on Adreno
+// 8xx: repacking the weights on the host reproduces the corruption bit for bit,
+// so the defect is in the matmul kernels rather than in the weight layout.
+// Decline the op so it runs on the CPU backend, which is the only configuration
+// that produces correct output on this hardware. Set
+// GGML_OPENCL_ADRENO_Q4K_MOE=1 to re-enable the kernels for driver validation.
+static bool adreno_q4_k_moe_mul_mat_id_broken(const ggml_backend_opencl_context * backend_ctx) {
+    if (!backend_ctx || backend_ctx->gpu_family != GPU_FAMILY::ADRENO ||
+        backend_ctx->adreno_gen != ADRENO_GPU_GEN::A8X) {
         return false;
     }
 
-    // Qualcomm E031.47 miscompiles the Q4_K trans4 OpenCL repack used by MoE
-    // weights. Some Android drivers omit the compiler token from
-    // CL_DRIVER_VERSION, so identify the affected Adreno 830 directly too.
-    return backend_ctx->device_name.find("830") != std::string::npos ||
-           (backend_ctx->adreno_cl_compiler_version.type == ADRENO_CL_COMPILER_TYPE::E031 &&
-            backend_ctx->adreno_cl_compiler_version.major == 47);
+    const char * env = getenv("GGML_OPENCL_ADRENO_Q4K_MOE");
+    return !(env && atoi(env) != 0);
 }
 
 inline bool enable_adreno_trans_weight(const ggml_backend_opencl_context *backend_ctx, const ggml_tensor *tensor) {
@@ -7883,6 +7888,10 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
                 op->src[0]->type == GGML_TYPE_Q6_K) {
 #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
                 if (op->src[1]->type == GGML_TYPE_F32) {
+                    if (op->src[0]->type == GGML_TYPE_Q4_K &&
+                        adreno_q4_k_moe_mul_mat_id_broken(backend_ctx)) {
+                        return false;
+                    }
                     return use_adreno_moe_kernels(backend_ctx, op->src[0])
                         && ggml_is_contiguous(op->src[0])
                         && ggml_is_contiguous(op->src[1]);
@@ -9578,7 +9587,7 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
             int ne01 = tensor->ne[1];
             int ne02 = tensor->ne[2];
 
-            if (use_cpu_q4_k_moe_repack(backend_ctx)) {
+            if (use_cpu_q4_k_moe_repack()) {
                 GGML_ASSERT(offset == 0 && size == ggml_nbytes(tensor) &&
                             "CPU Q4_K MoE repack requires a full-tensor upload");
                 GGML_LOG_INFO(

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -7,6 +7,10 @@
 #pragma GCC diagnostic ignored "-Wgnu-anonymous-struct"
 #endif
 
+#ifdef GGML_OPENCL_USE_ADRENO_KERNELS
+#define GGML_COMMON_DECL_CPP
+#include "ggml-common.h"
+#endif
 #include "ggml-opencl.h"
 #include "ggml-backend.h"
 #include "ggml-impl.h"
@@ -39,6 +43,7 @@ typedef const void * (*get_adreno_bin_kernel_func_t)(
 #include <cstddef>
 #include <cstdint>
 #include <fstream>
+#include <limits>
 #include <vector>
 #include <string>
 #include <cmath>
@@ -167,6 +172,130 @@ static size_t align_to(size_t value, size_t to_alignment) {
 
     return ((value + to_alignment - 1) / to_alignment) * to_alignment;
 }
+
+#ifdef GGML_OPENCL_USE_ADRENO_KERNELS
+static uint32_t ggml_opencl_pack_u8x4_lsb(uint8_t x0, uint8_t x1, uint8_t x2, uint8_t x3) {
+    return (uint32_t) x0 |
+           ((uint32_t) x1 << 8) |
+           ((uint32_t) x2 << 16) |
+           ((uint32_t) x3 << 24);
+}
+
+static uint32_t ggml_opencl_pack_q4_trans4_low(const uint8_t * q) {
+    return ggml_opencl_pack_u8x4_lsb(
+        (q[0] & 0x0F) | ((q[1] & 0x0F) << 4),
+        (q[2] & 0x0F) | ((q[3] & 0x0F) << 4),
+        (q[4] & 0x0F) | ((q[5] & 0x0F) << 4),
+        (q[6] & 0x0F) | ((q[7] & 0x0F) << 4));
+}
+
+static uint32_t ggml_opencl_pack_q4_trans4_high(const uint8_t * q) {
+    return ggml_opencl_pack_u8x4_lsb(
+        ((q[0] & 0xF0) >> 4) | (q[1] & 0xF0),
+        ((q[2] & 0xF0) >> 4) | (q[3] & 0xF0),
+        ((q[4] & 0xF0) >> 4) | (q[5] & 0xF0),
+        ((q[6] & 0xF0) >> 4) | (q[7] & 0xF0));
+}
+
+static void ggml_opencl_repack_q4_trans4_quants(
+        const block_q4_K & block,
+        std::vector<uint32_t> & q,
+        size_t q_base,
+        size_t row_count) {
+    for (size_t group = 0; group < QK_K / 64; ++group) {
+        const size_t src_offset = group * 32;
+        const size_t dst_offset = group * 8;
+        q[q_base + (dst_offset + 0) * row_count] = ggml_opencl_pack_q4_trans4_low(block.qs + src_offset + 0);
+        q[q_base + (dst_offset + 1) * row_count] = ggml_opencl_pack_q4_trans4_low(block.qs + src_offset + 8);
+        q[q_base + (dst_offset + 2) * row_count] = ggml_opencl_pack_q4_trans4_low(block.qs + src_offset + 16);
+        q[q_base + (dst_offset + 3) * row_count] = ggml_opencl_pack_q4_trans4_low(block.qs + src_offset + 24);
+        q[q_base + (dst_offset + 4) * row_count] = ggml_opencl_pack_q4_trans4_high(block.qs + src_offset + 0);
+        q[q_base + (dst_offset + 5) * row_count] = ggml_opencl_pack_q4_trans4_high(block.qs + src_offset + 8);
+        q[q_base + (dst_offset + 6) * row_count] = ggml_opencl_pack_q4_trans4_high(block.qs + src_offset + 16);
+        q[q_base + (dst_offset + 7) * row_count] = ggml_opencl_pack_q4_trans4_high(block.qs + src_offset + 24);
+    }
+}
+
+struct ggml_opencl_q4_k_moe_repack {
+    std::vector<ggml_fp16_t> d;
+    std::vector<ggml_fp16_t> dm;
+    std::vector<uint8_t> s;
+    std::vector<uint32_t> q;
+};
+
+static void ggml_opencl_repack_q4_k_moe_blocks(
+        const void * data,
+        size_t block_count,
+        size_t blocks_per_row,
+        size_t row_count,
+        ggml_opencl_q4_k_moe_repack & repack) {
+    const size_t blocks_per_batch = blocks_per_row * row_count;
+    const uint8_t * src = static_cast<const uint8_t *>(data);
+
+    for (size_t src_block_offset = 0; src_block_offset < block_count; ++src_block_offset) {
+        block_q4_K block;
+        memcpy(&block, src + src_block_offset * sizeof(block), sizeof(block));
+
+        const size_t batch = src_block_offset / blocks_per_batch;
+        const size_t batch_offset = src_block_offset % blocks_per_batch;
+        const size_t row = batch_offset / blocks_per_row;
+        const size_t block_column = batch_offset % blocks_per_row;
+        const size_t dst_block_offset =
+            row + block_column * row_count + batch * blocks_per_batch;
+
+        repack.d[dst_block_offset] = block.GGML_COMMON_AGGR_U.GGML_COMMON_AGGR_S.d;
+        repack.dm[dst_block_offset] = block.GGML_COMMON_AGGR_U.GGML_COMMON_AGGR_S.dmin;
+        memcpy(repack.s.data() + src_block_offset * K_SCALE_SIZE, block.scales, K_SCALE_SIZE);
+
+        const size_t q_base =
+            batch * blocks_per_batch * 32 + block_column * row_count * 32 + row;
+        ggml_opencl_repack_q4_trans4_quants(block, repack.q, q_base, row_count);
+    }
+}
+
+static ggml_opencl_q4_k_moe_repack ggml_opencl_repack_q4_k_moe(
+        const ggml_tensor * tensor,
+        const void * data,
+        size_t size_d,
+        size_t size_dm,
+        size_t size_s,
+        size_t size_q) {
+    GGML_ASSERT(tensor->ne[0] > 0 && tensor->ne[0] % QK_K == 0);
+    GGML_ASSERT(tensor->ne[1] > 0);
+    GGML_ASSERT(tensor->ne[2] > 0);
+    GGML_ASSERT(tensor->ne[3] == 1);
+
+    const size_t blocks_per_row = static_cast<size_t>(tensor->ne[0] / QK_K);
+    const size_t row_count = static_cast<size_t>(tensor->ne[1]);
+    const size_t batch_count = static_cast<size_t>(tensor->ne[2]);
+    GGML_ASSERT(blocks_per_row <= std::numeric_limits<size_t>::max() / row_count);
+    const size_t blocks_per_batch = blocks_per_row * row_count;
+    GGML_ASSERT(blocks_per_batch <= std::numeric_limits<size_t>::max() / batch_count);
+    const size_t block_count = blocks_per_batch * batch_count;
+
+    GGML_ASSERT(block_count == static_cast<size_t>(ggml_nelements(tensor) / QK_K));
+    GGML_ASSERT(block_count <= std::numeric_limits<size_t>::max() / sizeof(block_q4_K));
+    GGML_ASSERT(block_count <= std::numeric_limits<size_t>::max() / sizeof(ggml_fp16_t));
+    GGML_ASSERT(size_d == block_count * sizeof(ggml_fp16_t));
+    GGML_ASSERT(size_dm == block_count * sizeof(ggml_fp16_t));
+    GGML_ASSERT(block_count <= std::numeric_limits<size_t>::max() / K_SCALE_SIZE);
+    GGML_ASSERT(size_s == block_count * K_SCALE_SIZE);
+    GGML_ASSERT(block_count <= std::numeric_limits<size_t>::max() / (QK_K / 8));
+    const size_t q_word_count = block_count * (QK_K / 8);
+    GGML_ASSERT(q_word_count <= std::numeric_limits<size_t>::max() / sizeof(uint32_t));
+    GGML_ASSERT(size_q == q_word_count * sizeof(uint32_t));
+
+    ggml_opencl_q4_k_moe_repack repack {
+        std::vector<ggml_fp16_t>(block_count),
+        std::vector<ggml_fp16_t>(block_count),
+        std::vector<uint8_t>(size_s),
+        std::vector<uint32_t>(q_word_count),
+    };
+    ggml_opencl_repack_q4_k_moe_blocks(
+        data, block_count, blocks_per_row, row_count, repack);
+    return repack;
+}
+#endif
 
 
 // Parses a version string of form "XX.YY ". On an error returns ggml_cl_version with all zeroes.
@@ -9427,30 +9556,45 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
 
 #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
         if (use_adreno_moe_kernels(backend_ctx, tensor)) {
-            cl_kernel kernel = backend_ctx->kernel_convert_block_q4_k_trans4_ns;
-
             int ne00 = tensor->ne[0];
             int ne01 = tensor->ne[1];
             int ne02 = tensor->ne[2];
 
-            cl_uchar mask_0F = 0x0F;
-            cl_uchar mask_F0 = 0xF0;
-            CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &data_device));
-            CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->q));
-            CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &extra->d));
-            CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &extra->dm));
-            CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), &extra->s));
-            CL_CHECK(clSetKernelArg(kernel, 5, sizeof(int), &ne00));
-            CL_CHECK(clSetKernelArg(kernel, 6, sizeof(int), &ne01));
-            CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_uchar), &mask_0F));
-            CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_uchar), &mask_F0));
+            static const char * cpu_repack_env = getenv("GGML_OPENCL_Q4K_MOE_CPU_REPACK");
+            const bool use_cpu_repack = cpu_repack_env && atoi(cpu_repack_env) != 0;
+            if (use_cpu_repack) {
+                GGML_ASSERT(offset == 0 && size == ggml_nbytes(tensor) &&
+                            "CPU Q4_K MoE repack requires a full-tensor upload");
+                GGML_LOG_INFO(
+                    "ggml_opencl: using CPU Q4_K MoE repack for tensor '%s' [%" PRId64 ", %" PRId64 ", %" PRId64 ", %" PRId64 "]\n",
+                    tensor->name, tensor->ne[0], tensor->ne[1], tensor->ne[2], tensor->ne[3]);
+                ggml_opencl_q4_k_moe_repack repack =
+                    ggml_opencl_repack_q4_k_moe(tensor, data, size_d, size_dm, size_s, size_q);
+                CL_CHECK(clEnqueueWriteBuffer(queue, extra->d, CL_TRUE, 0, size_d, repack.d.data(), 0, NULL, NULL));
+                CL_CHECK(clEnqueueWriteBuffer(queue, extra->dm, CL_TRUE, 0, size_dm, repack.dm.data(), 0, NULL, NULL));
+                CL_CHECK(clEnqueueWriteBuffer(queue, extra->s, CL_TRUE, 0, size_s, repack.s.data(), 0, NULL, NULL));
+                CL_CHECK(clEnqueueWriteBuffer(queue, extra->q, CL_TRUE, 0, size_q, repack.q.data(), 0, NULL, NULL));
+            } else {
+                cl_kernel kernel = backend_ctx->kernel_convert_block_q4_k_trans4_ns;
+                cl_uchar mask_0F = 0x0F;
+                cl_uchar mask_F0 = 0xF0;
+                CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &data_device));
+                CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->q));
+                CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &extra->d));
+                CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &extra->dm));
+                CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), &extra->s));
+                CL_CHECK(clSetKernelArg(kernel, 5, sizeof(int), &ne00));
+                CL_CHECK(clSetKernelArg(kernel, 6, sizeof(int), &ne01));
+                CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_uchar), &mask_0F));
+                CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_uchar), &mask_F0));
 
-            size_t global_work_size[] = {static_cast<size_t>(((ne01 + 63) / 64) * 64), static_cast<size_t>(ne00 / 256), static_cast<size_t>(ne02)};
-            size_t local_work_size[] = {64, 1, 1};
+                size_t global_work_size[] = {static_cast<size_t>(((ne01 + 63) / 64) * 64), static_cast<size_t>(ne00 / 256), static_cast<size_t>(ne02)};
+                size_t local_work_size[] = {64, 1, 1};
 
-            cl_event evt;
-            CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, 3, NULL, global_work_size, local_work_size, 0, NULL, &evt));
-            CL_CHECK(clWaitForEvents(1, &evt));
+                cl_event evt;
+                CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, 3, NULL, global_work_size, local_work_size, 0, NULL, &evt));
+                CL_CHECK(clWaitForEvents(1, &evt));
+            }
             CL_CHECK(clReleaseMemObject(data_device));
 
             cl_image_format img_format_q = {CL_R, CL_UNSIGNED_INT32};

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -7573,15 +7573,21 @@ static bool use_cpu_q4_k_moe_repack() {
     return env && atoi(env) != 0;
 }
 
-// The optimized Q4_K MoE MUL_MAT_ID kernels return corrupted results on Adreno
-// 8xx: repacking the weights on the host reproduces the corruption bit for bit,
-// so the defect is in the matmul kernels rather than in the weight layout.
+// Both Q4_K MoE MUL_MAT_ID kernel families - the F32 kernels and the dp4a ones
+// - return corrupted results on Adreno 8xx with the E031.47 shader compiler
+// (observed on Adreno 830 / Snapdragon 8 Elite, compiler E031.47.18.51).
+// Repacking the weights on the host reproduces the corruption bit for bit, so
+// the defect is in the matmul kernels rather than in the weight layout.
+//
 // Decline the op so it runs on the CPU backend, which is the only configuration
-// that produces correct output on this hardware. Set
-// GGML_OPENCL_ADRENO_Q4K_MOE=1 to re-enable the kernels for driver validation.
+// that produces correct output on this driver. Newer compilers keep the
+// optimized kernels and must be re-validated before being trusted. Set
+// GGML_OPENCL_ADRENO_Q4K_MOE=1 to re-enable the kernels for that validation.
 static bool adreno_q4_k_moe_mul_mat_id_broken(const ggml_backend_opencl_context * backend_ctx) {
     if (!backend_ctx || backend_ctx->gpu_family != GPU_FAMILY::ADRENO ||
-        backend_ctx->adreno_gen != ADRENO_GPU_GEN::A8X) {
+        backend_ctx->adreno_gen != ADRENO_GPU_GEN::A8X ||
+        backend_ctx->adreno_cl_compiler_version.type != ADRENO_CL_COMPILER_TYPE::E031 ||
+        backend_ctx->adreno_cl_compiler_version.major > 47) {
         return false;
     }
 

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -7572,11 +7572,16 @@ static bool use_cpu_q4_k_moe_repack(const ggml_backend_opencl_context * backend_
         return atoi(env) != 0;
     }
 
+    if (!backend_ctx || backend_ctx->gpu_family != GPU_FAMILY::ADRENO) {
+        return false;
+    }
+
     // Qualcomm E031.47 miscompiles the Q4_K trans4 OpenCL repack used by MoE
-    // weights. Default to the equivalent host repack on affected drivers.
-    return backend_ctx &&
-           backend_ctx->adreno_cl_compiler_version.type == ADRENO_CL_COMPILER_TYPE::E031 &&
-           backend_ctx->adreno_cl_compiler_version.major == 47;
+    // weights. Some Android drivers omit the compiler token from
+    // CL_DRIVER_VERSION, so identify the affected Adreno 830 directly too.
+    return backend_ctx->device_name.find("830") != std::string::npos ||
+           (backend_ctx->adreno_cl_compiler_version.type == ADRENO_CL_COMPILER_TYPE::E031 &&
+            backend_ctx->adreno_cl_compiler_version.major == 47);
 }
 
 inline bool enable_adreno_trans_weight(const ggml_backend_opencl_context *backend_ctx, const ggml_tensor *tensor) {

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -7573,17 +7573,23 @@ static bool use_cpu_q4_k_moe_repack() {
     return env && atoi(env) != 0;
 }
 
-// Both Q4_K MoE MUL_MAT_ID kernel families - the F32 kernels and the dp4a ones
-// - return corrupted results on Adreno 8xx with the E031.47 shader compiler
-// (observed on Adreno 830 / Snapdragon 8 Elite, compiler E031.47.18.51).
-// Repacking the weights on the host reproduces the corruption bit for bit, so
-// the defect is in the matmul kernels rather than in the weight layout.
+// The optimized MoE MUL_MAT_ID kernels return corrupted results on Adreno 8xx
+// with the E031.47 shader compiler (observed on Adreno 830 / Snapdragon 8 Elite,
+// compiler E031.47.18.51). Both Q4_K kernel families are affected - the F32
+// kernels and the dp4a ones - and repacking the weights on the host reproduces
+// the corruption bit for bit, so the defect is in the matmul kernels rather than
+// in the weight layout.
+//
+// The guard covers every quantization that reaches these kernels, not just the
+// one observed failing: a Q4_K_M model also carries Q6_K and Q5_0 experts, and
+// leaving those on the GPU still produced garbage. Types with general
+// MUL_MAT_ID support (Q4_0, Q8_0, MXFP4) are handled earlier and keep the GPU.
 //
 // Decline the op so it runs on the CPU backend, which is the only configuration
 // that produces correct output on this driver. Newer compilers keep the
 // optimized kernels and must be re-validated before being trusted. Set
-// GGML_OPENCL_ADRENO_Q4K_MOE=1 to re-enable the kernels for that validation.
-static bool adreno_q4_k_moe_mul_mat_id_broken(const ggml_backend_opencl_context * backend_ctx) {
+// GGML_OPENCL_ADRENO_MOE_KERNELS=1 to re-enable the kernels for that validation.
+static bool adreno_moe_mul_mat_id_broken(const ggml_backend_opencl_context * backend_ctx) {
     if (!backend_ctx || backend_ctx->gpu_family != GPU_FAMILY::ADRENO ||
         backend_ctx->adreno_gen != ADRENO_GPU_GEN::A8X ||
         backend_ctx->adreno_cl_compiler_version.type != ADRENO_CL_COMPILER_TYPE::E031 ||
@@ -7591,7 +7597,7 @@ static bool adreno_q4_k_moe_mul_mat_id_broken(const ggml_backend_opencl_context 
         return false;
     }
 
-    const char * env = getenv("GGML_OPENCL_ADRENO_Q4K_MOE");
+    const char * env = getenv("GGML_OPENCL_ADRENO_MOE_KERNELS");
     return !(env && atoi(env) != 0);
 }
 
@@ -7894,8 +7900,7 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
                 op->src[0]->type == GGML_TYPE_Q6_K) {
 #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
                 if (op->src[1]->type == GGML_TYPE_F32) {
-                    if (op->src[0]->type == GGML_TYPE_Q4_K &&
-                        adreno_q4_k_moe_mul_mat_id_broken(backend_ctx)) {
+                    if (adreno_moe_mul_mat_id_broken(backend_ctx)) {
                         return false;
                     }
                     return use_adreno_moe_kernels(backend_ctx, op->src[0])

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -7566,6 +7566,19 @@ inline bool use_adreno_moe_kernels(const ggml_backend_opencl_context *backend_ct
     return (((strstr(tensor->name, "ffn") != NULL) && (strstr(tensor->name, "exps") != NULL)) || (strstr(tensor->name, "as") != NULL)) && (ne01 % 32 == 0);
 }
 
+static bool use_cpu_q4_k_moe_repack(const ggml_backend_opencl_context * backend_ctx) {
+    const char * env = getenv("GGML_OPENCL_Q4K_MOE_CPU_REPACK");
+    if (env) {
+        return atoi(env) != 0;
+    }
+
+    // Qualcomm E031.47 miscompiles the Q4_K trans4 OpenCL repack used by MoE
+    // weights. Default to the equivalent host repack on affected drivers.
+    return backend_ctx &&
+           backend_ctx->adreno_cl_compiler_version.type == ADRENO_CL_COMPILER_TYPE::E031 &&
+           backend_ctx->adreno_cl_compiler_version.major == 47;
+}
+
 inline bool enable_adreno_trans_weight(const ggml_backend_opencl_context *backend_ctx, const ggml_tensor *tensor) {
 
     bool adreno_kernel = use_adreno_kernels(backend_ctx, tensor);
@@ -9560,9 +9573,7 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
             int ne01 = tensor->ne[1];
             int ne02 = tensor->ne[2];
 
-            static const char * cpu_repack_env = getenv("GGML_OPENCL_Q4K_MOE_CPU_REPACK");
-            const bool use_cpu_repack = cpu_repack_env && atoi(cpu_repack_env) != 0;
-            if (use_cpu_repack) {
+            if (use_cpu_q4_k_moe_repack(backend_ctx)) {
                 GGML_ASSERT(offset == 0 && size == ggml_nbytes(tensor) &&
                             "CPU Q4_K MoE repack requires a full-tensor upload");
                 GGML_LOG_INFO(

--- a/ggml/src/ggml-opencl/kernels/cvt.cl
+++ b/ggml/src/ggml-opencl/kernels/cvt.cl
@@ -40,44 +40,25 @@ typedef ushort uint16_t;
 typedef int int32_t;
 typedef uint uint32_t;
 
+// trans4_ns GEMM kernels consume bytes in least-significant-first numeric order.
 static inline uint pack_uchar4(uchar x0, uchar x1, uchar x2, uchar x3) {
-#ifdef __ENDIAN_LITTLE__
     return (uint) x0 | ((uint) x1 << 8) | ((uint) x2 << 16) | ((uint) x3 << 24);
-#else
-    return ((uint) x0 << 24) | ((uint) x1 << 16) | ((uint) x2 << 8) | (uint) x3;
-#endif
 }
 
 static inline uchar unpack_uchar0(uint x) {
-#ifdef __ENDIAN_LITTLE__
     return (uchar) (x & 0xFF);
-#else
-    return (uchar) ((x >> 24) & 0xFF);
-#endif
 }
 
 static inline uchar unpack_uchar1(uint x) {
-#ifdef __ENDIAN_LITTLE__
     return (uchar) ((x >> 8) & 0xFF);
-#else
-    return (uchar) ((x >> 16) & 0xFF);
-#endif
 }
 
 static inline uchar unpack_uchar2(uint x) {
-#ifdef __ENDIAN_LITTLE__
     return (uchar) ((x >> 16) & 0xFF);
-#else
-    return (uchar) ((x >> 8) & 0xFF);
-#endif
 }
 
 static inline uchar unpack_uchar3(uint x) {
-#ifdef __ENDIAN_LITTLE__
     return (uchar) ((x >> 24) & 0xFF);
-#else
-    return (uchar) (x & 0xFF);
-#endif
 }
 
 static inline uint pack_trans4_low(__global const uchar * q, uint offset) {

--- a/ggml/src/ggml-opencl/kernels/cvt.cl
+++ b/ggml/src/ggml-opencl/kernels/cvt.cl
@@ -41,8 +41,13 @@ typedef int int32_t;
 typedef uint uint32_t;
 
 // trans4_ns GEMM kernels consume bytes in least-significant-first numeric order.
-static inline uint pack_uchar4(uchar x0, uchar x1, uchar x2, uchar x3) {
-    return (uint) x0 | ((uint) x1 << 8) | ((uint) x2 << 16) | ((uint) x3 << 24);
+//
+// Everything here stays in uint registers. Narrowing intermediates to uchar
+// locals is miscompiled by the Adreno E031.47 shader compiler: it keeps the
+// first byte of each packed word and drops the rest, which silently corrupts
+// every repacked expert weight.
+static inline uint pack_uchar4(uint x0, uint x1, uint x2, uint x3) {
+    return (x0 & 0xFFu) | ((x1 & 0xFFu) << 8) | ((x2 & 0xFFu) << 16) | ((x3 & 0xFFu) << 24);
 }
 
 static inline uchar unpack_uchar0(uint x) {
@@ -61,36 +66,33 @@ static inline uchar unpack_uchar3(uint x) {
     return (uchar) ((x >> 24) & 0xFF);
 }
 
+// The low nibbles are combined with a multiply rather than `| (x << 4)`: the
+// E031.47 compiler drops the mask on the shifted term, letting the odd byte's
+// high nibble leak into the next byte of the packed word.
 static inline uint pack_trans4_low(__global const uchar * q, uint offset) {
-    uchar x0 = q[offset + 0];
-    uchar x1 = q[offset + 1];
-    uchar x2 = q[offset + 2];
-    uchar x3 = q[offset + 3];
-    uchar x4 = q[offset + 4];
-    uchar x5 = q[offset + 5];
-    uchar x6 = q[offset + 6];
-    uchar x7 = q[offset + 7];
-    return pack_uchar4(
-        (x0 & 0x0F) | ((x1 & 0x0F) << 4),
-        (x2 & 0x0F) | ((x3 & 0x0F) << 4),
-        (x4 & 0x0F) | ((x5 & 0x0F) << 4),
-        (x6 & 0x0F) | ((x7 & 0x0F) << 4));
+    uint w = 0;
+    for (uint t = 0; t < 4; ++t) {
+        const uint lo = q[offset + 2 * t + 0] & 0x0Fu;
+        const uint hi = q[offset + 2 * t + 1] & 0x0Fu;
+        w |= ((lo + hi * 16u) & 0xFFu) << (8u * t);
+    }
+    return w;
 }
 
 static inline uint pack_trans4_high(__global const uchar * q, uint offset) {
-    uchar x0 = q[offset + 0];
-    uchar x1 = q[offset + 1];
-    uchar x2 = q[offset + 2];
-    uchar x3 = q[offset + 3];
-    uchar x4 = q[offset + 4];
-    uchar x5 = q[offset + 5];
-    uchar x6 = q[offset + 6];
-    uchar x7 = q[offset + 7];
+    const uint x0 = q[offset + 0];
+    const uint x1 = q[offset + 1];
+    const uint x2 = q[offset + 2];
+    const uint x3 = q[offset + 3];
+    const uint x4 = q[offset + 4];
+    const uint x5 = q[offset + 5];
+    const uint x6 = q[offset + 6];
+    const uint x7 = q[offset + 7];
     return pack_uchar4(
-        ((x0 & 0xF0) >> 4) | (x1 & 0xF0),
-        ((x2 & 0xF0) >> 4) | (x3 & 0xF0),
-        ((x4 & 0xF0) >> 4) | (x5 & 0xF0),
-        ((x6 & 0xF0) >> 4) | (x7 & 0xF0));
+        ((x0 & 0xF0u) >> 4) | (x1 & 0xF0u),
+        ((x2 & 0xF0u) >> 4) | (x3 & 0xF0u),
+        ((x4 & 0xF0u) >> 4) | (x5 & 0xF0u),
+        ((x6 & 0xF0u) >> 4) | (x7 & 0xF0u));
 }
 
 static inline void restore_trans4(

--- a/ggml/src/ggml-opencl/kernels/cvt.cl
+++ b/ggml/src/ggml-opencl/kernels/cvt.cl
@@ -40,6 +40,102 @@ typedef ushort uint16_t;
 typedef int int32_t;
 typedef uint uint32_t;
 
+static inline uint pack_uchar4(uchar x0, uchar x1, uchar x2, uchar x3) {
+#ifdef __ENDIAN_LITTLE__
+    return (uint) x0 | ((uint) x1 << 8) | ((uint) x2 << 16) | ((uint) x3 << 24);
+#else
+    return ((uint) x0 << 24) | ((uint) x1 << 16) | ((uint) x2 << 8) | (uint) x3;
+#endif
+}
+
+static inline uchar unpack_uchar0(uint x) {
+#ifdef __ENDIAN_LITTLE__
+    return (uchar) (x & 0xFF);
+#else
+    return (uchar) ((x >> 24) & 0xFF);
+#endif
+}
+
+static inline uchar unpack_uchar1(uint x) {
+#ifdef __ENDIAN_LITTLE__
+    return (uchar) ((x >> 8) & 0xFF);
+#else
+    return (uchar) ((x >> 16) & 0xFF);
+#endif
+}
+
+static inline uchar unpack_uchar2(uint x) {
+#ifdef __ENDIAN_LITTLE__
+    return (uchar) ((x >> 16) & 0xFF);
+#else
+    return (uchar) ((x >> 8) & 0xFF);
+#endif
+}
+
+static inline uchar unpack_uchar3(uint x) {
+#ifdef __ENDIAN_LITTLE__
+    return (uchar) ((x >> 24) & 0xFF);
+#else
+    return (uchar) (x & 0xFF);
+#endif
+}
+
+static inline uint pack_trans4_low(__global const uchar * q, uint offset) {
+    uchar x0 = q[offset + 0];
+    uchar x1 = q[offset + 1];
+    uchar x2 = q[offset + 2];
+    uchar x3 = q[offset + 3];
+    uchar x4 = q[offset + 4];
+    uchar x5 = q[offset + 5];
+    uchar x6 = q[offset + 6];
+    uchar x7 = q[offset + 7];
+    return pack_uchar4(
+        (x0 & 0x0F) | ((x1 & 0x0F) << 4),
+        (x2 & 0x0F) | ((x3 & 0x0F) << 4),
+        (x4 & 0x0F) | ((x5 & 0x0F) << 4),
+        (x6 & 0x0F) | ((x7 & 0x0F) << 4));
+}
+
+static inline uint pack_trans4_high(__global const uchar * q, uint offset) {
+    uchar x0 = q[offset + 0];
+    uchar x1 = q[offset + 1];
+    uchar x2 = q[offset + 2];
+    uchar x3 = q[offset + 3];
+    uchar x4 = q[offset + 4];
+    uchar x5 = q[offset + 5];
+    uchar x6 = q[offset + 6];
+    uchar x7 = q[offset + 7];
+    return pack_uchar4(
+        ((x0 & 0xF0) >> 4) | (x1 & 0xF0),
+        ((x2 & 0xF0) >> 4) | (x3 & 0xF0),
+        ((x4 & 0xF0) >> 4) | (x5 & 0xF0),
+        ((x6 & 0xF0) >> 4) | (x7 & 0xF0));
+}
+
+static inline void restore_trans4(
+    __global uchar * q,
+    uint offset,
+    uint low,
+    uint high
+) {
+    uchar lo0 = unpack_uchar0(low);
+    uchar lo1 = unpack_uchar1(low);
+    uchar lo2 = unpack_uchar2(low);
+    uchar lo3 = unpack_uchar3(low);
+    uchar hi0 = unpack_uchar0(high);
+    uchar hi1 = unpack_uchar1(high);
+    uchar hi2 = unpack_uchar2(high);
+    uchar hi3 = unpack_uchar3(high);
+    q[offset + 0] = (lo0 & 0x0F) | ((hi0 & 0x0F) << 4);
+    q[offset + 1] = ((lo0 & 0xF0) >> 4) | (hi0 & 0xF0);
+    q[offset + 2] = (lo1 & 0x0F) | ((hi1 & 0x0F) << 4);
+    q[offset + 3] = ((lo1 & 0xF0) >> 4) | (hi1 & 0xF0);
+    q[offset + 4] = (lo2 & 0x0F) | ((hi2 & 0x0F) << 4);
+    q[offset + 5] = ((lo2 & 0xF0) >> 4) | (hi2 & 0xF0);
+    q[offset + 6] = (lo3 & 0x0F) | ((hi3 & 0x0F) << 4);
+    q[offset + 7] = ((lo3 & 0xF0) >> 4) | (hi3 & 0xF0);
+}
+
 //------------------------------------------------------------------------------
 // block_q1_0
 //------------------------------------------------------------------------------
@@ -319,29 +415,16 @@ kernel void kernel_convert_block_q4_0_trans4_ns(
     global struct block_q4_0 * b = src0 + src_blk_offset;
     dst_d[dst_blk_offset] = b->d;
 
-    // extract quantization and unshuffle
-    ushort8 pre_block = ((global ushort8 *)(&(b->qs[0])))[0];
-
-    ushort8 post_block = (ushort8)(0);
-
-    uchar * pre_block_ptr = (uchar *)(&pre_block);
-    uchar * post_block_ptr = (uchar *)(&post_block);
-
-    for (int i = 0; i < QK4_0 / 4; ++i) {
-        uchar x0 = pre_block_ptr[2*i + 0];
-        uchar x1 = pre_block_ptr[2*i + 1];
-
-        post_block_ptr[i + 0        ] = convert_uchar(x0 & 0x0F) | convert_uchar((x1 & 0x0F) << 4);
-        post_block_ptr[i + QK4_0 / 4] = convert_uchar((x0 & 0xF0) >> 4) | convert_uchar(x1 & 0xF0);
-    }
-
-    uint4 q_block = as_uint4(post_block);
+    uint q0 = pack_trans4_low(b->qs, 0);
+    uint q1 = pack_trans4_low(b->qs, 8);
+    uint q2 = pack_trans4_high(b->qs, 0);
+    uint q3 = pack_trans4_high(b->qs, 8);
 
     uint offset = i02 * ne00_blk * ne01 * 4 + i00 * ne01 * 4 + i01;
-    dst_q[offset] = q_block.x;
-    dst_q[offset + ne01] = q_block.y;
-    dst_q[offset + ne01 * 2] = q_block.z;
-    dst_q[offset + ne01 * 3] = q_block.w;
+    dst_q[offset] = q0;
+    dst_q[offset + ne01] = q1;
+    dst_q[offset + ne01 * 2] = q2;
+    dst_q[offset + ne01 * 3] = q3;
 }
 
 kernel void kernel_restore_block_q4_0_trans4_ns(
@@ -366,29 +449,13 @@ kernel void kernel_restore_block_q4_0_trans4_ns(
     __global struct block_q4_0 * b = dst0 + dst_blk_offset;
     b->d = src_d[src_d_offset];
 
-    // collect transposed quantization parts for a block
     uint src_q_offset = i02 * ne00_blk * ne01 * 4 + i00 * ne01 * 4 + i01;
-    uint4 q_block;
-    q_block.x = src_q[src_q_offset];
-    q_block.y = src_q[src_q_offset + ne01];
-    q_block.z = src_q[src_q_offset + ne01 * 2];
-    q_block.w = src_q[src_q_offset + ne01 * 3];
-
-    ushort8 post_block = as_ushort8(q_block);
-    ushort8 pre_block = (ushort8)(0);
-
-    uchar * pre_block_ptr = (uchar *)(&pre_block);
-    uchar * post_block_ptr = (uchar *)(&post_block);
-
-    for (int i = 0; i < QK4_0 / 4; ++i) {
-        uchar x0 = post_block_ptr[i + 0];
-        uchar x1 = post_block_ptr[i + QK4_0 / 4];
-
-        pre_block_ptr[2 * i + 0] = convert_uchar(x0 & 0x0F) | convert_uchar((x1 & 0x0F) << 4);
-        pre_block_ptr[2 * i + 1] = convert_uchar((x0 & 0xF0) >> 4) | convert_uchar(x1 & 0xF0);
-    }
-
-    ((__global ushort8 *)(&(b->qs[0])))[0] = pre_block;
+    uint q0 = src_q[src_q_offset];
+    uint q1 = src_q[src_q_offset + ne01];
+    uint q2 = src_q[src_q_offset + ne01 * 2];
+    uint q3 = src_q[src_q_offset + ne01 * 3];
+    restore_trans4(b->qs, 0, q0, q2);
+    restore_trans4(b->qs, 8, q1, q3);
 }
 
 //------------------------------------------------------------------------------
@@ -509,29 +576,16 @@ kernel void kernel_convert_block_q4_1_trans4_ns(
     dst_d[dst_blk_offset] = b->d;
     dst_m[dst_blk_offset] = b->m;
 
-    // extract quantization and unshuffle
-    ushort8 pre_block = ((global ushort8 *)(&(b->qs[0])))[0];
-
-    ushort8 post_block = (ushort8)(0);
-
-    uchar * pre_block_ptr = (uchar *)(&pre_block);
-    uchar * post_block_ptr = (uchar *)(&post_block);
-
-    for (int i = 0; i < QK4_1 / 4; ++i) {
-        uchar x0 = pre_block_ptr[2*i + 0];
-        uchar x1 = pre_block_ptr[2*i + 1];
-
-        post_block_ptr[i + 0        ] = convert_uchar(x0 & 0x0F) | convert_uchar((x1 & 0x0F) << 4);
-        post_block_ptr[i + QK4_1 / 4] = convert_uchar((x0 & 0xF0) >> 4) | convert_uchar(x1 & 0xF0);
-    }
-
-    uint4 q_block = as_uint4(post_block);
+    uint q0 = pack_trans4_low(b->qs, 0);
+    uint q1 = pack_trans4_low(b->qs, 8);
+    uint q2 = pack_trans4_high(b->qs, 0);
+    uint q3 = pack_trans4_high(b->qs, 8);
 
     uint offset = i02 * ne00_blk * ne01 * 4 + i00 * ne01 * 4 + i01;
-    dst_q[offset] = q_block.x;
-    dst_q[offset + ne01] = q_block.y;
-    dst_q[offset + ne01 * 2] = q_block.z;
-    dst_q[offset + ne01 * 3] = q_block.w;
+    dst_q[offset] = q0;
+    dst_q[offset + ne01] = q1;
+    dst_q[offset + ne01 * 2] = q2;
+    dst_q[offset + ne01 * 3] = q3;
 }
 
 kernel void kernel_restore_block_q4_1_trans4_ns(
@@ -558,29 +612,13 @@ kernel void kernel_restore_block_q4_1_trans4_ns(
     b->d = src_d[src_dm_offset];
     b->m = src_m[src_dm_offset];
 
-    // collect transposed quantization parts for a block
     uint src_q_offset = i02 * ne00_blk * ne01 * 4 + i00 * ne01 * 4 + i01;
-    uint4 q_block;
-    q_block.x = src_q[src_q_offset];
-    q_block.y = src_q[src_q_offset + ne01];
-    q_block.z = src_q[src_q_offset + ne01 * 2];
-    q_block.w = src_q[src_q_offset + ne01 * 3];
-
-    ushort8 post_block = as_ushort8(q_block);
-    ushort8 pre_block = (ushort8)(0);
-
-    uchar * pre_block_ptr = (uchar *)(&pre_block);
-    uchar * post_block_ptr = (uchar *)(&post_block);
-
-    for (int i = 0; i < QK4_0 / 4; ++i) {
-        uchar x0 = post_block_ptr[i + 0];
-        uchar x1 = post_block_ptr[i + QK4_0 / 4];
-
-        pre_block_ptr[2 * i + 0] = convert_uchar(x0 & 0x0F) | convert_uchar((x1 & 0x0F) << 4);
-        pre_block_ptr[2 * i + 1] = convert_uchar((x0 & 0xF0) >> 4) | convert_uchar(x1 & 0xF0);
-    }
-
-    ((__global ushort8 *)(&(b->qs[0])))[0] = pre_block;
+    uint q0 = src_q[src_q_offset];
+    uint q1 = src_q[src_q_offset + ne01];
+    uint q2 = src_q[src_q_offset + ne01 * 2];
+    uint q3 = src_q[src_q_offset + ne01 * 3];
+    restore_trans4(b->qs, 0, q0, q2);
+    restore_trans4(b->qs, 8, q1, q3);
 }
 
 //------------------------------------------------------------------------------
@@ -707,30 +745,18 @@ kernel void kernel_convert_block_q5_0_trans4_ns(
     global struct block_q5_0 * b = src0 + src_blk_offset;
     dst_d[dst_blk_offset] = b->d;
 
-    dst_qh[dst_blk_offset] = ((global uint *)(&(b->qh[0])))[0];
+    dst_qh[dst_blk_offset] = pack_uchar4(b->qh[0], b->qh[1], b->qh[2], b->qh[3]);
 
-    // extract quantization and unshuffle
-    ushort8 pre_block = ((global ushort8 *)(&(b->qs[0])))[0];
-    ushort8 post_block = (ushort8)(0);
-
-    uchar * pre_block_ptr = (uchar *)(&pre_block);
-    uchar * post_block_ptr = (uchar *)(&post_block);
-
-    for (int i = 0; i < QK5_0 / 4; ++i) {
-        uchar x0 = pre_block_ptr[2*i + 0];
-        uchar x1 = pre_block_ptr[2*i + 1];
-
-        post_block_ptr[i + 0        ] = convert_uchar(x0 & 0x0F) | convert_uchar((x1 & 0x0F) << 4);
-        post_block_ptr[i + QK5_0 / 4] = convert_uchar((x0 & 0xF0) >> 4) | convert_uchar(x1 & 0xF0);
-    }
-
-    uint4 q_block = as_uint4(post_block);
+    uint q0 = pack_trans4_low(b->qs, 0);
+    uint q1 = pack_trans4_low(b->qs, 8);
+    uint q2 = pack_trans4_high(b->qs, 0);
+    uint q3 = pack_trans4_high(b->qs, 8);
 
     uint offset = i02 * ne00_blk * ne01 * 4 + i00 * ne01 * 4 + i01;
-    dst_qs[offset] = q_block.x;
-    dst_qs[offset + ne01] = q_block.y;
-    dst_qs[offset + ne01 * 2] = q_block.z;
-    dst_qs[offset + ne01 * 3] = q_block.w;
+    dst_qs[offset] = q0;
+    dst_qs[offset + ne01] = q1;
+    dst_qs[offset + ne01 * 2] = q2;
+    dst_qs[offset + ne01 * 3] = q3;
 }
 
 kernel void kernel_restore_block_q5_0_trans4_ns(
@@ -756,31 +782,19 @@ kernel void kernel_restore_block_q5_0_trans4_ns(
     __global struct block_q5_0 * b = dst0 + dst_blk_offset;
     b->d = src_d[src_blk_offset];
 
-    ((__global uint *)(&(b->qh[0])))[0] = src_qh[src_blk_offset];
+    uint qh = src_qh[src_blk_offset];
+    b->qh[0] = unpack_uchar0(qh);
+    b->qh[1] = unpack_uchar1(qh);
+    b->qh[2] = unpack_uchar2(qh);
+    b->qh[3] = unpack_uchar3(qh);
 
-    // collect transposed quantization parts for a block
     uint src_q_offset = i02 * ne00_blk * ne01 * 4 + i00 * ne01 * 4 + i01;
-    uint4 q_block;
-    q_block.x = src_qs[src_q_offset];
-    q_block.y = src_qs[src_q_offset + ne01];
-    q_block.z = src_qs[src_q_offset + ne01 * 2];
-    q_block.w = src_qs[src_q_offset + ne01 * 3];
-
-    ushort8 post_block = as_ushort8(q_block);
-    ushort8 pre_block = (ushort8)(0);
-
-    uchar * pre_block_ptr = (uchar *)(&pre_block);
-    uchar * post_block_ptr = (uchar *)(&post_block);
-
-    for (int i = 0; i < QK5_0 / 4; ++i) {
-        uchar x0 = post_block_ptr[i + 0];
-        uchar x1 = post_block_ptr[i + QK5_0 / 4];
-
-        pre_block_ptr[2 * i + 0] = convert_uchar(x0 & 0x0F) | convert_uchar((x1 & 0x0F) << 4);
-        pre_block_ptr[2 * i + 1] = convert_uchar((x0 & 0xF0) >> 4) | convert_uchar(x1 & 0xF0);
-    }
-
-    ((__global ushort8 *)(&(b->qs[0])))[0] = pre_block;
+    uint q0 = src_qs[src_q_offset];
+    uint q1 = src_qs[src_q_offset + ne01];
+    uint q2 = src_qs[src_q_offset + ne01 * 2];
+    uint q3 = src_qs[src_q_offset + ne01 * 3];
+    restore_trans4(b->qs, 0, q0, q2);
+    restore_trans4(b->qs, 8, q1, q3);
 }
 
 //------------------------------------------------------------------------------
@@ -921,30 +935,18 @@ kernel void kernel_convert_block_q5_1_trans4_ns(
     dst_d[dst_blk_offset] = b->d;
     dst_m[dst_blk_offset] = b->m;
 
-    dst_qh[dst_blk_offset] = ((global uint *)(&(b->qh[0])))[0];
+    dst_qh[dst_blk_offset] = pack_uchar4(b->qh[0], b->qh[1], b->qh[2], b->qh[3]);
 
-    // extract quantization and unshuffle
-    ushort8 pre_block = ((global ushort8 *)(&(b->qs[0])))[0];
-    ushort8 post_block = (ushort8)(0);
-
-    uchar * pre_block_ptr = (uchar *)(&pre_block);
-    uchar * post_block_ptr = (uchar *)(&post_block);
-
-    for (int i = 0; i < QK5_1 / 4; ++i) {
-        uchar x0 = pre_block_ptr[2*i + 0];
-        uchar x1 = pre_block_ptr[2*i + 1];
-
-        post_block_ptr[i + 0        ] = convert_uchar(x0 & 0x0F) | convert_uchar((x1 & 0x0F) << 4);
-        post_block_ptr[i + QK5_1 / 4] = convert_uchar((x0 & 0xF0) >> 4) | convert_uchar(x1 & 0xF0);
-    }
-
-    uint4 q_block = as_uint4(post_block);
+    uint q0 = pack_trans4_low(b->qs, 0);
+    uint q1 = pack_trans4_low(b->qs, 8);
+    uint q2 = pack_trans4_high(b->qs, 0);
+    uint q3 = pack_trans4_high(b->qs, 8);
 
     uint offset = i02 * ne00_blk * ne01 * 4 + i00 * ne01 * 4 + i01;
-    dst_qs[offset] = q_block.x;
-    dst_qs[offset + ne01] = q_block.y;
-    dst_qs[offset + ne01 * 2] = q_block.z;
-    dst_qs[offset + ne01 * 3] = q_block.w;
+    dst_qs[offset] = q0;
+    dst_qs[offset + ne01] = q1;
+    dst_qs[offset + ne01 * 2] = q2;
+    dst_qs[offset + ne01 * 3] = q3;
 }
 
 kernel void kernel_restore_block_q5_1_trans4_ns(
@@ -972,30 +974,19 @@ kernel void kernel_restore_block_q5_1_trans4_ns(
     b->d = src_d[src_blk_offset];
     b->m = src_m[src_blk_offset];
 
-    ((__global uint *)(&(b->qh[0])))[0] = src_qh[src_blk_offset];
+    uint qh = src_qh[src_blk_offset];
+    b->qh[0] = unpack_uchar0(qh);
+    b->qh[1] = unpack_uchar1(qh);
+    b->qh[2] = unpack_uchar2(qh);
+    b->qh[3] = unpack_uchar3(qh);
 
-    // collect transposed quantization parts for a block
     uint src_q_offset = i02 * ne00_blk * ne01 * 4 + i00 * ne01 * 4 + i01;
-    uint4 q_block;
-    q_block.x = src_qs[src_q_offset];
-    q_block.y = src_qs[src_q_offset + ne01];
-    q_block.z = src_qs[src_q_offset + ne01 * 2];
-    q_block.w = src_qs[src_q_offset + ne01 * 3];
-
-    ushort8 post_block = as_ushort8(q_block);
-    ushort8 pre_block = (ushort8)(0);
-
-    uchar * pre_block_ptr = (uchar *)(&pre_block);
-    uchar * post_block_ptr = (uchar *)(&post_block);
-
-    for (int i = 0; i < QK5_1 / 4; ++i) {
-        uchar x0 = post_block_ptr[i + 0];
-        uchar x1 = post_block_ptr[i + QK5_1 / 4];
-
-        pre_block_ptr[2 * i + 0] = convert_uchar(x0 & 0x0F) | convert_uchar((x1 & 0x0F) << 4);
-        pre_block_ptr[2 * i + 1] = convert_uchar((x0 & 0xF0) >> 4) | convert_uchar(x1 & 0xF0);
-    }
-    ((__global ushort8 *)(&(b->qs[0])))[0] = pre_block;
+    uint q0 = src_qs[src_q_offset];
+    uint q1 = src_qs[src_q_offset + ne01];
+    uint q2 = src_qs[src_q_offset + ne01 * 2];
+    uint q3 = src_qs[src_q_offset + ne01 * 3];
+    restore_trans4(b->qs, 0, q0, q2);
+    restore_trans4(b->qs, 8, q1, q3);
 }
 
 kernel void kernel_convert_block_q4_k_trans4_ns(
@@ -1026,26 +1017,18 @@ kernel void kernel_convert_block_q4_k_trans4_ns(
     dst_d [dst_blk_offset] = b->d;
     dst_dm[dst_blk_offset] = b->dm;
 
-    uint4 qv[8];
-    uchar * qv_bytes = (uchar *)qv;
     for (int i = 0; i < QK_K / 64; ++i) {
-        for (int j = 0; j < 16; ++j) {
-            uchar x0 = b->q[i*32 + 2*j];
-            uchar x1 = b->q[i*32 + 2*j + 1];
-
-            qv_bytes[i*32 + j     ] = convert_uchar(x0 & mask_0F) | convert_uchar((x1 & mask_0F) << 4);
-            qv_bytes[i*32 + j + 16] = convert_uchar((x0 & mask_F0) >> 4) | convert_uchar(x1 & mask_F0);
-        }
-    }
-
-    uint base = i02 * ne00_blk * ne01 * 32 + i00 * ne01 * 32 + i01;
-    #pragma unroll
-    for (int p = 0; p < 8; ++p) {
-        uint4 v = qv[p];
-        dst_q[base + (p * 4 + 0) * ne01] = v.x;
-        dst_q[base + (p * 4 + 1) * ne01] = v.y;
-        dst_q[base + (p * 4 + 2) * ne01] = v.z;
-        dst_q[base + (p * 4 + 3) * ne01] = v.w;
+        uint src_offset = i * 32;
+        uint dst_offset = i * 8;
+        uint base = i02 * ne00_blk * ne01 * 32 + i00 * ne01 * 32 + i01;
+        dst_q[base + (dst_offset + 0) * ne01] = pack_trans4_low(b->q, src_offset + 0);
+        dst_q[base + (dst_offset + 1) * ne01] = pack_trans4_low(b->q, src_offset + 8);
+        dst_q[base + (dst_offset + 2) * ne01] = pack_trans4_low(b->q, src_offset + 16);
+        dst_q[base + (dst_offset + 3) * ne01] = pack_trans4_low(b->q, src_offset + 24);
+        dst_q[base + (dst_offset + 4) * ne01] = pack_trans4_high(b->q, src_offset + 0);
+        dst_q[base + (dst_offset + 5) * ne01] = pack_trans4_high(b->q, src_offset + 8);
+        dst_q[base + (dst_offset + 6) * ne01] = pack_trans4_high(b->q, src_offset + 16);
+        dst_q[base + (dst_offset + 7) * ne01] = pack_trans4_high(b->q, src_offset + 24);
     }
 
     __global uchar * s_dst = dst_s + (i02 * ne01 + i01) * ne00_blk * K_SCALE_SIZE + i00 * K_SCALE_SIZE;
@@ -1091,22 +1074,17 @@ kernel void kernel_restore_block_q4_k_trans4_ns(
 
     uint base = i02 * ne00_blk * ne01 * 32 + i00 * ne01 * 32 + i01;
 
-    uint4 qv[8];
-    for (int p = 0; p < 8; ++p) {
-        qv[p].x = src_q[base + (p * 4 + 0) * ne01];
-        qv[p].y = src_q[base + (p * 4 + 1) * ne01];
-        qv[p].z = src_q[base + (p * 4 + 2) * ne01];
-        qv[p].w = src_q[base + (p * 4 + 3) * ne01];
-    }
-
-    uchar * qv_bytes = (uchar *)qv;
     for (int i = 0; i < QK_K / 64; ++i) {
-        for (int j = 0; j < 16; ++j) {
-            uchar lo = qv_bytes[i*32 + j];
-            uchar hi = qv_bytes[i*32 + j + 16];
-            b->q[i*32 + 2*j]     = convert_uchar((lo & mask_0F) | ((hi & mask_0F) << 4));
-            b->q[i*32 + 2*j + 1] = convert_uchar(((lo & mask_F0) >> 4) | (hi & mask_F0));
-        }
+        uint dst_offset = i * 32;
+        uint src_offset = i * 8;
+        restore_trans4(b->q, dst_offset + 0,
+            src_q[base + (src_offset + 0) * ne01], src_q[base + (src_offset + 4) * ne01]);
+        restore_trans4(b->q, dst_offset + 8,
+            src_q[base + (src_offset + 1) * ne01], src_q[base + (src_offset + 5) * ne01]);
+        restore_trans4(b->q, dst_offset + 16,
+            src_q[base + (src_offset + 2) * ne01], src_q[base + (src_offset + 6) * ne01]);
+        restore_trans4(b->q, dst_offset + 24,
+            src_q[base + (src_offset + 3) * ne01], src_q[base + (src_offset + 7) * ne01]);
     }
 }
 
@@ -1151,26 +1129,18 @@ kernel void kernel_convert_block_q5_k_trans4_ns(
         dst_qh[i01 + (i00 * 8 + k) * ne01 + i02 * ne00_blk * 8 * ne01] = packed;
     }
 
-    uint4 qv[8];
-    uchar * qv_bytes = (uchar *)qv;
     for (int i = 0; i < QK_K / 64; ++i) {
-        for (int j = 0; j < 16; ++j) {
-            uchar x0 = b->qs[i*32 + 2*j];
-            uchar x1 = b->qs[i*32 + 2*j + 1];
-
-            qv_bytes[i*32 + j     ] = convert_uchar(x0 & mask_0F) | convert_uchar((x1 & mask_0F) << 4);
-            qv_bytes[i*32 + j + 16] = convert_uchar((x0 & mask_F0) >> 4) | convert_uchar(x1 & mask_F0);
-        }
-    }
-
-    uint base = i02 * ne00_blk * ne01 * 32 + i00 * ne01 * 32 + i01;
-    #pragma unroll
-    for (int p = 0; p < 8; ++p) {
-        uint4 v = qv[p];
-        dst_qs[base + (p * 4 + 0) * ne01] = v.x;
-        dst_qs[base + (p * 4 + 1) * ne01] = v.y;
-        dst_qs[base + (p * 4 + 2) * ne01] = v.z;
-        dst_qs[base + (p * 4 + 3) * ne01] = v.w;
+        uint src_offset = i * 32;
+        uint dst_offset = i * 8;
+        uint base = i02 * ne00_blk * ne01 * 32 + i00 * ne01 * 32 + i01;
+        dst_qs[base + (dst_offset + 0) * ne01] = pack_trans4_low(b->qs, src_offset + 0);
+        dst_qs[base + (dst_offset + 1) * ne01] = pack_trans4_low(b->qs, src_offset + 8);
+        dst_qs[base + (dst_offset + 2) * ne01] = pack_trans4_low(b->qs, src_offset + 16);
+        dst_qs[base + (dst_offset + 3) * ne01] = pack_trans4_low(b->qs, src_offset + 24);
+        dst_qs[base + (dst_offset + 4) * ne01] = pack_trans4_high(b->qs, src_offset + 0);
+        dst_qs[base + (dst_offset + 5) * ne01] = pack_trans4_high(b->qs, src_offset + 8);
+        dst_qs[base + (dst_offset + 6) * ne01] = pack_trans4_high(b->qs, src_offset + 16);
+        dst_qs[base + (dst_offset + 7) * ne01] = pack_trans4_high(b->qs, src_offset + 24);
     }
 
     __global uchar * s_dst = dst_s + (i02 * ne01 + i01) * ne00_blk * K_SCALE_SIZE + i00 * K_SCALE_SIZE;
@@ -1232,22 +1202,17 @@ kernel void kernel_restore_block_q5_k_trans4_ns(
 
     uint base = i02 * ne00_blk * ne01 * 32 + i00 * ne01 * 32 + i01;
 
-    uint4 qv[8];
-    for (int p = 0; p < 8; ++p) {
-        qv[p].x = src_qs[base + (p * 4 + 0) * ne01];
-        qv[p].y = src_qs[base + (p * 4 + 1) * ne01];
-        qv[p].z = src_qs[base + (p * 4 + 2) * ne01];
-        qv[p].w = src_qs[base + (p * 4 + 3) * ne01];
-    }
-
-    uchar * qv_bytes = (uchar *)qv;
     for (int i = 0; i < QK_K / 64; ++i) {
-        for (int j = 0; j < 16; ++j) {
-            uchar lo = qv_bytes[i*32 + j];
-            uchar hi = qv_bytes[i*32 + j + 16];
-            b->qs[i*32 + 2*j]     = convert_uchar((lo & mask_0F) | ((hi & mask_0F) << 4));
-            b->qs[i*32 + 2*j + 1] = convert_uchar(((lo & mask_F0) >> 4) | (hi & mask_F0));
-        }
+        uint dst_offset = i * 32;
+        uint src_offset = i * 8;
+        restore_trans4(b->qs, dst_offset + 0,
+            src_qs[base + (src_offset + 0) * ne01], src_qs[base + (src_offset + 4) * ne01]);
+        restore_trans4(b->qs, dst_offset + 8,
+            src_qs[base + (src_offset + 1) * ne01], src_qs[base + (src_offset + 5) * ne01]);
+        restore_trans4(b->qs, dst_offset + 16,
+            src_qs[base + (src_offset + 2) * ne01], src_qs[base + (src_offset + 6) * ne01]);
+        restore_trans4(b->qs, dst_offset + 24,
+            src_qs[base + (src_offset + 3) * ne01], src_qs[base + (src_offset + 7) * ne01]);
     }
 }
 
@@ -1279,30 +1244,21 @@ kernel void kernel_convert_block_q6_k_trans4_ns(
 
     dst_d[dst_blk_offset] = b->d;
 
-    uint4 qlv[8];
-    uchar * qlv_bytes = (uchar *)qlv;
-    for (int i = 0; i < 2; ++i) {
-        for (int j = 0; j < 16; ++j) {
-            uchar x0 = b->ql[i*64 + 2*j];
-            uchar x1 = b->ql[i*64 + 2*j + 1];
-            uchar x2 = b->ql[i*64 + 32 + 2*j];
-            uchar x3 = b->ql[i*64 + 32 + 2*j + 1];
-            qlv_bytes[i*64 + j     ] = convert_uchar(x0 & mask_0F) | convert_uchar((x1 & mask_0F) << 4);
-            qlv_bytes[i*64 + j + 16] = convert_uchar(x2 & mask_0F) | convert_uchar((x3 & mask_0F) << 4);
-            qlv_bytes[i*64 + j + 32] = convert_uchar((x0 & mask_F0) >> 4) | convert_uchar(x1 & mask_F0);
-            qlv_bytes[i*64 + j + 48] = convert_uchar((x2 & mask_F0) >> 4) | convert_uchar(x3 & mask_F0);
-        }
-    }
-
     uint ql_base = i02 * ne00_blk * ne01 * 32 + i00 * ne01 * 32 + i01;
-
-    #pragma unroll
-    for (int p = 0; p < 8; ++p) {
-        uint4 v = qlv[p];
-        dst_ql[ql_base + (p * 4 + 0) * ne01] = v.x;
-        dst_ql[ql_base + (p * 4 + 1) * ne01] = v.y;
-        dst_ql[ql_base + (p * 4 + 2) * ne01] = v.z;
-        dst_ql[ql_base + (p * 4 + 3) * ne01] = v.w;
+    for (int i = 0; i < 2; ++i) {
+        uint src_offset = i * 64;
+        uint dst_offset = i * 16;
+        for (int j = 0; j < 4; ++j) {
+            uint chunk_offset = j * 8;
+            dst_ql[ql_base + (dst_offset + j) * ne01] =
+                pack_trans4_low(b->ql, src_offset + chunk_offset);
+            dst_ql[ql_base + (dst_offset + 4 + j) * ne01] =
+                pack_trans4_low(b->ql, src_offset + 32 + chunk_offset);
+            dst_ql[ql_base + (dst_offset + 8 + j) * ne01] =
+                pack_trans4_high(b->ql, src_offset + chunk_offset);
+            dst_ql[ql_base + (dst_offset + 12 + j) * ne01] =
+                pack_trans4_high(b->ql, src_offset + 32 + chunk_offset);
+        }
     }
 
     uint qhv[16] = {0};
@@ -1361,25 +1317,16 @@ kernel void kernel_restore_block_q6_k_trans4_ns(
     b->d = src_d[src_blk_offset];
 
     uint ql_base = i02 * ne00_blk * ne01 * 32 + i00 * ne01 * 32 + i01;
-    uint4 qlv[8];
-    for (int p = 0; p < 8; ++p) {
-        qlv[p].x = src_ql[ql_base + (p * 4 + 0) * ne01];
-        qlv[p].y = src_ql[ql_base + (p * 4 + 1) * ne01];
-        qlv[p].z = src_ql[ql_base + (p * 4 + 2) * ne01];
-        qlv[p].w = src_ql[ql_base + (p * 4 + 3) * ne01];
-    }
-
-    uchar * qlv_bytes = (uchar *)qlv;
     for (int i = 0; i < 2; ++i) {
-        for (int j = 0; j < 16; ++j) {
-            uchar lo_02 = qlv_bytes[i*64 + j];
-            uchar lo_13 = qlv_bytes[i*64 + j + 16];
-            uchar hi_02 = qlv_bytes[i*64 + j + 32];
-            uchar hi_13 = qlv_bytes[i*64 + j + 48];
-            b->ql[i*64 + 2*j]          = convert_uchar((lo_02 & mask_0F) | ((hi_02 & mask_0F) << 4));
-            b->ql[i*64 + 2*j + 1]      = convert_uchar(((lo_02 & mask_F0) >> 4) | (hi_02 & mask_F0));
-            b->ql[i*64 + 32 + 2*j]     = convert_uchar((lo_13 & mask_0F) | ((hi_13 & mask_0F) << 4));
-            b->ql[i*64 + 32 + 2*j + 1] = convert_uchar(((lo_13 & mask_F0) >> 4) | (hi_13 & mask_F0));
+        uint dst_offset = i * 64;
+        uint src_offset = i * 16;
+        for (int j = 0; j < 4; ++j) {
+            restore_trans4(b->ql, dst_offset + j * 8,
+                src_ql[ql_base + (src_offset + j) * ne01],
+                src_ql[ql_base + (src_offset + 8 + j) * ne01]);
+            restore_trans4(b->ql, dst_offset + 32 + j * 8,
+                src_ql[ql_base + (src_offset + 4 + j) * ne01],
+                src_ql[ql_base + (src_offset + 12 + j) * ne01]);
         }
     }
 
@@ -1516,29 +1463,16 @@ kernel void kernel_convert_block_mxfp4_trans4_ns(
     global struct block_mxfp4 * b = src0 + src_blk_offset;
     dst_e[dst_blk_offset] = b->e;
 
-    // extract quantization and unshuffle
-    ushort8 pre_block = ((global ushort8 *)(&(b->qs[0])))[0];
-
-    ushort8 post_block = (ushort8)(0);
-
-    uchar * pre_block_ptr = (uchar *)(&pre_block);
-    uchar * post_block_ptr = (uchar *)(&post_block);
-
-    for (int i = 0; i < QK_MXFP4 / 4; ++i) {
-        uchar x0 = pre_block_ptr[2*i + 0];
-        uchar x1 = pre_block_ptr[2*i + 1];
-
-        post_block_ptr[i + 0        ] = convert_uchar(x0 & 0x0F) | convert_uchar((x1 & 0x0F) << 4);
-        post_block_ptr[i + QK_MXFP4 / 4] = convert_uchar((x0 & 0xF0) >> 4) | convert_uchar(x1 & 0xF0);
-    }
-
-    uint4 q_block = as_uint4(post_block);
+    uint q0 = pack_trans4_low(b->qs, 0);
+    uint q1 = pack_trans4_low(b->qs, 8);
+    uint q2 = pack_trans4_high(b->qs, 0);
+    uint q3 = pack_trans4_high(b->qs, 8);
 
     uint offset = i02 * ne00_blk * ne01 * 4 + i00 * ne01 * 4 + i01;
-    dst_q[offset] = q_block.x;
-    dst_q[offset + ne01] = q_block.y;
-    dst_q[offset + ne01 * 2] = q_block.z;
-    dst_q[offset + ne01 * 3] = q_block.w;
+    dst_q[offset] = q0;
+    dst_q[offset + ne01] = q1;
+    dst_q[offset + ne01 * 2] = q2;
+    dst_q[offset + ne01 * 3] = q3;
 }
 
 kernel void kernel_restore_block_mxfp4_trans4_ns(
@@ -1563,29 +1497,13 @@ kernel void kernel_restore_block_mxfp4_trans4_ns(
     __global struct block_mxfp4 * b = dst0 + dst_blk_offset;
     b->e = src_e[src_d_offset];
 
-    // collect transposed quantization parts for a block
     uint src_q_offset = i02 * ne00_blk * ne01 * 4 + i00 * ne01 * 4 + i01;
-    uint4 q_block;
-    q_block.x = src_q[src_q_offset];
-    q_block.y = src_q[src_q_offset + ne01];
-    q_block.z = src_q[src_q_offset + ne01 * 2];
-    q_block.w = src_q[src_q_offset + ne01 * 3];
-
-    ushort8 post_block = as_ushort8(q_block);
-    ushort8 pre_block = (ushort8)(0);
-
-    uchar * pre_block_ptr = (uchar *)(&pre_block);
-    uchar * post_block_ptr = (uchar *)(&post_block);
-
-    for (int i = 0; i < QK_MXFP4 / 4; ++i) {
-        uchar x0 = post_block_ptr[i + 0];
-        uchar x1 = post_block_ptr[i + QK_MXFP4 / 4];
-
-        pre_block_ptr[2 * i + 0] = convert_uchar(x0 & 0x0F) | convert_uchar((x1 & 0x0F) << 4);
-        pre_block_ptr[2 * i + 1] = convert_uchar((x0 & 0xF0) >> 4) | convert_uchar(x1 & 0xF0);
-    }
-
-    ((__global ushort8 *)(&(b->qs[0])))[0] = pre_block;
+    uint q0 = src_q[src_q_offset];
+    uint q1 = src_q[src_q_offset + ne01];
+    uint q2 = src_q[src_q_offset + ne01 * 2];
+    uint q3 = src_q[src_q_offset + ne01 * 3];
+    restore_trans4(b->qs, 0, q0, q2);
+    restore_trans4(b->qs, 8, q1, q3);
 }
 
 

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q4_k_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q4_k_f32_ns.cl
@@ -290,59 +290,66 @@ kernel void kernel_gemm_moe_q4_k_f32_ns(
         if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
     }
 
-    if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {
-        return;
-    }
-
     // Load post router and share in LM
     __local uint out_idx[TILESIZE_N];
 
     if (get_local_id(0) < TILESIZE_N) {
         uint idx = src2[block_id_n * TILESIZE_N + get_local_id(0)];
-        if (idx == 0xFFFFFFFF) {
-            idx = src2[block_id_n * TILESIZE_N + 0];
-        }
-        out_idx[get_local_id(0)] = idx * ne01;
+        // Padding slots keep the sentinel so their store can be skipped below.
+        // ne01 is a multiple of 32 here, so a real idx * ne01 is even and can
+        // never collide with the odd sentinel value.
+        out_idx[get_local_id(0)] = (idx == 0xFFFFFFFFu) ? 0xFFFFFFFFu : idx * ne01;
     }
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
+    // Tail rows have to reach the barrier above before dropping out: the global
+    // size along dim 0 is rounded up to TILESIZE_M.
+    if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {
+        return;
+    }
+
     // Scatter results back to original position in output grid
     uint m_offset = row + get_local_id(0);
 
-    write_imagef(dst, out_idx[1] + m_offset, (reg_c.s1));
-    write_imagef(dst, out_idx[2] + m_offset, (reg_c.s2));
-    write_imagef(dst, out_idx[3] + m_offset, (reg_c.s3));
-    write_imagef(dst, out_idx[4] + m_offset, (reg_c.s4));
-    write_imagef(dst, out_idx[5] + m_offset, (reg_c.s5));
-    write_imagef(dst, out_idx[6] + m_offset, (reg_c.s6));
-    write_imagef(dst, out_idx[7] + m_offset, (reg_c.s7));
-    write_imagef(dst, out_idx[8] + m_offset, (reg_c.s8));
-    write_imagef(dst, out_idx[9] + m_offset, (reg_c.s9));
-    write_imagef(dst, out_idx[10] + m_offset, (reg_c.sa));
-    write_imagef(dst, out_idx[11] + m_offset, (reg_c.sb));
-    write_imagef(dst, out_idx[12] + m_offset, (reg_c.sc));
-    write_imagef(dst, out_idx[13] + m_offset, (reg_c.sd));
-    write_imagef(dst, out_idx[14] + m_offset, (reg_c.se));
-    write_imagef(dst, out_idx[15] + m_offset, (reg_c.sf));
-    write_imagef(dst, out_idx[16] + m_offset, (reg_c.sg));
-    write_imagef(dst, out_idx[17] + m_offset, (reg_c.sh));
-    write_imagef(dst, out_idx[18] + m_offset, (reg_c.si));
-    write_imagef(dst, out_idx[19] + m_offset, (reg_c.sj));
-    write_imagef(dst, out_idx[20] + m_offset, (reg_c.sk));
-    write_imagef(dst, out_idx[21] + m_offset, (reg_c.sl));
-    write_imagef(dst, out_idx[22] + m_offset, (reg_c.sm));
-    write_imagef(dst, out_idx[23] + m_offset, (reg_c.sn));
-    write_imagef(dst, out_idx[24] + m_offset, (reg_c.so));
-    write_imagef(dst, out_idx[25] + m_offset, (reg_c.sp));
-    write_imagef(dst, out_idx[26] + m_offset, (reg_c.sq));
-    write_imagef(dst, out_idx[27] + m_offset, (reg_c.sr));
-    write_imagef(dst, out_idx[28] + m_offset, (reg_c.ss));
-    write_imagef(dst, out_idx[29] + m_offset, (reg_c.st));
-    write_imagef(dst, out_idx[30] + m_offset, (reg_c.su));
-    write_imagef(dst, out_idx[31] + m_offset, (reg_c.sv));
+    // Skipping padding slots keeps every store to a distinct address. Aliasing
+    // them onto column 0 and overwriting it last would need CLK_IMAGE_MEM_FENCE
+    // to order image stores, which CLK_GLOBAL_MEM_FENCE does not provide.
+#define MOE_STORE_C(t, v) \
+    if (out_idx[t] != 0xFFFFFFFFu) { write_imagef(dst, out_idx[t] + m_offset, (v)); }
 
-    // Store zero padding parts to the index of first output in tile
-    barrier(CLK_GLOBAL_MEM_FENCE);
-    write_imagef(dst, out_idx[0] + m_offset, (reg_c.s0));
+    MOE_STORE_C(0,  reg_c.s0);
+    MOE_STORE_C(1,  reg_c.s1);
+    MOE_STORE_C(2,  reg_c.s2);
+    MOE_STORE_C(3,  reg_c.s3);
+    MOE_STORE_C(4,  reg_c.s4);
+    MOE_STORE_C(5,  reg_c.s5);
+    MOE_STORE_C(6,  reg_c.s6);
+    MOE_STORE_C(7,  reg_c.s7);
+    MOE_STORE_C(8,  reg_c.s8);
+    MOE_STORE_C(9,  reg_c.s9);
+    MOE_STORE_C(10, reg_c.sa);
+    MOE_STORE_C(11, reg_c.sb);
+    MOE_STORE_C(12, reg_c.sc);
+    MOE_STORE_C(13, reg_c.sd);
+    MOE_STORE_C(14, reg_c.se);
+    MOE_STORE_C(15, reg_c.sf);
+    MOE_STORE_C(16, reg_c.sg);
+    MOE_STORE_C(17, reg_c.sh);
+    MOE_STORE_C(18, reg_c.si);
+    MOE_STORE_C(19, reg_c.sj);
+    MOE_STORE_C(20, reg_c.sk);
+    MOE_STORE_C(21, reg_c.sl);
+    MOE_STORE_C(22, reg_c.sm);
+    MOE_STORE_C(23, reg_c.sn);
+    MOE_STORE_C(24, reg_c.so);
+    MOE_STORE_C(25, reg_c.sp);
+    MOE_STORE_C(26, reg_c.sq);
+    MOE_STORE_C(27, reg_c.sr);
+    MOE_STORE_C(28, reg_c.ss);
+    MOE_STORE_C(29, reg_c.st);
+    MOE_STORE_C(30, reg_c.su);
+    MOE_STORE_C(31, reg_c.sv);
+
+#undef MOE_STORE_C
 }

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q4_k_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q4_k_f32_ns.cl
@@ -10,19 +10,20 @@
 #define QK_K 256
 #define K_SCALE_SIZE 12
 
-inline void get_scale_min_k4(
-    int j,
-    global const uchar * q,
-    uchar * d,
-    uchar * m
-) {
+// Returns the 6-bit sub-block scale in bits 0-7 and the min in bits 8-15.
+// Writing the results through pointers to private scalars is miscompiled by the
+// Adreno E031.47 shader compiler, which yields corrupted scales, so this stays
+// pointer-free and scalar.
+inline uint get_scale_min_k4_packed(int j, global const uchar * q) {
+    uint d, m;
     if (j < 4) {
-        *d = q[j]   & 63;
-        *m = q[j+4] & 63;
+        d = q[j]   & 63u;
+        m = q[j+4] & 63u;
     } else {
-        *d = (q[j+4] & 0x0F) | ((q[j-4] & 0xC0) >> 2);
-        *m = ((q[j+4] >> 4) & 0x0F) | ((q[j]   & 0xC0) >> 2);
+        d = (q[j+4] & 0x0Fu) | ((q[j-4] & 0xC0u) >> 2);
+        m = ((q[j+4] >> 4) & 0x0Fu) | ((q[j] & 0xC0u) >> 2);
     }
+    return d | (m << 8);
 }
 
 #define dequantize_q4_k(q4, a_f16, scale, minv) \
@@ -232,11 +233,10 @@ kernel void kernel_gemm_moe_q4_k_f32_ns(
 
         // Load sub-block scale and min
         global const uchar * sc = src0_s + (expert_id * ne01 + row_idx) * scales_per_row + sb * K_SCALE_SIZE;
-        uchar sv, mn;
-        get_scale_min_k4(j, sc, &sv, &mn);
+        uint sm = get_scale_min_k4_packed(j, sc);
 
-        float scale = (float)d_val * (float)sv;
-        float minv = (float)dm_val * (float)mn;
+        float scale = (float)d_val * (float)(sm & 0xFFu);
+        float minv = (float)dm_val * (float)(sm >> 8);
 
         // First sub-block (16 elements)
         uint q_sub_offset = row + ((ne01 * step) >> 3) + ((expert_id * ne00 * ne01) >> 3);

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q4_k_q8_1_dp4a.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q4_k_q8_1_dp4a.cl
@@ -14,19 +14,20 @@
 #define QK_K 256
 #define K_SCALE_SIZE 12
 
-inline void get_scale_min_k4(
-    int j,
-    global const uchar * q,
-    uchar * d,
-    uchar * m
-) {
+// Returns the 6-bit sub-block scale in bits 0-7 and the min in bits 8-15.
+// Writing the results through pointers to private scalars is miscompiled by the
+// Adreno E031.47 shader compiler, which yields corrupted scales, so this stays
+// pointer-free and scalar.
+inline uint get_scale_min_k4_packed(int j, global const uchar * q) {
+    uint d, m;
     if (j < 4) {
-        *d = q[j]   & 63;
-        *m = q[j+4] & 63;
+        d = q[j]   & 63u;
+        m = q[j+4] & 63u;
     } else {
-        *d = (q[j+4] & 0x0F) | ((q[j-4] & 0xC0) >> 2);
-        *m = ((q[j+4] >> 4) & 0x0F) | ((q[j]   & 0xC0) >> 2);
+        d = (q[j+4] & 0x0Fu) | ((q[j-4] & 0xC0u) >> 2);
+        m = ((q[j+4] >> 4) & 0x0Fu) | ((q[j] & 0xC0u) >> 2);
     }
+    return d | (m << 8);
 }
 
 // Expand the 4 nibbles held in the low 16 bits of `u` into 4 bytes (one nibble
@@ -132,10 +133,9 @@ kernel void kernel_gemm_moe_q4_k_q8_1_dp4a(
         const float dm_val = (float)src0_dm[d_offset];
 
         global const uchar * sc = src0_s + (expert_id * ne01 + row_idx) * scales_per_row + sb * K_SCALE_SIZE;
-        uchar sv, mn;
-        get_scale_min_k4(j, sc, &sv, &mn);
-        const float scale = d_val  * (float)sv;
-        const float minv  = dm_val * (float)mn;
+        uint sm = get_scale_min_k4_packed(j, sc);
+        const float scale = d_val  * (float)(sm & 0xFFu);
+        const float minv  = dm_val * (float)(sm >> 8);
 
         // --- repack this WI's 32 weight nibbles into 8 dp4a uints ---
         const uint qoff0 = row + ((ne01 * step) >> 3)        + ((expert_id * ne00 * ne01) >> 3);

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q5_0_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q5_0_f32_ns.cl
@@ -270,59 +270,66 @@ kernel void kernel_gemm_moe_q5_0_f32_ns(
         if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
     }
 
-    if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {
-        return;
-    }
-
     // Load poster router and share in LM
     __local uint out_idx[TILESIZE_N];
 
     if (get_local_id(0) < TILESIZE_N) {
         uint idx = src2[block_id_n * TILESIZE_N + get_local_id(0)];
-        if (idx == 0xFFFFFFFF) {
-            idx = src2[block_id_n * TILESIZE_N + 0];
-        }
-        out_idx[get_local_id(0)] = idx * ne01;
+        // Padding slots keep the sentinel so their store can be skipped below.
+        // ne01 is a multiple of 32 here, so a real idx * ne01 is even and can
+        // never collide with the odd sentinel value.
+        out_idx[get_local_id(0)] = (idx == 0xFFFFFFFFu) ? 0xFFFFFFFFu : idx * ne01;
     }
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
+    // Tail rows have to reach the barrier above before dropping out: the global
+    // size along dim 0 is rounded up to TILESIZE_M.
+    if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {
+        return;
+    }
+
     // Scatter results back to original position in output grid
     uint m_offset = row + get_local_id(0);
 
-    write_imagef(dst, out_idx[1] + m_offset, (reg_c.s1));
-    write_imagef(dst, out_idx[2] + m_offset, (reg_c.s2));
-    write_imagef(dst, out_idx[3] + m_offset, (reg_c.s3));
-    write_imagef(dst, out_idx[4] + m_offset, (reg_c.s4));
-    write_imagef(dst, out_idx[5] + m_offset, (reg_c.s5));
-    write_imagef(dst, out_idx[6] + m_offset, (reg_c.s6));
-    write_imagef(dst, out_idx[7] + m_offset, (reg_c.s7));
-    write_imagef(dst, out_idx[8] + m_offset, (reg_c.s8));
-    write_imagef(dst, out_idx[9] + m_offset, (reg_c.s9));
-    write_imagef(dst, out_idx[10] + m_offset, (reg_c.sa));
-    write_imagef(dst, out_idx[11] + m_offset, (reg_c.sb));
-    write_imagef(dst, out_idx[12] + m_offset, (reg_c.sc));
-    write_imagef(dst, out_idx[13] + m_offset, (reg_c.sd));
-    write_imagef(dst, out_idx[14] + m_offset, (reg_c.se));
-    write_imagef(dst, out_idx[15] + m_offset, (reg_c.sf));
-    write_imagef(dst, out_idx[16] + m_offset, (reg_c.sg));
-    write_imagef(dst, out_idx[17] + m_offset, (reg_c.sh));
-    write_imagef(dst, out_idx[18] + m_offset, (reg_c.si));
-    write_imagef(dst, out_idx[19] + m_offset, (reg_c.sj));
-    write_imagef(dst, out_idx[20] + m_offset, (reg_c.sk));
-    write_imagef(dst, out_idx[21] + m_offset, (reg_c.sl));
-    write_imagef(dst, out_idx[22] + m_offset, (reg_c.sm));
-    write_imagef(dst, out_idx[23] + m_offset, (reg_c.sn));
-    write_imagef(dst, out_idx[24] + m_offset, (reg_c.so));
-    write_imagef(dst, out_idx[25] + m_offset, (reg_c.sp));
-    write_imagef(dst, out_idx[26] + m_offset, (reg_c.sq));
-    write_imagef(dst, out_idx[27] + m_offset, (reg_c.sr));
-    write_imagef(dst, out_idx[28] + m_offset, (reg_c.ss));
-    write_imagef(dst, out_idx[29] + m_offset, (reg_c.st));
-    write_imagef(dst, out_idx[30] + m_offset, (reg_c.su));
-    write_imagef(dst, out_idx[31] + m_offset, (reg_c.sv));
+    // Skipping padding slots keeps every store to a distinct address. Aliasing
+    // them onto column 0 and overwriting it last would need CLK_IMAGE_MEM_FENCE
+    // to order image stores, which CLK_GLOBAL_MEM_FENCE does not provide.
+#define MOE_STORE_C(t, v) \
+    if (out_idx[t] != 0xFFFFFFFFu) { write_imagef(dst, out_idx[t] + m_offset, (v)); }
 
-    // Store zero padding parts to the index of first output in tile, override correct result in the end
-    barrier(CLK_GLOBAL_MEM_FENCE);
-    write_imagef(dst, out_idx[0] + m_offset, (reg_c.s0));
+    MOE_STORE_C(0,  reg_c.s0);
+    MOE_STORE_C(1,  reg_c.s1);
+    MOE_STORE_C(2,  reg_c.s2);
+    MOE_STORE_C(3,  reg_c.s3);
+    MOE_STORE_C(4,  reg_c.s4);
+    MOE_STORE_C(5,  reg_c.s5);
+    MOE_STORE_C(6,  reg_c.s6);
+    MOE_STORE_C(7,  reg_c.s7);
+    MOE_STORE_C(8,  reg_c.s8);
+    MOE_STORE_C(9,  reg_c.s9);
+    MOE_STORE_C(10, reg_c.sa);
+    MOE_STORE_C(11, reg_c.sb);
+    MOE_STORE_C(12, reg_c.sc);
+    MOE_STORE_C(13, reg_c.sd);
+    MOE_STORE_C(14, reg_c.se);
+    MOE_STORE_C(15, reg_c.sf);
+    MOE_STORE_C(16, reg_c.sg);
+    MOE_STORE_C(17, reg_c.sh);
+    MOE_STORE_C(18, reg_c.si);
+    MOE_STORE_C(19, reg_c.sj);
+    MOE_STORE_C(20, reg_c.sk);
+    MOE_STORE_C(21, reg_c.sl);
+    MOE_STORE_C(22, reg_c.sm);
+    MOE_STORE_C(23, reg_c.sn);
+    MOE_STORE_C(24, reg_c.so);
+    MOE_STORE_C(25, reg_c.sp);
+    MOE_STORE_C(26, reg_c.sq);
+    MOE_STORE_C(27, reg_c.sr);
+    MOE_STORE_C(28, reg_c.ss);
+    MOE_STORE_C(29, reg_c.st);
+    MOE_STORE_C(30, reg_c.su);
+    MOE_STORE_C(31, reg_c.sv);
+
+#undef MOE_STORE_C
 }

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q5_k_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q5_k_f32_ns.cl
@@ -10,19 +10,20 @@
 #define QK_K 256
 #define K_SCALE_SIZE 12
 
-inline void get_scale_min_k4(
-    int j,
-    global const uchar * q,
-    uchar * d,
-    uchar * m
-) {
+// Returns the 6-bit sub-block scale in bits 0-7 and the min in bits 8-15.
+// Writing the results through pointers to private scalars is miscompiled by the
+// Adreno E031.47 shader compiler, which yields corrupted scales, so this stays
+// pointer-free and scalar.
+inline uint get_scale_min_k4_packed(int j, global const uchar * q) {
+    uint d, m;
     if (j < 4) {
-        *d = q[j]   & 63;
-        *m = q[j+4] & 63;
+        d = q[j]   & 63u;
+        m = q[j+4] & 63u;
     } else {
-        *d = (q[j+4] & 0x0F) | ((q[j-4] & 0xC0) >> 2);
-        *m = ((q[j+4] >> 4) & 0x0F) | ((q[j]   & 0xC0) >> 2);
+        d = (q[j+4] & 0x0Fu) | ((q[j-4] & 0xC0u) >> 2);
+        m = ((q[j+4] >> 4) & 0x0Fu) | ((q[j] & 0xC0u) >> 2);
     }
+    return d | (m << 8);
 }
 
 #define dequantize_q5_k(qs5x16, qh5x16, a_f16, scale, m) \
@@ -236,11 +237,10 @@ kernel void kernel_gemm_moe_q5_k_f32_ns(
 
         // Load sub-block scale and min
         global const uchar * sc = src0_s + (expert_id * ne01 + row_idx) * scales_per_row + sb * K_SCALE_SIZE;
-        uchar sv, mn;
-        get_scale_min_k4(j, sc, &sv, &mn);
+        uint sm = get_scale_min_k4_packed(j, sc);
 
-        float scale = (float)d_val * (float)sv;
-        float minv = -(float)dm_val * (float)mn;
+        float scale = (float)d_val * (float)(sm & 0xFFu);
+        float minv = -(float)dm_val * (float)(sm >> 8);
 
         // qh is stored at sub-block granularity
         uint qh_offset = row + sub * ne01 + expert_id * num_superblocks * 8 * ne01 + get_global_id(0);

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q6_k_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q6_k_f32_ns.cl
@@ -277,59 +277,66 @@ kernel void kernel_gemm_moe_q6_k_f32_ns(
         if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
     }
 
-    if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {
-        return;
-    }
-
     // Load post router and share in LM
     __local uint out_idx[TILESIZE_N];
 
     if (get_local_id(0) < TILESIZE_N) {
         uint idx = src2[block_id_n * TILESIZE_N + get_local_id(0)];
-        if (idx == 0xFFFFFFFF) {
-            idx = src2[block_id_n * TILESIZE_N + 0];
-        }
-        out_idx[get_local_id(0)] = idx * ne01;
+        // Padding slots keep the sentinel so their store can be skipped below.
+        // ne01 is a multiple of 32 here, so a real idx * ne01 is even and can
+        // never collide with the odd sentinel value.
+        out_idx[get_local_id(0)] = (idx == 0xFFFFFFFFu) ? 0xFFFFFFFFu : idx * ne01;
     }
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
+    // Tail rows have to reach the barrier above before dropping out: the global
+    // size along dim 0 is rounded up to TILESIZE_M.
+    if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {
+        return;
+    }
+
     // Scatter results back to original position in output grid
     uint m_offset = row + get_local_id(0);
 
-    write_imagef(dst, out_idx[1] + m_offset, (reg_c.s1));
-    write_imagef(dst, out_idx[2] + m_offset, (reg_c.s2));
-    write_imagef(dst, out_idx[3] + m_offset, (reg_c.s3));
-    write_imagef(dst, out_idx[4] + m_offset, (reg_c.s4));
-    write_imagef(dst, out_idx[5] + m_offset, (reg_c.s5));
-    write_imagef(dst, out_idx[6] + m_offset, (reg_c.s6));
-    write_imagef(dst, out_idx[7] + m_offset, (reg_c.s7));
-    write_imagef(dst, out_idx[8] + m_offset, (reg_c.s8));
-    write_imagef(dst, out_idx[9] + m_offset, (reg_c.s9));
-    write_imagef(dst, out_idx[10] + m_offset, (reg_c.sa));
-    write_imagef(dst, out_idx[11] + m_offset, (reg_c.sb));
-    write_imagef(dst, out_idx[12] + m_offset, (reg_c.sc));
-    write_imagef(dst, out_idx[13] + m_offset, (reg_c.sd));
-    write_imagef(dst, out_idx[14] + m_offset, (reg_c.se));
-    write_imagef(dst, out_idx[15] + m_offset, (reg_c.sf));
-    write_imagef(dst, out_idx[16] + m_offset, (reg_c.sg));
-    write_imagef(dst, out_idx[17] + m_offset, (reg_c.sh));
-    write_imagef(dst, out_idx[18] + m_offset, (reg_c.si));
-    write_imagef(dst, out_idx[19] + m_offset, (reg_c.sj));
-    write_imagef(dst, out_idx[20] + m_offset, (reg_c.sk));
-    write_imagef(dst, out_idx[21] + m_offset, (reg_c.sl));
-    write_imagef(dst, out_idx[22] + m_offset, (reg_c.sm));
-    write_imagef(dst, out_idx[23] + m_offset, (reg_c.sn));
-    write_imagef(dst, out_idx[24] + m_offset, (reg_c.so));
-    write_imagef(dst, out_idx[25] + m_offset, (reg_c.sp));
-    write_imagef(dst, out_idx[26] + m_offset, (reg_c.sq));
-    write_imagef(dst, out_idx[27] + m_offset, (reg_c.sr));
-    write_imagef(dst, out_idx[28] + m_offset, (reg_c.ss));
-    write_imagef(dst, out_idx[29] + m_offset, (reg_c.st));
-    write_imagef(dst, out_idx[30] + m_offset, (reg_c.su));
-    write_imagef(dst, out_idx[31] + m_offset, (reg_c.sv));
+    // Skipping padding slots keeps every store to a distinct address. Aliasing
+    // them onto column 0 and overwriting it last would need CLK_IMAGE_MEM_FENCE
+    // to order image stores, which CLK_GLOBAL_MEM_FENCE does not provide.
+#define MOE_STORE_C(t, v) \
+    if (out_idx[t] != 0xFFFFFFFFu) { write_imagef(dst, out_idx[t] + m_offset, (v)); }
 
-    // Store zero padding parts to the index of first output in tile
-    barrier(CLK_GLOBAL_MEM_FENCE);
-    write_imagef(dst, out_idx[0] + m_offset, (reg_c.s0));
+    MOE_STORE_C(0,  reg_c.s0);
+    MOE_STORE_C(1,  reg_c.s1);
+    MOE_STORE_C(2,  reg_c.s2);
+    MOE_STORE_C(3,  reg_c.s3);
+    MOE_STORE_C(4,  reg_c.s4);
+    MOE_STORE_C(5,  reg_c.s5);
+    MOE_STORE_C(6,  reg_c.s6);
+    MOE_STORE_C(7,  reg_c.s7);
+    MOE_STORE_C(8,  reg_c.s8);
+    MOE_STORE_C(9,  reg_c.s9);
+    MOE_STORE_C(10, reg_c.sa);
+    MOE_STORE_C(11, reg_c.sb);
+    MOE_STORE_C(12, reg_c.sc);
+    MOE_STORE_C(13, reg_c.sd);
+    MOE_STORE_C(14, reg_c.se);
+    MOE_STORE_C(15, reg_c.sf);
+    MOE_STORE_C(16, reg_c.sg);
+    MOE_STORE_C(17, reg_c.sh);
+    MOE_STORE_C(18, reg_c.si);
+    MOE_STORE_C(19, reg_c.sj);
+    MOE_STORE_C(20, reg_c.sk);
+    MOE_STORE_C(21, reg_c.sl);
+    MOE_STORE_C(22, reg_c.sm);
+    MOE_STORE_C(23, reg_c.sn);
+    MOE_STORE_C(24, reg_c.so);
+    MOE_STORE_C(25, reg_c.sp);
+    MOE_STORE_C(26, reg_c.sq);
+    MOE_STORE_C(27, reg_c.sr);
+    MOE_STORE_C(28, reg_c.ss);
+    MOE_STORE_C(29, reg_c.st);
+    MOE_STORE_C(30, reg_c.su);
+    MOE_STORE_C(31, reg_c.sv);
+
+#undef MOE_STORE_C
 }

--- a/ggml/src/ggml-opencl/kernels/gemv_moe_q4_k_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemv_moe_q4_k_f32_ns.cl
@@ -7,19 +7,20 @@
 #define N_SIMDGROUP 4
 #define SIMDGROUP_WIDTH 64
 
-inline void get_scale_min_k4(
-    int j,
-    global const uchar * q,
-    uchar * d,
-    uchar * m
-) {
+// Returns the 6-bit sub-block scale in bits 0-7 and the min in bits 8-15.
+// Writing the results through pointers to private scalars is miscompiled by the
+// Adreno E031.47 shader compiler, which yields corrupted scales, so this stays
+// pointer-free and scalar.
+inline uint get_scale_min_k4_packed(int j, global const uchar * q) {
+    uint d, m;
     if (j < 4) {
-        *d = q[j]   & 63;
-        *m = q[j+4] & 63;
+        d = q[j]   & 63u;
+        m = q[j+4] & 63u;
     } else {
-        *d = (q[j+4] & 0x0F) | ((q[j-4] & 0xC0) >> 2);
-        *m = ((q[j+4] >> 4) & 0x0F) | ((q[j]   & 0xC0) >> 2);
+        d = (q[j+4] & 0x0Fu) | ((q[j-4] & 0xC0u) >> 2);
+        m = ((q[j+4] >> 4) & 0x0Fu) | ((q[j] & 0xC0u) >> 2);
     }
+    return d | (m << 8);
 }
 
 static inline float8 q4_k_to_fp32_packed8(ushort2 q4x8, float scale, float minv) {
@@ -83,11 +84,10 @@ __kernel void kernel_gemv_moe_q4_k_f32_ns(
 
         // Load sub-block scale and min
         global const uchar * sc = src0_s + (expert_id * ne01 + i01) * scales_per_row + sb * K_SCALE_SIZE;
-        uchar sv, mn;
-        get_scale_min_k4(j, sc, &sv, &mn);
+        uint sm = get_scale_min_k4_packed(j, sc);
 
-        float scale = (float)d_val * (float)sv;
-        float minv  = (float)dm_val * (float)mn;
+        float scale = (float)d_val * (float)(sm & 0xFFu);
+        float minv  = (float)dm_val * (float)(sm >> 8);
 
         // Load 4 uints of quants (32 nibbles = 32 elements)
         uint q_base = expert_q_offset + ib * ne01 * 4 + i01;
@@ -198,11 +198,10 @@ __kernel void kernel_gemv_moe_q4_k_f32_ns_wimg(
         half dm_val  = src0_dm[expert_d_offset + sb * ne01 + i01];
 
         global const uchar * sc = src0_s + (expert_id * ne01 + i01) * scales_per_row + sb * K_SCALE_SIZE;
-        uchar sv, mn;
-        get_scale_min_k4(j, sc, &sv, &mn);
+        uint sm = get_scale_min_k4_packed(j, sc);
 
-        float scale = (float)d_val * (float)sv;
-        float minv  = (float)dm_val * (float)mn;
+        float scale = (float)d_val * (float)(sm & 0xFFu);
+        float minv  = (float)dm_val * (float)(sm >> 8);
 
         uint q_base = expert_q_offset + ib * ne01 * 4 + i01;
 

--- a/ggml/src/ggml-opencl/kernels/gemv_moe_q5_k_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemv_moe_q5_k_f32_ns.cl
@@ -7,19 +7,20 @@
 #define N_SIMDGROUP 4
 #define SIMDGROUP_WIDTH 64
 
-inline void get_scale_min_k4(
-    int j,
-    global const uchar * q,
-    uchar * d,
-    uchar * m
-) {
+// Returns the 6-bit sub-block scale in bits 0-7 and the min in bits 8-15.
+// Writing the results through pointers to private scalars is miscompiled by the
+// Adreno E031.47 shader compiler, which yields corrupted scales, so this stays
+// pointer-free and scalar.
+inline uint get_scale_min_k4_packed(int j, global const uchar * q) {
+    uint d, m;
     if (j < 4) {
-        *d = q[j]   & 63;
-        *m = q[j+4] & 63;
+        d = q[j]   & 63u;
+        m = q[j+4] & 63u;
     } else {
-        *d = (q[j+4] & 0x0F) | ((q[j-4] & 0xC0) >> 2);
-        *m = ((q[j+4] >> 4) & 0x0F) | ((q[j]   & 0xC0) >> 2);
+        d = (q[j+4] & 0x0Fu) | ((q[j-4] & 0xC0u) >> 2);
+        m = ((q[j+4] >> 4) & 0x0Fu) | ((q[j] & 0xC0u) >> 2);
     }
+    return d | (m << 8);
 }
 
 static inline float8 q5_k_to_fp32_packed8(ushort2 qs5x8, uchar qh5x8, half s, half m) {
@@ -88,11 +89,10 @@ __kernel void kernel_gemv_moe_q5_k_f32_ns(
 
         // Load sub-block scale and min
         global const uchar * sc = src0_s + (expert_id * ne01 + i01) * scales_per_row + sb * K_SCALE_SIZE;
-        uchar sv, mn;
-        get_scale_min_k4(j, sc, &sv, &mn);
+        uint sm = get_scale_min_k4_packed(j, sc);
 
-        float scale = (float)d_val * (float)sv;
-        float minv  = -(float)dm_val * (float)mn;
+        float scale = (float)d_val * (float)(sm & 0xFFu);
+        float minv  = -(float)dm_val * (float)(sm >> 8);
 
         // Load 4 uints of quants (32 nibbles = 32 elements)
         uint q_base = expert_q_offset + ib * ne01 * 4 + i01;

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4722,10 +4722,22 @@ static bool init_mul_mat_id_adreno_repack_tensors(ggml_context * ctx, int n_mats
             if (ggml_is_view_op(t->op)) {
                 continue;
             }
+            // A real router selects unordered experts from the whole range, so
+            // draw a deterministic per-row permutation instead of the ascending
+            // low-numbered run that (i + r) % n_mats produces.
+            std::vector<int32_t> perm(n_mats);
             for (int64_t r = 0; r < ggml_nrows(t); ++r) {
+                for (int m = 0; m < n_mats; ++m) {
+                    perm[m] = m;
+                }
+                uint32_t rng = (uint32_t) (r * 2654435761u + 12345u);
+                for (int m = n_mats - 1; m > 0; --m) {
+                    rng = rng * 1664525u + 1013904223u;
+                    std::swap(perm[m], perm[(rng >> 16) % (uint32_t) (m + 1)]);
+                }
                 std::vector<int32_t> data(t->ne[0]);
                 for (int64_t i = 0; i < t->ne[0]; ++i) {
-                    data[i] = (int32_t) ((i + r) % n_mats);
+                    data[i] = perm[i % n_mats];
                 }
                 ggml_backend_tensor_set(t, data.data(), r * t->nb[1], t->ne[0] * sizeof(int32_t));
             }
@@ -4752,7 +4764,18 @@ static bool init_mul_mat_id_adreno_repack_tensors(ggml_context * ctx, int n_mats
         std::vector<uint8_t> restored(dataq.size());
         ggml_backend_tensor_get(t, restored.data(), 0, restored.size());
         if (memcmp(dataq.data(), restored.data(), dataq.size()) != 0) {
-            printf("quantized tensor roundtrip mismatch for %s ", ggml_type_name(t->type));
+            const size_t row_size = ggml_row_size(t->type, t->ne[0]);
+            const size_t blk_size = row_size / (t->ne[0] / ggml_blck_size(t->type));
+            size_t n_bad = 0, first_bad = dataq.size();
+            for (size_t i = 0; i < dataq.size(); ++i) {
+                if (dataq[i] != restored[i]) {
+                    if (n_bad == 0) { first_bad = i; }
+                    n_bad++;
+                }
+            }
+            printf("quantized tensor roundtrip mismatch for %s (%zu/%zu bytes, first at %zu = block %zu byte %zu of %zu) ",
+                   ggml_type_name(t->type), n_bad, dataq.size(),
+                   first_bad, first_bad / blk_size, first_bad % blk_size, blk_size);
             roundtrip_ok = false;
         }
     }
@@ -4829,8 +4852,10 @@ struct test_mul_mat_id : public test_case {
 struct test_mul_mat_id_adreno_repack : public test_mul_mat_id {
     bool roundtrip_ok = true;
 
-    test_mul_mat_id_adreno_repack(ggml_type type_a) :
-        test_mul_mat_id(type_a, GGML_TYPE_F32, 4, 2, false, 128, 7, 512) {}
+    test_mul_mat_id_adreno_repack(ggml_type type_a, int n_mats = 4, int n_used = 2,
+                                  int64_t m = 128, int64_t n = 7, int64_t k = 512,
+                                  bool bcast = false) :
+        test_mul_mat_id(type_a, GGML_TYPE_F32, n_mats, n_used, bcast, m, n, k) {}
 
     std::string vars() override { return test_mul_mat_id::vars() + ",adreno_trans4_ns=1"; }
 
@@ -4839,7 +4864,11 @@ struct test_mul_mat_id_adreno_repack : public test_mul_mat_id {
     }
 
     double err(const float * a, const float * b, size_t n) override {
-        return roundtrip_ok ? test_mul_mat_id::err(a, b, n) : 1.0;
+        const double matmul_err = test_mul_mat_id::err(a, b, n);
+        if (!roundtrip_ok) {
+            printf("[repack readback defect, matmul err = %.9f] ", matmul_err);
+        }
+        return matmul_err;
     }
 };
 
@@ -9921,6 +9950,32 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
              GGML_TYPE_MXFP4,
          }) {
         test_cases.emplace_back(new test_mul_mat_id_adreno_repack(type_a));
+    }
+
+    // Shapes taken from the MoE experts of a real deployed model (n_embd=1280,
+    // n_ff_exp=896, 6 of 64 experts used), which the small shapes above miss.
+    // n_tokens spans the GEMV (decode) and GEMM (prefill) kernel paths.
+    for (ggml_type type_a : {
+             GGML_TYPE_Q4_0,
+             GGML_TYPE_Q5_0,
+             GGML_TYPE_Q4_K,
+             GGML_TYPE_Q5_K,
+             GGML_TYPE_Q6_K,
+             GGML_TYPE_MXFP4,
+         }) {
+        const int64_t blck = ggml_blck_size(type_a);
+        for (int64_t n_tokens : { 1, 7, 128, 512 }) {
+            // bcast=true matches how build_moe_ffn feeds one token vector to
+            // every selected expert; bcast=false keeps the non-broadcast path.
+            for (bool bcast : { false, true }) {
+                if (1280 % blck == 0) {  // ffn_gate_exps / ffn_up_exps
+                    test_cases.emplace_back(new test_mul_mat_id_adreno_repack(type_a, 64, 6, 896, n_tokens, 1280, bcast));
+                }
+                if (896 % blck == 0) {   // ffn_down_exps
+                    test_cases.emplace_back(new test_mul_mat_id_adreno_repack(type_a, 64, 6, 1280, n_tokens, 896, bcast));
+                }
+            }
+        }
     }
 
     for (ggml_type type_a : all_types) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4863,12 +4863,15 @@ struct test_mul_mat_id_adreno_repack : public test_mul_mat_id {
         roundtrip_ok = init_mul_mat_id_adreno_repack_tensors(ctx, n_mats);
     }
 
+    // A repack that does not survive a store/load roundtrip is a genuine
+    // failure. The matmul error on its own can stay under the threshold while
+    // the packed weights are wrong, which is how the Adreno E031.47 packing
+    // miscompile stayed hidden.
     double err(const float * a, const float * b, size_t n) override {
-        const double matmul_err = test_mul_mat_id::err(a, b, n);
         if (!roundtrip_ok) {
-            printf("[repack readback defect, matmul err = %.9f] ", matmul_err);
+            return DBL_MAX;
         }
-        return matmul_err;
+        return test_mul_mat_id::err(a, b, n);
     }
 };
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4705,6 +4705,61 @@ static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats) {
     }
 }
 
+static float mul_mat_id_adversarial_value(size_t i) {
+    static const float values[] = {
+        -1.0f,   1.0f,   -0.875f,   0.875f,   -0.625f, 0.625f, -0.375f, 0.375f,
+        -0.125f, 0.125f, -0.03125f, 0.03125f, -0.999f, 0.999f, 0.0f,    -0.0f,
+    };
+    const size_t count = sizeof(values) / sizeof(values[0]);
+    return values[(i * 13 + (i / 7) * 5 + i / 257) % count];
+}
+
+static bool init_mul_mat_id_adreno_repack_tensors(ggml_context * ctx, int n_mats) {
+    bool roundtrip_ok = true;
+
+    for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
+        if (t->type == GGML_TYPE_I32) {
+            if (ggml_is_view_op(t->op)) {
+                continue;
+            }
+            for (int64_t r = 0; r < ggml_nrows(t); ++r) {
+                std::vector<int32_t> data(t->ne[0]);
+                for (int64_t i = 0; i < t->ne[0]; ++i) {
+                    data[i] = (int32_t) ((i + r) % n_mats);
+                }
+                ggml_backend_tensor_set(t, data.data(), r * t->nb[1], t->ne[0] * sizeof(int32_t));
+            }
+            continue;
+        }
+
+        const size_t       nels = ggml_nelements(t);
+        std::vector<float> data(nels);
+        for (size_t i = 0; i < nels; ++i) {
+            data[i] = mul_mat_id_adversarial_value(i);
+        }
+
+        if (t->type == GGML_TYPE_F32) {
+            ggml_backend_tensor_set(t, data.data(), 0, data.size() * sizeof(float));
+            continue;
+        }
+
+        GGML_ASSERT(ggml_is_quantized(t->type));
+        const int64_t        nrows = ggml_nrows(t);
+        std::vector<float>   imatrix(t->ne[0], 1.0f);
+        std::vector<uint8_t> dataq(ggml_row_size(t->type, t->ne[0]) * nrows);
+        ggml_quantize_chunk(t->type, data.data(), dataq.data(), 0, nrows, t->ne[0], imatrix.data());
+        ggml_backend_tensor_set(t, dataq.data(), 0, dataq.size());
+        std::vector<uint8_t> restored(dataq.size());
+        ggml_backend_tensor_get(t, restored.data(), 0, restored.size());
+        if (memcmp(dataq.data(), restored.data(), dataq.size()) != 0) {
+            printf("quantized tensor roundtrip mismatch for %s ", ggml_type_name(t->type));
+            roundtrip_ok = false;
+        }
+    }
+
+    return roundtrip_ok;
+}
+
 // GGML_OP_MUL_MAT_ID
 struct test_mul_mat_id : public test_case {
     const ggml_type type_a;
@@ -4768,6 +4823,23 @@ struct test_mul_mat_id : public test_case {
 
     void initialize_tensors(ggml_context * ctx) override {
         init_mul_mat_id_tensors(ctx, n_mats);
+    }
+};
+
+struct test_mul_mat_id_adreno_repack : public test_mul_mat_id {
+    bool roundtrip_ok = true;
+
+    test_mul_mat_id_adreno_repack(ggml_type type_a) :
+        test_mul_mat_id(type_a, GGML_TYPE_F32, 4, 2, false, 128, 7, 512) {}
+
+    std::string vars() override { return test_mul_mat_id::vars() + ",adreno_trans4_ns=1"; }
+
+    void initialize_tensors(ggml_context * ctx) override {
+        roundtrip_ok = init_mul_mat_id_adreno_repack_tensors(ctx, n_mats);
+    }
+
+    double err(const float * a, const float * b, size_t n) override {
+        return roundtrip_ok ? test_mul_mat_id::err(a, b, n) : 1.0;
     }
 };
 
@@ -9837,6 +9909,19 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     // gpt-oss issue with Vulkan mmq_id
     test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_MXFP4, GGML_TYPE_F32, 32, 2, false, 2880, 32, 2880));
     test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_Q4_0, GGML_TYPE_F32, 32, 2, false, 2880, 32, 2880));
+
+    for (ggml_type type_a : {
+             GGML_TYPE_Q4_0,
+             GGML_TYPE_Q4_1,
+             GGML_TYPE_Q5_0,
+             GGML_TYPE_Q5_1,
+             GGML_TYPE_Q4_K,
+             GGML_TYPE_Q5_K,
+             GGML_TYPE_Q6_K,
+             GGML_TYPE_MXFP4,
+         }) {
+        test_cases.emplace_back(new test_mul_mat_id_adreno_repack(type_a));
+    }
 
     for (ggml_type type_a : all_types) {
         test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 4, 2, false, 64, 16, 3*ggml_blck_size(type_a)));


### PR DESCRIPTION
## Root cause

MoE models emitted garbage on Adreno 8xx (Adreno 830, driver E031.47). The
defect is **not** in the matmul kernels — it is in the weight **repack**.

The E031.47 shader compiler miscompiles the two nibble-packing helpers in
`cvt.cl` that every `*_trans4_ns` repack kernel shares:

- `pack_trans4_high` — narrowing intermediates to `uchar` locals keeps only the
  first byte of each packed word and drops the rest.
- `pack_trans4_low` — additionally loses the mask on the `<< 4` term, so the odd
  byte's high nibble leaks into the next byte of the word.

Because both helpers are shared, **every** MoE expert weight repacked for the
optimized kernels was silently corrupted, regardless of quantization type. That
is why excluding the q4_K gate/up experts and excluding the q5_0 down experts
each still produced garbage: one shared defect, not two.

## Changes

- `opencl : fix Adreno nibble-packing miscompile in trans4_ns repack` — the
  actual fix. All intermediates stay in `uint` registers, `pack_uchar4` masks
  each byte explicitly, and the low path combines nibbles as `lo + hi * 16u` so
  no term can exceed 8 bits even if a mask is elided.
- `opencl : fix get_scale_min_k4 miscompile in MoE matmul kernels` — a second,
  independent miscompile of the same flavour: returning the 6-bit scale and min
  through pointers to private scalars yields noise for Q4_K/Q5_K `MUL_MAT_ID`.
  Now returned packed in a single `uint`.
- `test : cover Adreno MoE repack shapes in test-backend-ops` — repack coverage
  at the expert geometry of a real deployed model across both the GEMV (decode)
  and GEMM (prefill) paths, with expert ids drawn from a deterministic
  permutation instead of an ascending run.
- `test : fail Adreno repack cases on a broken weight roundtrip` — a failed
  store/load roundtrip used to be an informational note that returned the
  matmul error unchanged, so a corrupted repack could pass while that error
  stayed under the threshold. It is now a genuine failure.
- `opencl : re-enable MoE MUL_MAT_ID on Adreno 8xx` — removes the
  `adreno_moe_mul_mat_id_broken` guard added earlier in this branch. It was a
  mitigation for the miscompiles above, and keeping it would fix the defect and
  then disable the code path it fixes. Its stated rationale was also wrong on
  the decisive point: it concluded that host-side repacking reproduced the
  corruption bit for bit and therefore the defect lay in the matmul kernels
  rather than the weight layout. Host repacking in fact produces correct output.

The earlier guard and workaround commits in this branch are superseded by the
last commit. The commits that hardened the GEMM epilogue are kept on their own
merit: `opencl : skip padded MoE output stores` also moves a tail-row `return`
to after the shared barrier, and an early return before a barrier is undefined
behaviour in OpenCL. The compiler-version detection the guard used is also
kept — it predates this branch and backs unrelated feature checks.

## Evidence

Measured by diffing the convert kernel's four output buffers against a host
reference repack, per buffer and per lane:

| stage | d / dm / s | q bytes bad | low lanes | high lanes |
|---|---|---|---|---|
| before | 0 bad | 54.2% | ~1.138M each | ~1.034M each |
| `uint` locals only | 0 bad | 12.2% | ~0.56M each | 0 |
| + multiply form | 0 bad | **0** | **0** | **0** |

Validated from this branch's exact contents on Adreno 830 / SM8750, driver
build 0800.74, compiler **E031.47.18.51** — the reported configuration — with a
Q4_K_M MoE model:

- text reproducer: byte-identical to the CPU baseline continuation (271 chars)
- OCR reproducer (the reported case): text identical to the CPU baseline; 3 of 24
  detection-box coordinates differ by 1px, which is ordinary GPU/CPU float variance
- `test-backend-ops -o MUL_MAT_ID`: **463/463 passed**, 0 failures
- `test-backend-ops` full suite: **8330/8330 passed**, 0 failures, 2/2 backends

Re-validated on the **default path after the guard removal**, with no
environment overrides of any kind:

- text reproducer: byte-identical to the CPU-fallback baseline (md5
  `b2b59745e6bcf79d7297a7bf90d5fe3c`), where the pre-fix run on the same device
  produced CJK garbage
- `test-backend-ops -o MUL_MAT_ID`: **463/463 passed**, and **0** of the
  previously guarded types (q4_K, q5_K, q6_K, q5_0, q5_1, q4_0, q4_1) reported
  `not supported`, confirming the ops are claimed by the OpenCL backend again.
  80 `adreno_trans4_ns=1` repack cases ran, 72 of them at the real
  `n_mats=64, n_used=6` expert geometry.
- `test-backend-ops` full suite re-run on the guard-removed build:
  **8330/8330 passed**, 0 failures, 2/2 backends.
- decode throughput: **3.15 -> 74.55 tokens/s (23.7x)**, prompt eval 2.41 ->
  4.01 tokens/s. This is both the payoff and independent proof that the GPU MoE
  kernels are engaged — the CPU fallback cannot reach 74 tokens/s.
- OCR reproducer (the reported case) on the default path: all 9 recognized text
  lines character-for-character identical to the CPU baseline, all 6 detection
  boxes with matching labels, 3 of 24 coordinates differing by 1px. It is
  **bit-identical** to the env-forced GPU run (0 of 24 coordinates differ),
  which is a second confirmation that the op now runs on the GPU rather than
  the CPU. For contrast, a pre-fix run on the same device collapsed to
  "In the image is the image for the image of the image ..." with **zero**
  detection boxes.

## Ruled out (recorded so they are not revisited)

- **Router-table staleness** — `argsort` does run on OpenCL (2241x) and the table
  is rebuilt per layer; reuse by up/down is legitimate. Forcing an unconditional
  rebuild changed nothing.
- **Uninitialized `hist` buffer** — a genuine latent defect
  (`kernel_moe_histogram` accumulates onto memory only zeroed later by
  `kernel_moe_scan`), but explicitly zeroing it produced byte-identical garbage.
  Worth fixing separately; it is not this bug.
- **Per-type matmul kernels** — each role excluded in turn still corrupted, which
  is what pointed at the shared repack.
- **A test-only read-back artifact** — the quantized roundtrip mismatch seen on
  the repack cases was initially attributed to a raw read path in the test that
  skipped the restore kernel. That was wrong: it was the same packing
  miscompile. With the packing helpers fixed, all 80 `adreno_trans4_ns` cases
  roundtrip byte-exact, and the roundtrip check is now enforced rather than
  tolerated.
- **A GEMM-only defect** — `-b 1 -ub 1` was corrupt with *zero* GEMM dispatches,
  verified by probe rather than assumed.

## Follow-ups

- Fix the uninitialized `hist` / `slot_counter` buffers.
- Consider an Android arm64 OpenCL `test-backend-ops` CI job so this class of
  driver-specific miscompile is caught automatically.
- Validation covered Adreno 830 with compiler E031.47.18.51. Other Adreno 8xx
  drivers now take the optimized path again, as they did before this branch, and
  are worth a spot check on Device Farm.
