### PR TITLE
RPC: More TP improvments

### DIFF
--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -1670,6 +1670,9 @@ private:
         uint64_t                next_op_id = 0;
         ggml_backend_buffer_ptr scratch;
         size_t                  scratch_size = 0;
+        ggml_backend_buffer_ptr send_host;
+        ggml_backend_buffer_ptr recv_host;
+        size_t                  host_size = 0;
         std::vector<uint8_t>    send_buf;
         std::vector<uint8_t>    recv_buf;
     };
@@ -2648,11 +2651,36 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
         state.scratch_size = need;
     }
     char * scratch_base = (char *) ggml_backend_buffer_get_base(state.scratch.get());
-    state.send_buf.resize(frame_bytes);
-    state.recv_buf.resize(frame_bytes);
-    memcpy(state.send_buf.data(), &request.op_id, sizeof(request.op_id));
-    uint8_t * send_data = state.send_buf.data() + sizeof(request.op_id);
-    uint8_t * recv_data = state.recv_buf.data() + sizeof(request.op_id);
+    uint8_t * send_frame = nullptr;
+    uint8_t * recv_frame = nullptr;
+    static const bool use_pinned_comm = getenv("GGML_RPC_NO_PINNED_COMM") == nullptr;
+    ggml_backend_buffer_type_t host_buft =
+        use_pinned_comm ? ggml_backend_dev_host_buffer_type(ggml_backend_get_device(backend)) : nullptr;
+    if (host_buft != nullptr && state.host_size < frame_bytes) {
+        ggml_backend_synchronize(backend);
+        state.send_host.reset(ggml_backend_buft_alloc_buffer(host_buft, frame_bytes));
+        state.recv_host.reset(ggml_backend_buft_alloc_buffer(host_buft, frame_bytes));
+        if (state.send_host != nullptr && state.recv_host != nullptr) {
+            state.host_size = frame_bytes;
+        } else {
+            state.send_host.reset();
+            state.recv_host.reset();
+            state.host_size = 0;
+        }
+    }
+    if (state.host_size >= frame_bytes) {
+        send_frame = (uint8_t *) ggml_backend_buffer_get_base(state.send_host.get());
+        recv_frame = (uint8_t *) ggml_backend_buffer_get_base(state.recv_host.get());
+    }
+    if (send_frame == nullptr || recv_frame == nullptr) {
+        state.send_buf.resize(frame_bytes);
+        state.recv_buf.resize(frame_bytes);
+        send_frame = state.send_buf.data();
+        recv_frame = state.recv_buf.data();
+    }
+    memcpy(send_frame, &request.op_id, sizeof(request.op_id));
+    uint8_t * send_data = send_frame + sizeof(request.op_id);
+    uint8_t * recv_data = recv_frame + sizeof(request.op_id);
 
     auto new_scratch_tensor = [&](ggml_type type, size_t offset) {
         ggml_tensor * t = ggml_new_tensor_4d(ctx, type, t_dst->ne[0], t_dst->ne[1], t_dst->ne[2], t_dst->ne[3]);
@@ -2697,13 +2725,13 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
 
     bool exchange_ok;
     if (wire_bytes >= RPC_COMM_FULL_DUPLEX_THRESHOLD) {
-        exchange_ok = state.peer->exchange_data(state.send_buf.data(), state.recv_buf.data(), frame_bytes);
+        exchange_ok = state.peer->exchange_data(send_frame, recv_frame, frame_bytes);
     } else if (state.rank == 0) {
-        exchange_ok = state.peer->send_data(state.send_buf.data(), frame_bytes) &&
-                      state.peer->recv_data(state.recv_buf.data(), frame_bytes);
+        exchange_ok = state.peer->send_data(send_frame, frame_bytes) &&
+                      state.peer->recv_data(recv_frame, frame_bytes);
     } else {
-        exchange_ok = state.peer->recv_data(state.recv_buf.data(), frame_bytes) &&
-                      state.peer->send_data(state.send_buf.data(), frame_bytes);
+        exchange_ok = state.peer->recv_data(recv_frame, frame_bytes) &&
+                      state.peer->send_data(send_frame, frame_bytes);
     }
     if (!exchange_ok) {
         GGML_LOG_ERROR("[%s] peer exchange failed for operation %" PRIu64 "\n", __func__, request.op_id);
@@ -2711,7 +2739,7 @@ bool rpc_server::comm_allreduce(const rpc_msg_comm_allreduce_req & request) {
     }
 
     uint64_t peer_op_id;
-    memcpy(&peer_op_id, state.recv_buf.data(), sizeof(peer_op_id));
+    memcpy(&peer_op_id, recv_frame, sizeof(peer_op_id));
     if (peer_op_id != request.op_id) {
         GGML_LOG_ERROR("[%s] peer operation id %" PRIu64 " does not match %" PRIu64 "\n",
                        __func__, peer_op_id, request.op_id);

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -3344,24 +3344,32 @@ static ggml_backend_dev_t ggml_backend_rpc_reg_get_device(ggml_backend_reg_t reg
 // Pairwise allreduce between two RPC servers over a direct server-to-server connection.
 // The client only sends fire-and-forget COMM_ALLREDUCE commands; the tensor data is
 // exchanged between the servers and never passes through the client.
-struct ggml_backend_rpc_comm_context {
+struct ggml_backend_rpc_comm_shared_context {
     struct rank_info {
         std::string endpoint;
         uint32_t    device;
         std::shared_ptr<rpc_command_queue> cmd_queue;
     };
     std::vector<rank_info> ranks;
+    std::mutex mutex;
     uint64_t next_op_id = 0;
+
+    ~ggml_backend_rpc_comm_shared_context() {
+        for (const auto & rank : ranks) {
+            rpc_msg_comm_free_req request = {rank.device};
+            rank.cmd_queue->submit_rpc(RPC_CMD_COMM_FREE, &request, sizeof(request));
+        }
+    }
+};
+
+struct ggml_backend_rpc_comm_context {
+    std::shared_ptr<ggml_backend_rpc_comm_shared_context> shared;
 };
 
 static void ggml_backend_rpc_comm_free(void * comm_ctx_v) {
     ggml_backend_rpc_comm_context * comm_ctx = (ggml_backend_rpc_comm_context *) comm_ctx_v;
     if (comm_ctx == nullptr) {
         return;
-    }
-    for (const auto & rank : comm_ctx->ranks) {
-        rpc_msg_comm_free_req request = {rank.device};
-        rank.cmd_queue->submit_rpc(RPC_CMD_COMM_FREE, &request, sizeof(request));
     }
     delete comm_ctx;
 }
@@ -3373,7 +3381,7 @@ static void * ggml_backend_rpc_comm_init(ggml_backend_t * backends, size_t n_bac
         }
         return nullptr;
     }
-    std::vector<ggml_backend_rpc_comm_context::rank_info> ranks;
+    std::vector<ggml_backend_rpc_comm_shared_context::rank_info> ranks;
     ranks.reserve(n_backends);
     for (size_t i = 0; i < n_backends; i++) {
         if (!ggml_backend_is_rpc(backends[i])) {
@@ -3393,6 +3401,26 @@ static void * ggml_backend_rpc_comm_init(ggml_backend_t * backends, size_t n_bac
             return nullptr;
         }
         ranks.push_back({rpc_ctx->endpoint, rpc_ctx->device, std::move(cmd_queue)});
+    }
+
+    const bool wire_bf16 = std::getenv("GGML_RPC_NO_WIRE_BF16") == nullptr;
+    std::string key = wire_bf16 ? "bf16;" : "f32;";
+    for (const auto & rank : ranks) {
+        key += std::to_string(rank.endpoint.size()) + ":" + rank.endpoint + ":" +
+               std::to_string(rank.device) + ";";
+    }
+
+    static std::mutex registry_mutex;
+    static std::unordered_map<std::string, std::weak_ptr<ggml_backend_rpc_comm_shared_context>> registry;
+    std::lock_guard<std::mutex> registry_lock(registry_mutex);
+
+    auto it = registry.find(key);
+    if (it != registry.end()) {
+        if (auto shared = it->second.lock()) {
+            GGML_LOG_INFO("%s: reusing pairwise communicator (%s <-> %s)\n", __func__,
+                          ranks[0].endpoint.c_str(), ranks[1].endpoint.c_str());
+            return new ggml_backend_rpc_comm_context{std::move(shared)};
+        }
     }
 
     // rank 1 connects to rank 0 on its serving host; endpoints must be mutually reachable
@@ -3430,7 +3458,6 @@ static void * ggml_backend_rpc_comm_init(ggml_backend_t * backends, size_t n_bac
 
     // Submit all init requests before waiting for any response: rank 0 blocks in accept
     // until rank 1 has connected.
-    const bool wire_bf16 = std::getenv("GGML_RPC_NO_WIRE_BF16") == nullptr;
     std::vector<std::shared_ptr<rpc_completion>> completions;
     completions.reserve(n_backends);
     for (size_t i = 0; i < n_backends; i++) {
@@ -3478,15 +3505,20 @@ static void * ggml_backend_rpc_comm_init(ggml_backend_t * backends, size_t n_bac
     }
     GGML_LOG_INFO("%s: pairwise communicator initialized (%s <-> %s)\n", __func__,
                   ranks[0].endpoint.c_str(), ranks[1].endpoint.c_str());
-    return new ggml_backend_rpc_comm_context{std::move(ranks)};
+    auto shared = std::make_shared<ggml_backend_rpc_comm_shared_context>();
+    shared->ranks = std::move(ranks);
+    registry[key] = shared;
+    return new ggml_backend_rpc_comm_context{std::move(shared)};
 }
 
 static bool ggml_backend_rpc_comm_allreduce_tensor(void * comm_ctx_v, ggml_tensor ** tensors) {
     ggml_backend_rpc_comm_context * comm_ctx = (ggml_backend_rpc_comm_context *) comm_ctx_v;
-    if (comm_ctx == nullptr) {
+    if (comm_ctx == nullptr || comm_ctx->shared == nullptr) {
         return false;
     }
-    const size_t n_ranks = comm_ctx->ranks.size();
+    auto shared = comm_ctx->shared;
+    std::lock_guard<std::mutex> lock(shared->mutex);
+    const size_t n_ranks = shared->ranks.size();
     const int64_t ne = ggml_nelements(tensors[0]);
     if (ne == 0) {
         return true;
@@ -3503,20 +3535,20 @@ static bool ggml_backend_rpc_comm_allreduce_tensor(void * comm_ctx_v, ggml_tenso
             return false;
         }
     }
-    const uint64_t op_id = comm_ctx->next_op_id;
+    const uint64_t op_id = shared->next_op_id;
     for (size_t i = 0; i < n_ranks; i++) {
         rpc_msg_comm_allreduce_req request = {};
-        request.device = comm_ctx->ranks[i].device;
+        request.device = shared->ranks[i].device;
         request.op_id   = op_id;
         request.tensor = serialize_tensor(tensors[i]);
-        if (!comm_ctx->ranks[i].cmd_queue->submit_rpc_checked(RPC_CMD_COMM_ALLREDUCE, &request, sizeof(request))) {
+        if (!shared->ranks[i].cmd_queue->submit_rpc_checked(RPC_CMD_COMM_ALLREDUCE, &request, sizeof(request))) {
             if (i == 0) {
                 return false;
             }
             GGML_ABORT("RPC all-reduce dispatch failed");
         }
     }
-    comm_ctx->next_op_id++;
+    shared->next_op_id++;
     return true;
 }
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -18892,6 +18892,15 @@ static void ggml_backend_vk_get_tensor_2d_async(ggml_backend_t backend, const gg
     vk_buffer buf = buf_ctx->dev_buffer;
 
     auto src_offset = vk_tensor_offset(tensor) + tensor->view_offs + offset;
+    vk_buffer pinned_buf = nullptr;
+    size_t pinned_offset = 0;
+    ggml_vk_host_get(ctx->device, data, pinned_buf, pinned_offset);
+    if (pinned_buf != nullptr) {
+        const bool copied = ggml_vk_buffer_read_2d_async(
+                compute_ctx, buf, src_offset, data, stride_tensor, stride_data, size, n_copies);
+        GGML_ASSERT(copied);
+        return;
+    }
     if (buf->memory_property_flags & vk::MemoryPropertyFlagBits::eHostVisible && buf->device->uma) {
         GGML_ASSERT(buf->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent);
 

--- a/tests/test-rpc.cpp
+++ b/tests/test-rpc.cpp
@@ -194,6 +194,11 @@ int main() {
         fprintf(stderr, "failed to initialize RPC communicator\n");
         return 1;
     }
+    void * comm_reused = comm_init(comm_backends, 2);
+    if (comm_reused == nullptr) {
+        fprintf(stderr, "failed to reuse RPC communicator\n");
+        return 1;
+    }
     ggml_tensor * comm_tensors[2] = { tensor_a, tensor_b };
     if (!comm_allreduce(comm, comm_tensors)) {
         return 1;
@@ -203,6 +208,21 @@ int main() {
     ggml_backend_tensor_get(tensor_a, ones.data(), 0, ggml_nbytes(tensor_a));
     ggml_backend_tensor_get(tensor_b, twos.data(), 0, ggml_nbytes(tensor_b));
     if (!check_values(ones, 3.0f) || !check_values(twos, 3.0f)) {
+        return 1;
+    }
+
+    std::fill(ones.begin(), ones.end(), 4.0f);
+    std::fill(twos.begin(), twos.end(), 5.0f);
+    ggml_backend_tensor_set(tensor_a, ones.data(), 0, ggml_nbytes(tensor_a));
+    ggml_backend_tensor_set(tensor_b, twos.data(), 0, ggml_nbytes(tensor_b));
+    if (!comm_allreduce(comm_reused, comm_tensors)) {
+        return 1;
+    }
+    ggml_backend_synchronize(backend_a.get());
+    ggml_backend_synchronize(backend_b.get());
+    ggml_backend_tensor_get(tensor_a, ones.data(), 0, ggml_nbytes(tensor_a));
+    ggml_backend_tensor_get(tensor_b, twos.data(), 0, ggml_nbytes(tensor_b));
+    if (!check_values(ones, 9.0f) || !check_values(twos, 9.0f)) {
         return 1;
     }
 
@@ -236,6 +256,24 @@ int main() {
     }
 
     comm_free(comm);
+
+    std::fill(ones.begin(), ones.end(), 6.0f);
+    std::fill(twos.begin(), twos.end(), 7.0f);
+    ggml_backend_tensor_set(tensor_a, ones.data(), 0, ggml_nbytes(tensor_a));
+    ggml_backend_tensor_set(tensor_b, twos.data(), 0, ggml_nbytes(tensor_b));
+    if (!comm_allreduce(comm_reused, comm_tensors)) {
+        fprintf(stderr, "reused RPC communicator stopped after releasing first handle\n");
+        return 1;
+    }
+    ggml_backend_synchronize(backend_a.get());
+    ggml_backend_synchronize(backend_b.get());
+    ggml_backend_tensor_get(tensor_a, ones.data(), 0, ggml_nbytes(tensor_a));
+    ggml_backend_tensor_get(tensor_b, twos.data(), 0, ggml_nbytes(tensor_b));
+    if (!check_values(ones, 13.0f) || !check_values(twos, 13.0f)) {
+        return 1;
+    }
+
+    comm_free(comm_reused);
     ggml_backend_synchronize(backend_a.get());
     ggml_backend_synchronize(backend_b.get());
 

--- a/tests/test-rpc.cpp
+++ b/tests/test-rpc.cpp
@@ -274,6 +274,28 @@ int main() {
     }
 
     comm_free(comm_reused);
+
+    void * comm_reinitialized = comm_init(comm_backends, 2);
+    if (comm_reinitialized == nullptr) {
+        fprintf(stderr, "failed to reinitialize RPC communicator\n");
+        return 1;
+    }
+    std::fill(ones.begin(), ones.end(), 8.0f);
+    std::fill(twos.begin(), twos.end(), 9.0f);
+    ggml_backend_tensor_set(tensor_a, ones.data(), 0, ggml_nbytes(tensor_a));
+    ggml_backend_tensor_set(tensor_b, twos.data(), 0, ggml_nbytes(tensor_b));
+    if (!comm_allreduce(comm_reinitialized, comm_tensors)) {
+        return 1;
+    }
+    ggml_backend_synchronize(backend_a.get());
+    ggml_backend_synchronize(backend_b.get());
+    ggml_backend_tensor_get(tensor_a, ones.data(), 0, ggml_nbytes(tensor_a));
+    ggml_backend_tensor_get(tensor_b, twos.data(), 0, ggml_nbytes(tensor_b));
+    if (!check_values(ones, 17.0f) || !check_values(twos, 17.0f)) {
+        return 1;
+    }
+    comm_free(comm_reinitialized);
+
     ggml_backend_synchronize(backend_a.get());
     ggml_backend_synchronize(backend_b.get());
 


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

Problem: most GGUFs ship with the MTP head attached. Running that causes the drafter and the target to contend for the communicator. This PR makes it a shared resource. 

Problem 2: vulkan was not using pinned host buffers, this PR also adds that change for RPC.

## Results 

# 2x Strix Halo results

Results measured with `mtp-bench.py` over Thunderbolt TCP:

| Backend | Split | Target | Drafter | Eval tok/s | Acceptance |
| --- | --- | --- | --- | ---: | ---: |
| Vulkan | Tensor | Q4_K_M | MTP | ~~18.10~~ 22.8 | 72.9% |
| ROCm | Tensor | Q4_K_M | MTP | 20.88 | 73.1% |
| ROCm | Layer | Q4_K_M | None | 10.84 | - |

All MTP runs used `n-max=3` and `p-min=0`.

TODO: test for 2x Sparks


## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
